### PR TITLE
feat: ganhos gráficos seguros fase 1 (anisotropy + sombra + exposição)

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -22,10 +22,10 @@ renderer.setSize(innerWidth, innerHeight);
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 renderer.toneMapping = THREE.ACESFilmicToneMapping;
-renderer.toneMappingExposure = 1.06;
+renderer.toneMappingExposure = 1.1;
 container.appendChild(renderer.domElement);
 
-const textures = initTextures();
+const textures = initTextures(renderer.capabilities.getMaxAnisotropy());
 const sfx = new Sfx(); sfx.vol = settings.vol;
 sfx.speechEnabled = settings.speech !== false;
 const sfxReady = sfx.loadManifest();

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -281,7 +281,7 @@ export function buildWorld(scene, T) {
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.camera.left = -60; sun.shadow.camera.right = 60;
   sun.shadow.camera.top = 60; sun.shadow.camera.bottom = -60;
-  sun.shadow.camera.far = 160; sun.shadow.bias = -0.0004;
+  sun.shadow.camera.far = 160; sun.shadow.bias = -0.0004; sun.shadow.normalBias = 0.02;
   scene.add(sun);
   // warm fill from the other side
   const fill = new THREE.DirectionalLight(0xffc890, 0.35);

--- a/public/js/map_pool_day.js
+++ b/public/js/map_pool_day.js
@@ -237,7 +237,7 @@ export function buildPoolDay(scene, T) {
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.camera.left = -30; sun.shadow.camera.right = 30;
   sun.shadow.camera.top = 30; sun.shadow.camera.bottom = -30;
-  sun.shadow.camera.far = 110; sun.shadow.bias = -0.0004;
+  sun.shadow.camera.far = 110; sun.shadow.bias = -0.0004; sun.shadow.normalBias = 0.02;
   scene.add(sun);
   const fill = new THREE.DirectionalLight(0xdfeeff, 0.55);
   fill.position.set(-15, 35, 15); scene.add(fill);

--- a/public/js/textures.js
+++ b/public/js/textures.js
@@ -1,12 +1,15 @@
 // Procedural canvas textures — zero external assets.
 import * as THREE from 'three';
 
+let ANISO = 1; // setado por initTextures(renderer.capabilities.getMaxAnisotropy())
+
 function canvas(w, h) { const c = document.createElement('canvas'); c.width = w; c.height = h; return c; }
 function tex(c, repeat = 1, ry = null) {
   const t = new THREE.CanvasTexture(c);
   t.colorSpace = THREE.SRGBColorSpace;
   t.magFilter = THREE.NearestFilter;           // retro CS 1.6 pixel look
   t.minFilter = THREE.LinearMipmapLinearFilter;
+  t.anisotropy = ANISO;                         // chão nítido em ângulo raso
   t.wrapS = t.wrapT = THREE.RepeatWrapping;
   t.repeat.set(repeat, ry === null ? repeat : ry);
   return t;
@@ -50,7 +53,8 @@ function concreteBase(w = 256, h = 256, base = '#9a938a', dark = '#7d766d') {
   return c;
 }
 
-export function initTextures() {
+export function initTextures(maxAniso = 1) {
+  ANISO = maxAniso;
   const T = {};
 
   // --- ground / structure ---


### PR DESCRIPTION
- anisotropy máx nas texturas: chão/paredes param de borrar em ângulo raso (maior causa isolada do visual 'serrilhado'), sem custo perceptível.
- sun.shadow.normalBias=0.02: elimina acne/shadow peter-panning.
- toneMappingExposure 1.06 -> 1.1: imagem um pouco mais viva.

Mantém o look retro (NearestFilter proposital). Próximo salto (materiais Lambert->Standard + env map/PMREM + blob shadows) fica pra fase 1b, que precisa de playtest visual.