### PR TITLE
feat: mapa fy_metro (Metrô SP — Estação Treta) 🚇

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -677,7 +677,9 @@ export class Game {
     const row = document.createElement('div');
     row.className = 'kf-row';
     const cn = e => `<span class="${e.team === 'P' ? 'kp' : 'kb'}">${e.name}</span>`;
-    row.innerHTML = attacker && attacker !== victim
+    row.innerHTML = weap === 'METRÔ'
+      ? `${cn(victim)} <span class="kx">🚇 atropelado pelo metrô</span>`
+      : attacker && attacker !== victim
       ? `${cn(attacker)} <span class="kx">[${weap}${head ? ' 💀' : ''}]</span> ${cn(victim)}`
       : `${cn(victim)} <span class="kx">tropeçou na treta</span>`;
     this.el.killfeed.prepend(row);
@@ -792,6 +794,13 @@ export class Game {
     tryAxis(p.vel.x * dt, 0); tryAxis(0, p.vel.z * dt);
     this._collide(p.pos, 0.38);
     p.pos.y += p.vel.y * dt;
+    // movers (trem): atropelo letal + transporte quando porta aberta/fechando
+    if (this.world.movers) for (const m of this.world.movers) {
+      if (p.pos.x > m.minX && p.pos.x < m.maxX && p.pos.y + 1.6 > m.minY && p.pos.y < m.maxY && p.pos.z > m.minZ && p.pos.z < m.maxZ) {
+        if (m.lethal) this._damage(p, 1000, null, 'METRÔ');
+        else if (m.carry) p.pos.z += m.carry * dt;
+      }
+    }
     const g2 = this.world.groundHeightAt(p.pos.x, p.pos.z);
     if (p.pos.y <= g2) {
       if (!p.grounded && p.vel.y < -6) this.sfx.land();
@@ -1061,6 +1070,13 @@ export class Game {
       }
     }
     b.pos.y = this.world.groundHeightAt(b.pos.x, b.pos.z);
+    // movers (trem): bots também são atropelados/transportados
+    if (this.world.movers) for (const m of this.world.movers) {
+      if (b.pos.x > m.minX && b.pos.x < m.maxX && b.pos.y + 1.6 > m.minY && b.pos.y < m.maxY && b.pos.z > m.minZ && b.pos.z < m.maxZ) {
+        if (m.lethal) this._damage(b, 1000, null, 'METRÔ');
+        else if (m.carry) b.pos.z += m.carry * dt;
+      }
+    }
     b.phase += dt * (moving ? 9 : 0);
     g.position.copy(b.pos);
     g.rotation.set(0, b.yaw, 0);
@@ -1153,6 +1169,7 @@ export class Game {
     }
     this._updatePlayer(dt);
     for (const b of this.bots) this._updateBot(b, dt);
+    if (this.world.tick) this.world.tick(this, dt);   // trem em movimento (mapas com movers)
     this._updatePickups();
     this._updateFx(dt);
     this._updateHud();

--- a/public/js/map_metro.js
+++ b/public/js/map_metro.js
@@ -1,0 +1,366 @@
+// fy_metro — "Estação Treta": trincheira central com trilhos, trem Linha Azul
+// que vai e volta (para, abre portas, transporta), mezanino com escadas
+// rolantes cruzando os lados. Identidade Metrô de SP, 100% fictício.
+import * as THREE from 'three';
+
+function mkCanvas(w, h, fn) { const c = document.createElement('canvas'); c.width = w; c.height = h; fn(c.getContext('2d')); return c; }
+function texOf(c, rx = 1, ry = 1) {
+  const t = new THREE.CanvasTexture(c);
+  t.colorSpace = THREE.SRGBColorSpace; t.magFilter = THREE.NearestFilter;
+  t.wrapS = t.wrapT = THREE.RepeatWrapping; t.repeat.set(rx, ry);
+  return t;
+}
+function noiseOver(x, w, h, alpha, colors) {
+  for (let i = 0; i < w * h / 14; i++) {
+    x.fillStyle = colors[(Math.random() * colors.length) | 0];
+    x.globalAlpha = Math.random() * alpha;
+    x.fillRect(Math.random() * w, Math.random() * h, 2, 2);
+  }
+  x.globalAlpha = 1;
+}
+
+const BLUE = 0x0f5fb7, YELLOW = 0xf5c400, STEEL = 0xb8bcbe;
+
+export function buildMetro(scene, T) {
+  const colliders = [];
+  const occluders = [];
+  const movers = [];          // AABBs do trem (atualizados no tick)
+  const root = new THREE.Group();
+  scene.add(root);
+  const lam = o => new THREE.MeshLambertMaterial(o);
+
+  /* ---------------- texturas ---------------- */
+  const tileTex = texOf(mkCanvas(256, 256, x => {
+    x.fillStyle = '#dcd8d0'; x.fillRect(0, 0, 256, 256);
+    x.strokeStyle = '#b8b4ac'; x.lineWidth = 1;
+    for (let i = 0; i <= 256; i += 32) { x.beginPath(); x.moveTo(i, 0); x.lineTo(i, 256); x.stroke(); x.beginPath(); x.moveTo(0, i); x.lineTo(256, i); x.stroke(); }
+    x.fillStyle = '#0f5fb7'; x.fillRect(0, 96, 256, 40);   // faixa Linha Azul
+    noiseOver(x, 256, 256, 0.08, ['#c8c4bc']);
+  }), 6, 2);
+  const floorTex = texOf(mkCanvas(256, 256, x => {
+    x.fillStyle = '#8a8680'; x.fillRect(0, 0, 256, 256);
+    noiseOver(x, 256, 256, 0.2, ['#7a7670', '#9a9690']);
+  }), 8, 8);
+  const tactileTex = texOf(mkCanvas(128, 128, x => {
+    x.fillStyle = '#e8b400'; x.fillRect(0, 0, 128, 128);
+    x.fillStyle = '#c89800';
+    for (let a = 0; a < 128; a += 16) for (let b = 0; b < 128; b += 16) { x.beginPath(); x.arc(a + 8, b + 8, 4, 0, 7); x.fill(); }
+  }), 1, 12);
+  const signStation = texOf(mkCanvas(512, 96, x => {
+    x.fillStyle = '#0f5fb7'; x.fillRect(0, 0, 512, 96);
+    x.fillStyle = '#fff'; x.font = 'bold 44px Arial Black,sans-serif'; x.textAlign = 'center';
+    x.fillText('ESTAÇÃO TRETA', 256, 62);
+  }), 1, 1);
+  const signExit = texOf(mkCanvas(256, 64, x => {
+    x.fillStyle = '#1a1a1a'; x.fillRect(0, 0, 256, 64);
+    x.fillStyle = '#ffd23f'; x.font = 'bold 30px Arial Black,sans-serif'; x.textAlign = 'center';
+    x.fillText('SAÍDA →', 128, 42);
+  }), 1, 1);
+  const signYellow = texOf(mkCanvas(512, 48, x => {
+    x.fillStyle = '#1a1a1a'; x.fillRect(0, 0, 512, 48);
+    x.fillStyle = '#e8b400'; x.font = 'bold 22px Arial,sans-serif'; x.textAlign = 'center';
+    x.fillText('NÃO ULTRAPASSE A FAIXA AMARELA', 256, 32);
+  }), 1, 1);
+  const signDest = texOf(mkCanvas(256, 64, x => {
+    x.fillStyle = '#111'; x.fillRect(0, 0, 256, 64);
+    x.fillStyle = '#ffb400'; x.font = 'bold 34px monospace'; x.textAlign = 'center';
+    x.fillText('TRETA', 128, 44);
+  }), 1, 1);
+  const adTex = (lines, bg, fg) => texOf(mkCanvas(256, 128, x => {
+    x.fillStyle = bg; x.fillRect(0, 0, 256, 128);
+    x.strokeStyle = fg; x.lineWidth = 6; x.strokeRect(4, 4, 248, 120);
+    x.fillStyle = fg; x.textAlign = 'center';
+    x.font = 'bold 26px Arial Black,sans-serif';
+    lines.forEach((l, i) => x.fillText(l, 128, 48 + i * 34));
+  }), 1, 1);
+  const ads = [
+    adTex(['TretaTok', 'a rede da treta™'], '#1b2a4a', '#ffd23f'),
+    adTex(['PASTEL DO ZÉ', 'o oficial da linha'], '#8f1d1d', '#ffe9c4'),
+    adTex(['CURSO QUÂNTICO', 'manifeste headshots'], '#3b1b4a', '#ff7ad9'),
+  ];
+
+  function addBox(w, h, d, mat, x, y, z, opts = {}) {
+    const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat);
+    m.position.set(x, y + h / 2, z);
+    m.castShadow = opts.cast !== false; m.receiveShadow = true;
+    if (opts.ry) m.rotation.y = opts.ry;
+    if (opts.rx) m.rotation.x = opts.rx;
+    if (opts.rz) m.rotation.z = opts.rz;
+    root.add(m);
+    if (opts.collide !== false) {
+      const ex = (opts.ry || opts.rz) ? Math.max(w, d) / 2 : w / 2;
+      const ez = (opts.ry || opts.rz) ? Math.max(w, d) / 2 : d / 2;
+      colliders.push({ minX: x - ex, maxX: x + ex, minY: y, maxY: y + h, minZ: z - ez, maxZ: z + ez });
+      occluders.push(m);
+    }
+    return m;
+  }
+  function addPlane(w, h, mat, x, y, z, ry = 0, rx = 0) {
+    const m = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
+    m.position.set(x, y, z); m.rotation.y = ry; m.rotation.x = rx;
+    m.receiveShadow = true; root.add(m); return m;
+  }
+
+  /* ---------------- caixa da estação ---------------- */
+  const LEN = 96;   // z -48..48
+  // piso das plataformas laterais + pontas
+  for (const s of [-1, 1]) {
+    addBox(18, 0.22, LEN, lam({ map: floorTex }), s * 17, 0.9, 0, { collide: false });
+    // piso tátil amarelo na borda
+    addBox(1.1, 0.02, LEN, lam({ map: tactileTex }), s * 8.6, 1.13, 0, { collide: false });
+    // piso das pontas (spawns)
+    addBox(52, 0.22, 14, lam({ map: floorTex }), 0, 0.9, s * 41, { collide: false });
+    addBox(1.1, 0.02, 52, lam({ map: tactileTex }), 0, 1.13, s * 34.4, { collide: false });
+  }
+  // trincheira dos trilhos
+  addBox(16, 0.2, LEN, lam({ color: 0x3a3a3a }), 0, -1.0, 0, { collide: false });
+  // paredes laterais com azulejo + faixa azul
+  for (const s of [-1, 1]) {
+    addBox(0.6, 6.5, LEN, lam({ map: tileTex }), s * 26.3, 0, 0);
+    addBox(52.6, 6.5, 0.6, lam({ map: tileTex }), 0, 0, s * (LEN / 2 + 0.3));
+  }
+  // teto com vigas
+  addBox(53, 0.4, LEN, lam({ color: 0x4a4a48 }), 0, 6.4, 0, { collide: false });
+  for (let i = -5; i <= 5; i++) addBox(53, 0.5, 0.7, lam({ color: 0x3a3a38 }), 0, 6.1, i * 8, { collide: false });
+  // luminárias fluorescentes
+  for (let i = -5; i <= 5; i++) for (const fx of [-10, 0, 10])
+    addBox(4, 0.1, 0.6, new THREE.MeshBasicMaterial({ color: 0xf0f4ff }), fx, 5.85, i * 8, { collide: false });
+
+  /* ---------------- trilhos ---------------- */
+  for (const rx of [-1.6, 1.6]) {
+    addBox(0.18, 0.12, LEN, lam({ color: 0x8a8a8a }), rx, -0.8, 0, { collide: false });
+    addBox(0.18, 0.12, LEN, lam({ color: 0x8a8a8a }), rx + 1.4, -0.8, 0, { collide: false });
+  }
+  for (let i = -22; i <= 22; i++) addBox(5.4, 0.06, 0.5, lam({ color: 0x5c4a32 }), 0, -0.84, i * 2.2, { collide: false });
+
+  /* ---------------- colunas amarelas Metrô ---------------- */
+  for (const s of [-1, 1]) for (const cz of [-28, -10, 10, 28])
+    addBox(0.9, 5.4, 0.9, lam({ color: 0xd8a800 }), s * 13, 1.1, cz);
+
+  /* ---------------- bancos, ads e placas ---------------- */
+  for (const s of [-1, 1]) for (const bz of [-18, 0, 18]) {
+    addBox(3.4, 0.5, 0.8, lam({ color: 0x2a4a6a }), s * 22, 1.1, bz);
+    addBox(0.2, 0.5, 0.7, lam({ color: 0x1a1a1a }), s * 22 - 1.5, 1.1, bz, { collide: false });
+    addBox(0.2, 0.5, 0.7, lam({ color: 0x1a1a1a }), s * 22 + 1.5, 1.1, bz, { collide: false });
+  }
+  for (const s of [-1, 1]) {
+    addPlane(10, 2, lam({ map: signStation }), s * 25.9, 4.2, 0, s < 0 ? Math.PI / 2 : -Math.PI / 2);
+    addPlane(4.5, 1.1, lam({ map: signExit }), s * 25.9, 3.4, s * 40, s < 0 ? Math.PI / 2 : -Math.PI / 2);
+    addPlane(9, 0.85, lam({ map: signYellow }), s * 8.2, 2.6, s * 20, s < 0 ? Math.PI / 2 : -Math.PI / 2);
+    addPlane(3.4, 1.7, lam({ map: ads[(s + 1) / 2] }), s * 25.9, 3.4, s * 14, s < 0 ? Math.PI / 2 : -Math.PI / 2);
+    addPlane(3.4, 1.7, lam({ map: ads[2] }), s * 25.9, 3.4, s * 30, s < 0 ? Math.PI / 2 : -Math.PI / 2);
+  }
+
+  /* ---------------- mezanino + escadas rolantes ---------------- */
+  const MEZ = 3.4, PLAT = 1.1, BED = -0.8;
+  addBox(24, 0.3, 6.4, lam({ map: floorTex }), 0, MEZ - 0.15, 0, { collide: false });
+  // guarda-corpos do mezanino
+  addBox(24, 1.0, 0.15, lam({ color: 0x8a8a8a }), 0, MEZ, -3.1, { collide: false });
+  addBox(24, 1.0, 0.15, lam({ color: 0x8a8a8a }), 0, MEZ, 3.1, { collide: false });
+  // escadas rolantes (visuais) nas duas pontas do mezanino
+  for (const s of [-1, 1]) {
+    const ramp = addBox(4.6, 0.22, 7.4, lam({ color: 0x6a6a6a }), s * 14, 2.1, 0, { collide: false });
+    ramp.rotation.z = s * 0.42;
+    for (let i = 0; i < 6; i++)
+      addBox(4.4, 0.1, 0.9, lam({ color: 0x8a8a8a }), s * (11.2 + i * 0.95), 1.35 + i * 0.38, 0, { collide: false });
+    // corrimão
+    addBox(4.8, 0.9, 0.1, lam({ color: 0x1a1a1a }), s * 14, 2.7, -3.4, { collide: false, rz: s * 0.42 });
+    addBox(4.8, 0.9, 0.1, lam({ color: 0x1a1a1a }), s * 14, 2.7, 3.4, { collide: false, rz: s * 0.42 });
+  }
+
+  /* ---------------- alturas ---------------- */
+  function groundHeightAt(x, z) {
+    const ax = Math.abs(x);
+    if (z >= -3.2 && z <= 3.2 && ax <= 12) return MEZ;                 // mezanino
+    if (z >= -3.2 && z <= 3.2 && ax > 12 && ax <= 16)                  // escadas (rampas)
+      return MEZ - (MEZ - PLAT) * ((ax - 12) / 4);
+    if (ax >= 8) return PLAT;                                          // plataformas laterais
+    return BED;                                                        // trincheira
+  }
+
+  /* ---------------- o TREM (Linha Azul) ---------------- */
+  const train = {
+    state: 'away', t: 0, z: -70, speed: 0,
+    STOP_Z: 0, DOOR_TIME: 7, AWAY_TIME: 13, V: 9,
+    cars: [],
+  };
+  function buildCar(idx) {
+    const g = new THREE.Group();
+    // corpo inox
+    addBoxGroup(g, 3.4, 2.6, 10.6, lam({ color: STEEL }), 0, -0.5, 0);
+    // faixa azul
+    addBoxGroup(g, 3.5, 0.6, 10.7, lam({ color: BLUE }), 0, 0.6, 0);
+    // janelas
+    addBoxGroup(g, 3.5, 0.7, 9.6, lam({ color: 0x1a2a3a }), 0, 1.0, 0);
+    // portas amarelas (2 por lado por carro)
+    g.userData.doors = [];
+    for (const side of [-1, 1]) for (const dz of [-2.6, 2.6]) {
+      const dL = new THREE.Mesh(new THREE.BoxGeometry(0.06, 1.9, 0.8), lam({ color: YELLOW }));
+      dL.position.set(side * 1.72, 0.05, dz - 0.4); g.add(dL);
+      const dR = dL.clone(); dR.position.z = dz + 0.4; g.add(dR);
+      g.userData.doors.push({ dL, dR, dz, side });
+    }
+    // bancos internos + postes
+    for (const side of [-1, 1]) addBoxGroup(g, 0.5, 0.45, 8.4, lam({ color: 0x2a4a6a }), side * 1.1, -0.55, 0);
+    for (const pz of [-3.5, 0, 3.5]) {
+      const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 2.2, 6), lam({ color: 0xd8d8d8 }));
+      pole.position.set(0, 0.3, pz); g.add(pole);
+    }
+    g.userData.idx = idx;
+    root.add(g);
+    train.cars.push(g);
+    return g;
+  }
+  function addBoxGroup(g, w, h, d, mat, x, y, z) {
+    const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat);
+    m.position.set(x, y, z); m.castShadow = m.receiveShadow = true; g.add(m); return m;
+  }
+  buildCar(0); buildCar(1);
+  // cabine dianteira
+  const cab = new THREE.Group();
+  addBoxGroup(cab, 3.4, 2.2, 1.6, lam({ color: 0x8a9094 }), 0, -0.4, 0);
+  addBoxGroup(cab, 3.0, 0.8, 0.1, lam({ color: 0x1a2a3a }), 0, 0.75, 0.83);
+  addPlaneGroup(cab, 2.6, 0.7, lam({ map: signDest }), 0, 1.5, 0.86);
+  root.add(cab);
+  function addPlaneGroup(g, w, h, mat, x, y, z) {
+    const m = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
+    m.position.set(x, y, z); g.add(m); return m;
+  }
+
+  // colisores estáticos da cabine? não — tudo do trem vai por movers.
+  function trainAABBs() {
+    const out = [];
+    const z0 = train.z, z1 = train.z - 21.5;
+    out.push({ minX: -2, maxX: 2, minY: BED, maxY: 2.4, minZ: z1 - 1.5, maxZ: z0 + 1.5, dz: train.speed * (1 / 60), lethal: Math.abs(train.speed) > 1.2, state: train.state });
+    return out;
+  }
+
+  /* ---------------- luz de estação ---------------- */
+  scene.background = T.sky;
+  scene.fog = new THREE.Fog(0x2a2d33, 40, 160);
+  const hemi = new THREE.HemisphereLight(0xe8f0ff, 0x3a3a3a, 1.05);
+  scene.add(hemi);
+  const sun = new THREE.DirectionalLight(0xf0f4ff, 0.9);
+  sun.position.set(10, 40, 10);
+  sun.castShadow = true;
+  sun.shadow.mapSize.set(2048, 2048);
+  sun.shadow.camera.left = -40; sun.shadow.camera.right = 40;
+  sun.shadow.camera.top = 55; sun.shadow.camera.bottom = -55;
+  sun.shadow.camera.far = 120; sun.shadow.bias = -0.0004;
+  scene.add(sun);
+
+  /* ---------------- waypoints (sem trincheira; cruzam pelo mezanino) ---------------- */
+  const nodes = [], adj = [];
+  const STEP = 4.5;
+  const blocked = (x, z, inflate) => {
+    const g = groundHeightAt(x, z);
+    for (const c of colliders) {
+      if (x > c.minX - inflate && x < c.maxX + inflate &&
+          z > c.minZ - inflate && z < c.maxZ + inflate &&
+          c.minY < g + 1.6 && c.maxY > g + 0.15) return true;
+    }
+    return false;
+  };
+  for (let gx = -24; gx <= 24; gx += STEP)
+    for (let gz = -46; gz <= 46; gz += STEP) {
+      const g = groundHeightAt(gx, gz);
+      if (g > BED + 0.2 && !blocked(gx, gz, 0.5)) nodes.push({ x: gx, z: gz });   // nada na trincheira
+    }
+  const segClear = (a, b) => {
+    for (let i = 1; i < 6; i++) {
+      const t = i / 6, x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+      if (blocked(x, z, 0.25)) return false;
+      const ga = groundHeightAt(a.x, a.z), gb = groundHeightAt(x, z);
+      if (Math.abs(gb - ga) > 0.65) return false;
+    }
+    return true;
+  };
+  for (let i = 0; i < nodes.length; i++) {
+    adj.push([]);
+    for (let j = 0; j < nodes.length; j++) {
+      if (i === j) continue;
+      const dx = nodes[i].x - nodes[j].x, dz = nodes[i].z - nodes[j].z;
+      const d2 = dx * dx + dz * dz;
+      if (d2 < STEP * STEP * 2.2 && segClear(nodes[i], nodes[j])) adj[i].push(j);
+    }
+  }
+  function nearestWaypoint(x, z) {
+    let best = 0, bd = 1e9;
+    for (let i = 0; i < nodes.length; i++) {
+      const dx = nodes[i].x - x, dz = nodes[i].z - z, d = dx * dx + dz * dz;
+      if (d < bd) { bd = d; best = i; }
+    }
+    return best;
+  }
+  function findPath(fromIdx, toIdx) {
+    if (fromIdx === toIdx) return [toIdx];
+    const prev = new Int16Array(nodes.length).fill(-1);
+    const q = [fromIdx]; prev[fromIdx] = fromIdx;
+    while (q.length) {
+      const n = q.shift();
+      for (const m of adj[n]) if (prev[m] === -1) {
+        prev[m] = n;
+        if (m === toIdx) {
+          const path = [m]; let c = n;
+          while (c !== fromIdx) { path.unshift(c); c = prev[c]; }
+          path.unshift(fromIdx);
+          return path;
+        }
+        q.push(m);
+      }
+    }
+    return [fromIdx];
+  }
+
+  /* ---------------- spawns (plataformas das pontas) ---------------- */
+  const mk = s => [-10, -4, 4, 10].map(x => ({ x, z: 42 * s, yaw: s < 0 ? 0 : Math.PI }));
+  const spawns = { P: mk(-1), B: mk(1) };
+
+  /* ---------------- tick do trem ---------------- */
+  function tick(game, dt) {
+    train.t += dt;
+    switch (train.state) {
+      case 'away':
+        if (train.t >= train.AWAY_TIME) { train.state = 'approach'; train.t = 0; train.speed = train.V; }
+        break;
+      case 'approach': {
+        const target = train.STOP_Z + 11.5;
+        train.z += train.speed * dt;
+        if (train.z > target - 14) train.speed = Math.max(2.2, train.speed - dt * 4);
+        if (train.z >= target) { train.z = target; train.speed = 0; train.state = 'stopped'; train.t = 0; }
+        break;
+      }
+      case 'stopped':
+        if (train.t >= train.DOOR_TIME) { train.state = 'depart'; train.t = 0; train.speed = train.V; }
+        break;
+      case 'depart':
+        train.z += train.speed * dt;
+        if (train.z > 70) { train.z = -70; train.state = 'away'; train.t = 0; }
+        break;
+    }
+    // posição dos carros + cabine
+    train.cars[0].position.set(0, 0, train.z - 5.5);
+    train.cars[1].position.set(0, 0, train.z - 16.5);
+    cab.position.set(0, 0, train.z + 0.8);
+    // portas: abrem parado, fecham andando
+    const open = train.state === 'stopped' ? Math.min(1, train.t * 2.5) : train.state === 'depart' ? Math.max(0, 1 - train.t * 2.5) : 0;
+    for (const car of train.cars)
+      for (const d of car.userData.doors) {
+        d.dL.position.z = d.dz - 0.4 - open * 0.75;
+        d.dR.position.z = d.dz + 0.4 + open * 0.75;
+      }
+    // movers (AABB do trem inteiro): atropelo letal só na CHEGADA em velocidade;
+    // na SAÍDA o trem carrega quem embarcou
+    const m = trainAABBs()[0];
+    movers.length = 0;
+    movers.push({ ...m, lethal: train.state === 'approach' && Math.abs(train.speed) > 1.2, carry: train.state === 'depart' && train.z < 60 ? train.speed : 0 });
+    // atualiza colisores "estáticos" do trem pros tiros (occluders dinâmicos usa meshes dos carros direto)
+  }
+
+  return {
+    root, colliders, occluders, groundHeightAt, spawns, sun, hemi,
+    waypoints: { nodes, adj }, nearestWaypoint, findPath,
+    bounds: { minX: -25.5, maxX: 25.5, minZ: -47.5, maxZ: 47.5 },
+    movers, tick,
+  };
+}

