### PR TITLE
fix(weapons): recarga automática ao esvaziar o pente

### DIFF
--- a/godot/src/weapons/hitscan_weapon.gd
+++ b/godot/src/weapons/hitscan_weapon.gd
@@ -3,6 +3,7 @@ extends Node3D
 
 signal fired(result: Dictionary)
 signal ammo_changed(ammo: int, reserve: int)
+signal reload_started
 
 const WeaponStateScript := preload("res://src/weapons/weapon_state.gd")
 
@@ -41,6 +42,8 @@ func fire(origin: Vector3, direction: Vector3, source: Node = null) -> Dictionar
 		return result
 	result.fired = true
 	ammo_changed.emit(state.ammo, state.reserve)
+	if state.ammo <= 0:
+		reload()
 
 	var shot_direction := _spread_direction(direction.normalized())
 	var query := PhysicsRayQueryParameters3D.create(
@@ -71,7 +74,10 @@ func fire(origin: Vector3, direction: Vector3, source: Node = null) -> Dictionar
 
 
 func reload() -> bool:
-	return state.start_reload()
+	var started: bool = state.start_reload()
+	if started:
+		reload_started.emit()
+	return started
 
 
 func _spread_direction(direction: Vector3) -> Vector3:

--- a/godot/src/weapons/weapon_inventory.gd
+++ b/godot/src/weapons/weapon_inventory.gd
@@ -23,6 +23,8 @@ func _ready() -> void:
 		_weapons[weapon_id] = child
 		if child.has_signal("ammo_changed"):
 			child.ammo_changed.connect(_on_child_ammo_changed.bind(child))
+		if child.has_signal("reload_started"):
+			child.reload_started.connect(_on_child_reload_started.bind(child))
 	active_weapon = _weapons.get(initial_weapon)
 	assert(active_weapon != null, "Initial weapon must exist in inventory")
 	_update_visibility()
@@ -47,6 +49,8 @@ func switch_to(weapon_id: StringName) -> bool:
 	draw_remaining = float(active_weapon.definition.draw_delay)
 	_update_visibility()
 	_publish_weapon()
+	if active_weapon is HitscanWeapon and active_weapon.state.ammo <= 0:
+		active_weapon.reload()
 	return true
 
 
@@ -65,10 +69,7 @@ func attack(origin: Vector3, direction: Vector3, source: Node = null) -> Diction
 func reload() -> bool:
 	if active_weapon == null or active_weapon.definition.melee:
 		return false
-	var started: bool = active_weapon.reload()
-	if started:
-		reload_started.emit(active_weapon.definition.weapon_id)
-	return started
+	return active_weapon.reload()
 
 
 func set_scoped(active: bool) -> bool:
@@ -106,3 +107,8 @@ func _publish_weapon() -> void:
 func _on_child_ammo_changed(ammo: int, reserve: int, weapon: Node3D) -> void:
 	if weapon == active_weapon:
 		ammo_changed.emit(ammo, reserve)
+
+
+func _on_child_reload_started(weapon: Node3D) -> void:
+	if weapon == active_weapon:
+		reload_started.emit(weapon.definition.weapon_id)

--- a/godot/tests/integration/test_hitscan_weapon.gd
+++ b/godot/tests/integration/test_hitscan_weapon.gd
@@ -53,6 +53,20 @@ func test_world_geometry_occludes_target() -> void:
 	assert_eq(bot.health.current_health, 100)
 
 
+func test_emptying_magazine_starts_reload_automatically() -> void:
+	var weapon: Node3D = (load(WEAPON_PATH) as GDScript).new()
+	weapon.definition = load(AWP_PATH)
+	add_child_autofree(weapon)
+	weapon.state.ammo = 1
+	watch_signals(weapon)
+
+	var result: Dictionary = weapon.fire(Vector3(0.0, 1.55, 0.0), Vector3.FORWARD)
+	assert_true(result.fired)
+	assert_eq(weapon.state.ammo, 0)
+	assert_true(weapon.state.reloading, "Reload must start as soon as the magazine empties")
+	assert_signal_emitted(weapon, "reload_started")
+
+
 func test_reload_completion_publishes_ammo_for_hud() -> void:
 	var weapon: Node3D = (load(WEAPON_PATH) as GDScript).new()
 	weapon.definition = load(AWP_PATH)

--- a/godot/tests/integration/test_weapon_inventory.gd
+++ b/godot/tests/integration/test_weapon_inventory.gd
@@ -29,6 +29,20 @@ func test_inventory_switches_three_independent_weapon_scenes() -> void:
 	assert_eq(inventory.active_weapon.state.ammo, 4)
 
 
+func test_drawing_weapon_with_empty_magazine_starts_reload() -> void:
+	var player := (load(PLAYER_SCENE_PATH) as PackedScene).instantiate()
+	add_child_autofree(player)
+	var inventory := player.get_node("CameraPivot/Camera3D/Inventory")
+	var awp: Node3D = inventory.get_node("AWP")
+	awp.state.ammo = 0
+	awp.state.cancel_reload()
+	assert_true(inventory.switch_to(&"pistol"))
+	watch_signals(inventory)
+	assert_true(inventory.switch_to(&"awp"))
+	assert_true(awp.state.reloading, "Empty weapon must start reloading when drawn")
+	assert_signal_emitted_with_parameters(inventory, "reload_started", [&"awp"])
+
+
 func test_knife_disables_scope_and_has_no_ammo_state() -> void:
 	var player := (load(PLAYER_SCENE_PATH) as PackedScene).instantiate()
 	add_child_autofree(player)

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -516,6 +516,8 @@ export class Game {
     this.el.weaponName.textContent = WEAPONS[w].name;
     this.el.reloadNote.classList.add('hidden');
     if (w === 'knife') this.sfx.knifeDeploy(); else this.sfx.uiClick();
+    // sacar arma com pente vazio já inicia a recarga automaticamente
+    if (w !== 'knife' && p.ammo[w].mag <= 0 && p.ammo[w].res > 0) this._startReload();
   }
   _scope(on, silent = false) {
     const p = this.player;
@@ -570,6 +572,8 @@ export class Game {
     p.pitch += w.recoil * (1 - 0.25 * p.crouchF); this.vm.kick = 1;
     this._flash(this.camera.localToWorld(new THREE.Vector3(0.26, -0.2, -1.1)));
     if (p.weapon === 'awp') this._scope(false, true);
+    // recarga automática assim que o pente esvazia (sem exigir clique com 0 balas)
+    if (a.mag <= 0 && a.res > 0) this._startReload();
   }
   _meleeHit() {
     const from = this.camera.getWorldPosition(new THREE.Vector3());


### PR DESCRIPTION
## Summary
- Inicia a recarga automaticamente quando o pente chega a 0 balas (se ainda houver reserva), sem exigir dry-fire ou apertar `R`.
- Ao trocar de arma e sacar uma com pente vazio, a recarga começa assim que a arma entra na mão.
- Ajuste aplicado no cliente legado (`public/js/game.js`) e no cliente Godot (`hitscan_weapon` / `weapon_inventory`), com testes de integração cobrindo os dois cenários.

## Proposta
Antes, o personagem só começava a recarregar ao tentar atirar com 0 balas (ou ao apertar `R`). Isso deixava um gap chato: esvaziar o pente, trocar de arma e voltar ainda obrigava dry-fire/`R`.

A proposta deste PR é alinhar o feel com FPS táticos modernos (e com CS): **você não fica com uma arma de 0/X na mão sem recarregar**, a menos que não exista munição reserva. Com reserva, a recarga começa sozinha no momento em que o pente zera e também ao sacar uma arma já vazia.

## Dúvida / paridade com CS
No Valorant esse comportamento é exatamente assim. No CS também: com pente vazio e reserva, a recarga automática começa sozinha (em CS, segurar o botão de tiro pode atrasar um pouco até soltar o clique). Só permanece em 0 quando a reserva acabou.

Se a gente quiser ficar ainda mais próximo do CS no futuro, um detalhe fino seria: ao manter o botão de tiro pressionado no momento em que o pente zera, só iniciar a recarga ao soltar o clique. Neste PR priorizei o comportamento “nunca ficar parado em 0 com reserva”, que cobre o gap reportado no playtest.

## Test plan
- [ ] Esvaziar o pente de AWP/pistola com reserva e confirmar que a recarga começa sozinha (HUD/som).
- [ ] Esvaziar o pente, trocar para outra arma e voltar: a arma vazia deve começar a recarregar ao ser sacada.
- [ ] Esvaziar o pente sem reserva: a arma deve permanecer em 0 e não iniciar recarga.
- [ ] Dry-fire/`R` ainda funcionam como fallback manual.
- [ ] Faca não dispara recarga.
- [ ] (Godot) `scripts/godot.sh --headless --path godot -s addons/gut/gut_cmdln.gd -gdir=res://tests -ginclude_subdirs -gexit`


Made with [Cursor](https://cursor.com)