### PR TITLE
feat(hud): estatísticas de FPS/ping ativáveis nas configurações

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -174,6 +174,9 @@
     <label class="set-row">Falas dos memes (vozes dos times)
       <input id="set-speech" type="checkbox" checked>
     </label>
+    <label class="set-row">Estatísticas (FPS / ping)
+      <input id="set-stats" type="checkbox">
+    </label>
     <label class="set-row">Qualidade gráfica
       <select id="set-quality">
         <option value="low">Batata (rápido)</option>
@@ -227,6 +230,7 @@
     <button id="hud-speech" title="Liga/desliga as falas (memes)">🔊</button>
     <button id="hud-settings" title="Configurações">⚙</button>
   </div>
+  <div id="hud-stats" class="hidden"></div>
   <canvas id="radar" width="150" height="150"></canvas>
   <div id="radio-log"></div>
   <div id="radio-menu" class="hidden"></div>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -9,7 +9,7 @@ import { VERSION } from './version.js';
 
 /* ---------------- settings & nickname ---------------- */
 const SETTINGS_KEY = 'awpbr_settings';
-const settings = Object.assign({ sens: 1, vol: 0.7, quality: 'med', speech: true, map: DEFAULT_MAP, wpnMode: 'all' },
+const settings = Object.assign({ sens: 1, vol: 0.7, quality: 'med', speech: true, map: DEFAULT_MAP, wpnMode: 'all', stats: false },
   JSON.parse(localStorage.getItem(SETTINGS_KEY) || '{}'));
 const saveSettings = () => localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
 const NICK_KEY = 'awpbr_nick';
@@ -504,6 +504,9 @@ speechEl.onchange = () => {
   saveSettings();
   if (game?.el?.hudSpeech) game.el.hudSpeech.textContent = settings.speech ? '🔊' : '🔇';
 };
+const statsEl = $('set-stats');
+statsEl.checked = settings.stats === true;
+statsEl.onchange = () => { settings.stats = statsEl.checked; saveSettings(); };
 updLabels();
 
 /* ---------------- logo ---------------- */
@@ -573,6 +576,29 @@ updLabels();
   x.fillStyle = sg; x.fillText('TRETA SUPREMA', W / 2, 338);
 })();
 
+/* ---------------- hud stats (FPS / ping) ---------------- */
+const hudStats = $('hud-stats');
+let fpsEma = 0, statsTextAt = 0, pingMs = null, pingAt = 0;
+// ping = RTT de um GET leve no servidor (vale até 404); sem rede mostra "—"
+function measurePing() {
+  const t0 = performance.now();
+  fetch('/api/config', { cache: 'no-store' })
+    .then(() => { pingMs = Math.round(performance.now() - t0); })
+    .catch(() => { pingMs = null; });
+}
+function updHudStats(dt) {
+  const on = settings.stats && game;
+  hudStats.classList.toggle('hidden', !on);
+  if (!on) return;
+  if (dt > 0) fpsEma = fpsEma ? fpsEma * 0.9 + (1 / dt) * 0.1 : 1 / dt;
+  const now = performance.now();
+  if (now - pingAt > 5000) { pingAt = now; measurePing(); }
+  if (now - statsTextAt > 500) {
+    statsTextAt = now;
+    hudStats.textContent = `${Math.round(fpsEma)} FPS · ${pingMs == null ? '—' : pingMs + ' ms'}`;
+  }
+}
+
 /* ---------------- loop ---------------- */
 addEventListener('resize', () => {
   renderer.setSize(innerWidth, innerHeight);
@@ -583,7 +609,9 @@ const clock = new THREE.Clock();
 let menuAngle = 0;
 function loop() {
   requestAnimationFrame(loop);
-  const dt = Math.min(0.05, clock.getDelta());
+  const rawDt = clock.getDelta();
+  const dt = Math.min(0.05, rawDt);
+  updHudStats(rawDt);
   if (game) {
     game.update(dt);
   } else {

--- a/public/style.css
+++ b/public/style.css
@@ -96,6 +96,9 @@ body{font-family:"Arial Black",Impact,Haettenschweiler,"Segoe UI",sans-serif;col
 #hud-actions button{width:34px;height:34px;border-radius:6px;border:1px solid #4a5a2a;cursor:pointer;
   background:rgba(8,10,6,.8);color:var(--cs);font-size:16px;pointer-events:auto}
 #hud-actions button:hover{border-color:var(--cs)}
+#hud-stats{position:absolute;top:56px;right:14px;z-index:25;font-family:Consolas,monospace;font-size:12px;
+  color:var(--hud);text-shadow:0 1px 0 #000;text-align:right;line-height:1.5;pointer-events:none;
+  background:rgba(8,10,6,.6);border:1px solid #4a5a2a;border-radius:6px;padding:4px 8px}
 .set-row input[type=checkbox]{width:18px;height:18px;accent-color:var(--yellow)}
 .rank-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px 26px;font-family:Consolas,monospace;font-size:14px;color:#c9bfa4}
 .rank-stats b{color:var(--yellow);font-size:26px;display:block;text-align:center}


### PR DESCRIPTION
- nova opção "Estatísticas (FPS / ping)" no painel CONFIGURAÇÕES (checkbox, default desligado), persistida em `awpbr_settings` no localStorage junto com as demais settings.
- ligada, mostra um overlay no canto superior direito do HUD: FPS suavizado (EMA sobre o delta bruto do clock, sem o clamp de 0.05 que mascararia FPS baixo) e ping a cada 5s como RTT de um `GET /api/config` com `cache: 'no-store'` — mostra "—" quando sem rede.
- vanilla JS, sem deps, zero mudança de gameplay: overlay com `pointer-events:none`, escondido fora de partida e quando a opção está desligada.

como testar: `cd public && python3 -m http.server 8123`, marcar a opção em CONFIG. e iniciar uma partida — o overlay aparece no canto superior direito do HUD.