--- a/public/js/map_sitio.js
+++ b/public/js/map_sitio.js
@@ -1,0 +1,362 @@
+// fy_sitio — "Sítio da Treta" (Atibaia): casa sede, lago com pedalinhos,
+// área gourmet, pomar, porteira com placa. Sátira 100% fictícia.
+import * as THREE from 'three';
+
+function mkCanvas(w, h, fn) { const c = document.createElement('canvas'); c.width = w; c.height = h; fn(c.getContext('2d')); return c; }
+function noiseOver(x, w, h, alpha, colors) {
+  for (let i = 0; i < w * h / 14; i++) {
+    x.fillStyle = colors[(Math.random() * colors.length) | 0];
+    x.globalAlpha = Math.random() * alpha;
+    x.fillRect(Math.random() * w, Math.random() * h, 2 + Math.random() * 4, 2 + Math.random() * 4);
+  }
+  x.globalAlpha = 1;
+}
+function signTex(lines, bg, fg) {
+  return mkCanvas(256, 96, x => {
+    x.fillStyle = bg; x.fillRect(0, 0, 256, 96);
+    x.strokeStyle = fg; x.lineWidth = 5; x.strokeRect(4, 4, 248, 88);
+    x.fillStyle = fg; x.textAlign = 'center';
+    x.font = `bold ${lines.length > 1 ? 26 : 30}px Arial Black,sans-serif`;
+    lines.forEach((l, i) => x.fillText(l, 128, lines.length > 1 ? 40 + i * 34 : 58));
+  });
+}
+
+export function buildSitio(scene, T) {
+  const colliders = [];
+  const occluders = [];
+  const pickups = [];
+  const root = new THREE.Group();
+  scene.add(root);
+  const lam = o => new THREE.MeshLambertMaterial(o);
+  const texOf = (c, rx = 1, ry = 1) => {
+    const t = new THREE.CanvasTexture(c);
+    t.colorSpace = THREE.SRGBColorSpace; t.magFilter = THREE.NearestFilter;
+    t.wrapS = t.wrapT = THREE.RepeatWrapping; t.repeat.set(rx, ry);
+    return t;
+  };
+
+  /* ---------------- texturas locais ---------------- */
+  const waterTex = texOf(mkCanvas(256, 256, x => {
+    x.fillStyle = '#2a6b7a'; x.fillRect(0, 0, 256, 256);
+    noiseOver(x, 256, 256, 0.3, ['#35808f', '#1f5a68', '#4a98a5']);
+  }), 6, 4);
+  const woodTex = texOf(mkCanvas(128, 128, x => {
+    x.fillStyle = '#7a5c38'; x.fillRect(0, 0, 128, 128);
+    for (let i = 0; i < 4; i++) { x.fillStyle = i % 2 ? '#6b4f2e' : '#87673f'; x.fillRect(i * 32, 0, 30, 128); }
+    noiseOver(x, 128, 128, 0.2, ['#5c4426']);
+  }), 2, 1);
+  const roofTex = texOf(mkCanvas(128, 128, x => {
+    x.fillStyle = '#a8503a'; x.fillRect(0, 0, 128, 128);
+    x.fillStyle = '#8f4030';
+    for (let r = 0; r < 128; r += 16) for (let c = (r / 16 % 2) * 8; c < 128; c += 16) x.fillRect(c, r, 14, 14);
+  }), 4, 3);
+  const wallTex = texOf(mkCanvas(256, 256, x => {
+    x.fillStyle = '#e8ddc8'; x.fillRect(0, 0, 256, 256);
+    noiseOver(x, 256, 256, 0.15, ['#d8ccb4', '#f2e9d8']);
+    x.fillStyle = '#7a4a3a'; x.fillRect(0, 236, 256, 20);      // rodapé
+  }), 2, 1);
+  const signObra = texOf(signTex(['OBRA:', 'ZECA PAGODINHO LTDA'], '#5c2a2a', '#ffd23f'));
+  const signSitio = texOf(signTex(['SÍTIO SANTA TRETA'], '#2a4a2a', '#f2ead8'));
+  const signPedal = texOf(signTex(['PEDALINHO', 'NÃO É PROVA'], '#e03232', '#f2ead8'));
+
+  function addBox(w, h, d, mat, x, y, z, opts = {}) {
+    const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat);
+    m.position.set(x, y + h / 2, z);
+    m.castShadow = opts.cast !== false; m.receiveShadow = true;
+    if (opts.ry) m.rotation.y = opts.ry;
+    if (opts.rx) m.rotation.x = opts.rx;
+    if (opts.rz) m.rotation.z = opts.rz;
+    root.add(m);
+    if (opts.collide !== false) {
+      const pad = opts.pad || 0;
+      const ex = (opts.ry || opts.rz) ? Math.max(w, d) / 2 : w / 2;
+      const ez = (opts.ry || opts.rz) ? Math.max(w, d) / 2 : d / 2;
+      colliders.push({ minX: x - ex - pad, maxX: x + ex + pad, minY: y, maxY: y + h, minZ: z - ez - pad, maxZ: z + ez + pad });
+      occluders.push(m);
+    }
+    return m;
+  }
+  function addPlane(w, h, mat, x, y, z, ry = 0, rx = 0) {
+    const m = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
+    m.position.set(x, y, z); m.rotation.y = ry; m.rotation.x = rx;
+    m.receiveShadow = true; root.add(m); return m;
+  }
+
+  /* ---------------- campo (grama + estrada de terra) ---------------- */
+  const grassMat = lam({ map: T.grass });
+  T.grass.repeat.set(18, 18);
+  const ground = new THREE.Mesh(new THREE.PlaneGeometry(180, 200), grassMat);
+  ground.rotation.x = -Math.PI / 2; ground.receiveShadow = true; root.add(ground);
+  // estrada de terra da porteira até a casa
+  for (const [dx, dz, w, l] of [[8, 30, 5, 42], [8, 6, 5, 12], [4, -16, 5, 34], [-6, -34, 18, 5]])
+    addPlane(w, l, lam({ map: T.dirt }), dx, 0.04, dz, 0, -Math.PI / 2);
+
+  /* ---------------- O LAGO (com pedalinhos) ---------------- */
+  const LAKE = { minX: -15, maxX: 15, minZ: -9, maxZ: 9 };
+  const bed = addPlane(30, 18, lam({ color: 0x1a3a42 }), 0, -0.55, 0, 0, -Math.PI / 2);
+  bed.receiveShadow = true;
+  const water = addPlane(30, 18, new THREE.MeshLambertMaterial({ map: waterTex, transparent: true, opacity: 0.82 }), 0, -0.06, 0, 0, -Math.PI / 2);
+  water.userData.isWater = true;
+  // margem de areia
+  for (const [bx, bz, bw, bl] of [[0, -10, 34, 2], [0, 10, 34, 2], [-16.5, 0, 3, 22], [16.5, 0, 3, 22]])
+    addPlane(bw, bl, lam({ map: T.dirt }), bx, 0.03, bz, 0, -Math.PI / 2);
+
+  function pedalinho(x, z, ry, cor) {
+    const g = new THREE.Group();
+    const hull = new THREE.Mesh(new THREE.BoxGeometry(1.5, 0.5, 2.8), lam({ color: 0xf0f0f0 }));
+    hull.position.y = 0.05; g.add(hull);
+    const nose = new THREE.Mesh(new THREE.CylinderGeometry(0.75, 0.75, 0.5, 3), lam({ color: 0xf0f0f0 }));
+    nose.rotation.set(0, 0, Math.PI / 2); nose.rotation.x = Math.PI / 2; nose.position.set(0, 0.05, 1.4); g.add(nose);
+    const seat1 = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.1, 0.4), lam({ color: cor })); seat1.position.set(0, 0.34, 0.5); g.add(seat1);
+    const seat2 = seat1.clone(); seat2.position.z = -0.6; g.add(seat2);
+    for (const [px, pz] of [[-0.6, 0.9], [0.6, 0.9], [-0.6, -0.9], [0.6, -0.9]]) {
+      const post = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 1.1, 6), lam({ color: 0x888888 }));
+      post.position.set(px, 0.9, pz); g.add(post);
+    }
+    const canopy = new THREE.Mesh(new THREE.BoxGeometry(1.5, 0.08, 2.2), lam({ color: cor }));
+    canopy.position.y = 1.45; canopy.castShadow = true; g.add(canopy);
+    g.position.set(x, -0.25, z); g.rotation.y = ry;
+    g.traverse(o => { if (o.isMesh) o.castShadow = true; });
+    root.add(g);
+    colliders.push({ minX: x - 1.2, maxX: x + 1.2, minY: -0.55, maxY: 1.9, minZ: z - 1.6, maxZ: z + 1.6 });
+    occluders.push(canopy);
+    return g;
+  }
+  const boat1 = pedalinho(-6, 1, 0.4, 0x2b4d8f);
+  pedalinho(5, 4, -0.5, 0xe03232);
+  pedalinho(8, -5, 1.1, 0xffd23f);
+
+  /* ---------------- CASA SEDE (spawn P, norte) ---------------- */
+  {
+    const HX = -10, HZ = -38;
+    addBox(16, 4.5, 9, lam({ map: wallTex }), HX, 0, HZ);
+    // telhado duas águas
+    addBox(17, 0.3, 5.4, lam({ map: roofTex }), HX, 4.5, HZ - 2.3, { rx: 0.42, collide: false });
+    addBox(17, 0.3, 5.4, lam({ map: roofTex }), HX, 4.5, HZ + 2.3, { rx: -0.42, collide: false });
+    // janelas/porta
+    addPlane(1.4, 2.2, lam({ color: 0x3a2a1e }), HX + 2, 1.1, HZ + 4.53, 0);
+    for (const wx of [-5, -1, 5]) addPlane(1.6, 1.2, lam({ color: 0x2a3a4a }), HX + wx, 1.6, HZ + 4.53, 0);
+    // varanda (plataforma jogável) de frente pro lago
+    addBox(18, 1.0, 4.5, lam({ map: woodTex }), HX, 0, HZ + 6.5, { collide: false });
+    for (let i = 0; i < 6; i++) addBox(0.18, 2.6, 0.18, lam({ map: woodTex }), HX - 7.5 + i * 3, 1.0, HZ + 8.4, { collide: false });
+    addBox(18, 0.15, 5, lam({ map: roofTex }), HX, 3.6, HZ + 6.5, { collide: false });
+    // rampa lateral da varanda
+    addBox(3, 0.2, 5, lam({ map: woodTex }), HX + 9.5, 0.4, HZ + 6.5, { collide: false, rz: -0.18 });
+  }
+
+  /* ---------------- ÁREA GOURMET (NE) ---------------- */
+  {
+    const GX = 16, GZ = -32;
+    addBox(5, 1.1, 2, lam({ color: 0x8f4a3a }), GX, 0, GZ);                 // balcão tijolo
+    addBox(1.2, 0.5, 1.2, lam({ color: 0x2a2a2a }), GX - 1, 1.1, GZ);      // churrasqueira
+    for (const [px, pz] of [[-2.5, -1.5], [2.5, -1.5], [-2.5, 1.5], [2.5, 1.5]])
+      addBox(0.16, 2.6, 0.16, lam({ map: woodTex }), GX + px, 0, GZ + pz, { collide: false });
+    addBox(6, 0.15, 4, lam({ map: roofTex }), GX, 2.6, GZ, { collide: false });
+    const s = addPlane(3.2, 1.2, lam({ map: signObra }), GX, 2.0, GZ + 2.05, 0);
+    s.rotation.y = 0;
+  }
+
+  /* ---------------- PISCINA (perto da casa) ---------------- */
+  {
+    const PX = -22, PZ = -28;
+    addPlane(7, 4.5, lam({ map: waterTex, transparent: true, opacity: 0.85 }), PX, -0.3, PZ, 0, -Math.PI / 2);
+    addBox(8, 0.25, 5.5, lam({ map: T.concrete }), PX, 0, PZ, { collide: false });
+    colliders.push({ minX: PX - 3.5, maxX: PX + 3.5, minY: -0.5, maxY: 0.2, minZ: PZ - 2.25, maxZ: PZ + 2.25 });
+  }
+
+  /* ---------------- POMAR (linhas de árvores como cover) ---------------- */
+  for (const tx of [-20, 20])
+    for (let i = 0; i < 5; i++) {
+      const tz = -16 + i * 8 + (tx > 0 ? 2 : 0);
+      const trunk = new THREE.Mesh(new THREE.CylinderGeometry(0.22, 0.3, 1.8, 7), lam({ color: 0x6b4f2c }));
+      trunk.position.set(tx, 0.9, tz); trunk.castShadow = true; root.add(trunk); occluders.push(trunk);
+      const c1 = new THREE.Mesh(new THREE.SphereGeometry(1.6, 8, 6), lam({ color: 0x3f6b2a }));
+      c1.position.set(tx, 2.6, tz); c1.castShadow = true; root.add(c1);
+      const c2 = new THREE.Mesh(new THREE.SphereGeometry(1.1, 8, 6), lam({ color: 0x4a7d32 }));
+      c2.position.set(tx + 0.7, 3.3, tz + 0.4); root.add(c2);
+      colliders.push({ minX: tx - 0.35, maxX: tx + 0.35, minY: 0, maxY: 1.8, minZ: tz - 0.35, maxZ: tz + 0.35 });
+    }
+
+  /* ---------------- cercas de madeira (meio-campo, cover) ---------------- */
+  for (const [fx, fz, len, ry] of [[-10, -14, 10, 0.2], [10, 14, 10, -0.2], [-12, 20, 8, 1.0], [12, -20, 8, 1.0]]) {
+    addBox(len, 0.12, 0.08, lam({ map: woodTex }), fx, 0.85, fz, { ry });
+    addBox(len, 0.12, 0.08, lam({ map: woodTex }), fx, 0.45, fz, { ry });
+    for (let i = -1; i <= 1; i++)
+      addBox(0.14, 1.0, 0.14, lam({ map: woodTex }), fx + Math.cos(ry) * (len / 2) * i, 0, fz - Math.sin(ry) * (len / 2) * i, { collide: false });
+  }
+
+  /* ---------------- mais obstáculos rurais ---------------- */
+  // fardos de feno (cover cilíndrico)
+  for (const [hx, hz, hr] of [[-8, 14, 0.2], [9, -13, -0.3], [-17, 3, 0.8], [14, 22, 0.1]]) {
+    const hay = new THREE.Mesh(new THREE.CylinderGeometry(1.0, 1.0, 1.6, 12), lam({ color: 0xc9a24a }));
+    hay.rotation.set(Math.PI / 2, 0, hr); hay.position.set(hx, 1.0, hz);
+    hay.castShadow = hay.receiveShadow = true; root.add(hay); occluders.push(hay);
+    colliders.push({ minX: hx - 1, maxX: hx + 1, minY: 0, maxY: 2, minZ: hz - 1, maxZ: hz + 1 });
+  }
+  // trator velho (cover grande)
+  {
+    const TX = 22, TZ = 34, TR = -0.4;
+    addBox(2.2, 1.2, 3.2, lam({ color: 0x8f2a2a }), TX, 0.6, TZ, { ry: TR });           // corpo
+    addBox(1.6, 1.4, 1.6, lam({ color: 0x8f2a2a }), TX - 0.2, 1.8, TZ + 0.5, { ry: TR }); // cabine
+    addBox(1.8, 0.5, 2.2, lam({ color: 0x2a2a2a }), TX, 0, TZ - 0.3, { ry: TR, collide: false }); // chassis
+    for (const [wx, wz, r] of [[-1.2, -1, 0.55], [1.2, -1, 0.55], [-1.2, 1.1, 0.75], [1.2, 1.1, 0.75]]) {
+      const wheel = new THREE.Mesh(new THREE.CylinderGeometry(r, r, 0.4, 10), lam({ color: 0x1a1a1a }));
+      wheel.rotation.z = Math.PI / 2; wheel.rotation.y = TR;
+      wheel.position.set(TX + wx, r, TZ + wz); root.add(wheel);
+    }
+  }
+  // poço de pedra (cover central no pasto)
+  {
+    const WX = -14, WZ = 26;
+    const well = new THREE.Mesh(new THREE.CylinderGeometry(1.2, 1.3, 1.0, 10), lam({ map: T.concreteDark }));
+    well.position.set(WX, 0.5, WZ); well.castShadow = true; root.add(well); occluders.push(well);
+    colliders.push({ minX: WX - 1.2, maxX: WX + 1.2, minY: 0, maxY: 1.0, minZ: WZ - 1.2, maxZ: WZ + 1.2 });
+    for (const px of [-1, 1]) addBox(0.12, 1.8, 0.12, lam({ map: woodTex }), WX + px, 0.5, WZ, { collide: false });
+    addBox(2.8, 0.12, 2.2, lam({ map: roofTex }), WX, 2.3, WZ, { collide: false });
+  }
+  // bebedouro dos cavalos
+  addBox(3.4, 0.6, 1.0, lam({ map: woodTex }), -4, 0, 34);
+  addPlane(3.2, 0.7, lam({ map: waterTex, transparent: true, opacity: 0.85 }), -4, 0.62, 34, 0, -Math.PI / 2);
+  // mais cercas (zig-zag de cover no pasto sul)
+  for (const [fx, fz, len, ry] of [[-18, 38, 8, 0.6], [-6, 40, 7, -0.4], [18, 40, 8, 0.3]]) {
+    addBox(len, 0.12, 0.08, lam({ map: woodTex }), fx, 0.85, fz, { ry });
+    addBox(len, 0.12, 0.08, lam({ map: woodTex }), fx, 0.45, fz, { ry });
+  }
+
+  /* ---------------- PORTEIRA + placas (spawn B, sul) ---------------- */
+  {
+    const GX = 8, GZ = 46;
+    addBox(0.5, 3.4, 0.5, lam({ map: T.concreteDark }), GX - 4, 0, GZ);
+    addBox(0.5, 3.4, 0.5, lam({ map: T.concreteDark }), GX + 4, 0, GZ);
+    const arch = addPlane(7, 1.4, lam({ map: signSitio }), GX, 3.2, GZ - 0.2, Math.PI);   // face sul (portaria)
+    addPlane(7, 1.4, lam({ map: signSitio }), GX, 3.2, GZ + 0.2, 0);                      // face norte (lago)
+    addBox(2.2, 1.8, 0.3, lam({ map: wallTex }), GX - 7.5, 0, GZ);
+    addPlane(2.4, 0.9, lam({ map: signPedal }), GX - 7.5, 1.0, GZ - 0.16, Math.PI);
+  }
+
+  /* ---------------- pickups estilo fy_ ---------------- */
+  function gunAt(kind, x, z, yaw = 0, y = 0.02) {
+    let mesh;
+    if (kind === 'awp') {
+      mesh = (function () {
+        const g = new THREE.Group();
+        const body = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.09, 1.1), lam({ color: 0x2e4a2e })); g.add(body);
+        const sc = new THREE.Mesh(new THREE.CylinderGeometry(0.045, 0.045, 0.3, 8), lam({ color: 0x1a1a1a }));
+        sc.rotation.x = Math.PI / 2; sc.position.set(0, 0.08, 0.1); g.add(sc);
+        return g;
+      })();
+    } else {
+      mesh = new THREE.Group();
+      mesh.add(new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.1, 0.28), lam({ color: 0x333333 })));
+    }
+    mesh.position.set(x, y + 0.05, z); mesh.rotation.set(0, yaw, Math.PI / 2 * 0.1);
+    mesh.traverse(o => { if (o.isMesh) o.castShadow = true; });
+    root.add(mesh);
+    pickups.push({ x, z, weapon: kind, readyAt: 0, mesh });
+  }
+  gunAt('awp', -6, 1, 0.4, 0.6);            // em cima do pedalinho azul (meme)
+  gunAt('awp', 16, -29, 1.2);
+  gunAt('pistol', 8, 43, 0);
+  gunAt('pistol', -19, -25, 0.5);
+  gunAt('awp', 0, -16, 0.8);
+  gunAt('pistol', -20, 8, 0.2);
+
+  /* ---------------- luz do interior de SP ---------------- */
+  scene.background = T.sky;
+  scene.fog = new THREE.Fog(0xd8e8c8, 60, 200);
+  const hemi = new THREE.HemisphereLight(0xfff0d8, 0x5a7a3a, 0.95);
+  scene.add(hemi);
+  const sun = new THREE.DirectionalLight(0xffe8c0, 1.5);
+  sun.position.set(-30, 50, 25);
+  sun.castShadow = true;
+  sun.shadow.mapSize.set(2048, 2048);
+  sun.shadow.camera.left = -55; sun.shadow.camera.right = 55;
+  sun.shadow.camera.top = 55; sun.shadow.camera.bottom = -55;
+  sun.shadow.camera.far = 160; sun.shadow.bias = -0.0004;
+  scene.add(sun);
+  const fill = new THREE.DirectionalLight(0xc8e8a8, 0.3);
+  fill.position.set(25, 30, -30); scene.add(fill);
+
+  /* ---------------- altura do chão / água ---------------- */
+  function groundHeightAt(x, z) {
+    if (x >= LAKE.minX && x <= LAKE.maxX && z >= LAKE.minZ && z <= LAKE.maxZ) return -0.55;
+    if (x >= -19 && x <= -1 && z >= -34.5 && z <= -29.5) return 1.0;      // varanda
+    if (x >= -2.5 && x <= -0.5 && z >= -34.5 && z <= -29.5) return 0.5;   // rampa varanda (aprox)
+    return 0;
+  }
+  function slowAt(x, z) {
+    return x >= LAKE.minX && x <= LAKE.maxX && z >= LAKE.minZ && z <= LAKE.maxZ;
+  }
+
+  /* ---------------- waypoints ---------------- */
+  const nodes = [], adj = [];
+  const STEP = 4.5;
+  const blocked = (x, z, inflate) => {
+    const g = groundHeightAt(x, z);
+    for (const c of colliders) {
+      if (x > c.minX - inflate && x < c.maxX + inflate &&
+          z > c.minZ - inflate && z < c.maxZ + inflate &&
+          c.minY < g + 1.6 && c.maxY > g + 0.15) return true;
+    }
+    return false;
+  };
+  for (let gx = -30; gx <= 30; gx += STEP)
+    for (let gz = -52; gz <= 52; gz += STEP)
+      if (!blocked(gx, gz, 0.5)) nodes.push({ x: gx, z: gz });
+  const segClear = (a, b) => {
+    for (let i = 1; i < 6; i++) {
+      const t = i / 6, x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+      if (blocked(x, z, 0.25)) return false;
+      if (Math.abs(groundHeightAt(x, z) - groundHeightAt(a.x, a.z)) > 0.65) return false;
+    }
+    return true;
+  };
+  for (let i = 0; i < nodes.length; i++) {
+    adj.push([]);
+    for (let j = 0; j < nodes.length; j++) {
+      if (i === j) continue;
+      const dx = nodes[i].x - nodes[j].x, dz = nodes[i].z - nodes[j].z;
+      const d2 = dx * dx + dz * dz;
+      if (d2 < STEP * STEP * 2.2 && segClear(nodes[i], nodes[j])) adj[i].push(j);
+    }
+  }
+  function nearestWaypoint(x, z) {
+    let best = 0, bd = 1e9;
+    for (let i = 0; i < nodes.length; i++) {
+      const dx = nodes[i].x - x, dz = nodes[i].z - z, d = dx * dx + dz * dz;
+      if (d < bd) { bd = d; best = i; }
+    }
+    return best;
+  }
+  function findPath(fromIdx, toIdx) {
+    if (fromIdx === toIdx) return [toIdx];
+    const prev = new Int16Array(nodes.length).fill(-1);
+    const q = [fromIdx]; prev[fromIdx] = fromIdx;
+    while (q.length) {
+      const n = q.shift();
+      for (const m of adj[n]) if (prev[m] === -1) {
+        prev[m] = n;
+        if (m === toIdx) {
+          const path = [m]; let c = n;
+          while (c !== fromIdx) { path.unshift(c); c = prev[c]; }
+          path.unshift(fromIdx);
+          return path;
+        }
+        q.push(m);
+      }
+    }
+    return [fromIdx];
+  }
+
+  /* ---------------- spawns ---------------- */
+  const spawns = {
+    P: [-14, -10, -6, -2].map(x => ({ x, z: -33, yaw: 0 })),
+    B: [4, 7, 10, 13].map(x => ({ x, z: 43, yaw: Math.PI })),
+  };
+
+  return {
+    root, colliders, occluders, groundHeightAt, slowAt, spawns, sun, hemi, pickups,
+    waypoints: { nodes, adj }, nearestWaypoint, findPath,
+    bounds: { minX: -32, maxX: 32, minZ: -54, maxZ: 54 },
+  };
+}

--- a/public/js/maps.js
+++ b/public/js/maps.js
@@ -1,10 +1,14 @@
 // Map registry — single source of truth for selectable arenas.
 import { buildWorld } from './map.js';
 import { buildPoolDay } from './map_pool_day.js';
+import { buildSitio } from './map_sitio.js';
+import { buildMetro } from './map_metro.js';
 
 export const MAPS = {
   awp_map:     { name: 'AWP Treta (Praça)',   build: buildWorld },
   fy_pool_day: { name: 'Piscinão da Treta',   build: buildPoolDay },
+  fy_sitio:    { name: 'Sítio da Treta (Atibaia)', build: buildSitio },
+  fy_metro:    { name: 'Metrô SP (Estação Treta)', build: buildMetro },
 };
 export const MAP_IDS = Object.keys(MAPS);
 export const DEFAULT_MAP = 'awp_map';


### PR DESCRIPTION
## O que é

Novo mapa **fy_metro** — uma estação de metrô paulistana completa: trincheira central com trilhos, plataformas nas laterais e nas pontas, e um **trem da Linha Azul** que chega, para, abre as portas e transporta jogadores.

## O trem (a estrela)

- Chega do sul, **para 7s no centro** com as portas amarelas abrindo animadas
- Quem embarca é **carregado até a outra ponta** (testado: z=5 → z=32 vivo)
- **Atropelo letal** na chegada em velocidade — feed "🚇 atropelado pelo metrô"
- Suporte novo no engine: `world.tick()` + `world.movers` (AABB móvel + carry) em game.js

## A estação (identidade Metrô SP)

- Azulejo branco com **faixa azul**, **piso tátil** amarelo na borda das plataformas
- **Mezanino central** com **escadas rolantes** nas duas pontas — rota estática que os bots usam pra cruzar (waypoints evitam a trincheira)
- Colunas amarelas, bancos, luminárias fluorescentes, placas ESTAÇÃO TRETA / SAÍDA / NÃO ULTRAPASSE A FAIXA AMARELA, ads fictícios (TretaTok, Pastel do Zé, Curso Quântico)
- 151 waypoints; alturas: plataforma 1.1 / trincheira −0.8 / mezanino 3.4 / rampa interpolada

## Testado (headless)

- Trem para e abre portas; carry transporta; atropelo mata na chegada; bots vivos usando mezanino; zero erros

## Como testar local

```bash
git checkout map/metro-sp
cd public && python3 -m http.server 8123
# http://localhost:8123/?map=fy_metro
```

Nota: a branch traz também `map_sitio.js` (dependência do registry — sai do diff quando o PR #4 mergear).