### PR TITLE
fix(api): robustez dos endpoints e stack trace fora da resposta

### DIFF
--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -1,6 +1,13 @@
 // Geo a partir dos headers da Vercel (grátis, sem API externa).
 export interface Geo { city: string | null; country: string | null; lat: number | null; lon: number | null; }
 
+// a cidade vem percent-encoded ("S%C3%A3o%20Paulo"); se vier malformada,
+// decodeURIComponent joga URIError e derruba o endpoint inteiro (500) — aí
+// vale mais devolver o valor cru do que perder a partida do jogador.
+function decodeCity(raw: string): string {
+  try { return decodeURIComponent(raw); } catch { return raw; }
+}
+
 export function geoFrom(request: Request): Geo | null {
   const h = request.headers;
   const country = h.get('x-vercel-ip-country');
@@ -9,7 +16,7 @@ export function geoFrom(request: Request): Geo | null {
   const lat = parseFloat(h.get('x-vercel-ip-latitude') || '');
   const lon = parseFloat(h.get('x-vercel-ip-longitude') || '');
   return {
-    city: cityRaw ? decodeURIComponent(cityRaw) : null,
+    city: cityRaw ? decodeCity(cityRaw) : null,
     country,
     lat: Number.isFinite(lat) ? lat : null,
     lon: Number.isFinite(lon) ? lon : null,

--- a/src/pages/api/avatar.ts
+++ b/src/pages/api/avatar.ts
@@ -23,6 +23,11 @@ export const POST: APIRoute = async ({ request }) => {
     return new Response(JSON.stringify({ error: 'token inválido' }), { status: 403, headers: { 'content-type': 'application/json' } });
 
   const b64 = image.replace(/^data:image\/[a-zA-Z0-9.+-]+;base64,/, '');
+  // barra pelo tamanho da string ANTES de decodificar: base64 rende ~0,75 byte
+  // por char, então 3MB ≈ 4M chars. Decodificar primeiro alocava o buffer
+  // inteiro (dezenas de MB na função) só pra recusar depois.
+  if (b64.length > 4_100_000)
+    return new Response(JSON.stringify({ error: 'imagem muito grande (máx ~3MB)' }), { status: 400, headers: { 'content-type': 'application/json' } });
   let png: Buffer;
   try {
     const buf = Buffer.from(b64, 'base64');

--- a/src/pages/api/badge/[...path].png.ts
+++ b/src/pages/api/badge/[...path].png.ts
@@ -15,11 +15,13 @@ export const prerender = false;
 const fontBuffers = [Buffer.from(FONT_BOLD_B64, 'base64')];
 let wasmReady: Promise<unknown> | null = null;
 function init(req: Request) {
+  // NÃO deixar a promise rejeitada no cache: com `??=` puro, um blip de rede no
+  // primeiro badge fritava TODOS os badges daquela instância morna pra sempre.
   return wasmReady ??= (async () => {
     const r = await fetch(new URL('/wasm/resvg.wasm', req.url));
     if (!r.ok) throw new Error('wasm fetch failed: ' + r.status);
     return initWasm(await r.arrayBuffer());
-  })();
+  })().catch(err => { wasmReady = null; throw err; });
 }
 
 const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -87,7 +89,9 @@ export const GET: APIRoute = async (ctx) => {
   try {
     return await handle(ctx);
   } catch (e: any) {
-    return new Response(JSON.stringify({ error: String(e?.message || e), stack: String(e?.stack || '').slice(0, 600) }),
+    // stack fica no log da Vercel, nunca na resposta (vazava caminho interno)
+    console.error('[badge] falhou:', e);
+    return new Response(JSON.stringify({ error: 'erro ao gerar a badge' }),
       { status: 500, headers: { 'content-type': 'application/json' } });
   }
 };

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -5,7 +5,15 @@ import { buildSocialUrl } from '../../lib/social';
 
 export const prerender = false;
 
+const REG_WINDOW_MS = 60_000;
 const regHits = new Map<string, number[]>();
+
+// o Map só crescia: um IP visto uma vez ficava na memória da instância morna
+// pra sempre. Varre e solta os IPs cuja janela já venceu.
+function prune(now: number) {
+  for (const [k, ts] of regHits)
+    if (ts.every(t => now - t >= REG_WINDOW_MS)) regHits.delete(k);
+}
 
 export const POST: APIRoute = async ({ request }) => {
   if (!supabaseAdmin)
@@ -14,8 +22,9 @@ export const POST: APIRoute = async ({ request }) => {
   // rate limit de registro: 10/min por IP (anti nick-farming)
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'unknown';
   const now = Date.now();
+  prune(now);
   const prev = regHits.get(ip) || [];
-  const recent = prev.filter(t => now - t < 60_000);
+  const recent = prev.filter(t => now - t < REG_WINDOW_MS);
   if (recent.length >= 10)
     return new Response(JSON.stringify({ error: 'rate_limited' }), { status: 429, headers: { 'content-type': 'application/json' } });
   recent.push(now); regHits.set(ip, recent);

--- a/src/pages/api/submit-match.ts
+++ b/src/pages/api/submit-match.ts
@@ -11,12 +11,18 @@ export const prerender = false;
 const hits = new Map<string, number>();
 const WINDOW_MS = 30_000;
 
+// idem register.ts: sem expurgo o Map acumulava um registro por IP pra sempre.
+function prune(now: number) {
+  for (const [k, t] of hits) if (now - t >= WINDOW_MS) hits.delete(k);
+}
+
 export const POST: APIRoute = async ({ request, clientAddress }) => {
   if (!supabaseAdmin)
     return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
 
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() || clientAddress || 'unknown';
   const now = Date.now();
+  prune(now);
   if (hits.get(ip) && now - hits.get(ip)! < WINDOW_MS)
     return new Response(JSON.stringify({ error: 'rate_limited' }), { status: 429, headers: { 'content-type': 'application/json' } });
 


### PR DESCRIPTION
Cinco fixes pontuais nas API routes. Nenhuma mudança de comportamento visível pro jogador — só correções de robustez e um vazamento de informação. Não toca em `public/` (jogo intocado), então não conflita com as PRs de armas/mapas/gráficos em aberto.

## O que tem aqui

### 1. Stack trace exposto ao público — `api/badge/[...path].png.ts`
O `catch` do handler devolvia `e.stack` (600 chars) no corpo do 500:

```ts
return new Response(JSON.stringify({ error: ..., stack: String(e?.stack || "").slice(0, 600) }), { status: 500 })
```

Qualquer request que force um erro no badge recebia caminho interno e estrutura do runtime. Agora o stack vai pro `console.error` (log da Vercel) e a resposta é genérica.

### 2. WASM quebrava permanentemente após uma falha — mesmo arquivo
```ts
return wasmReady ??= (async () => { ...; if (!r.ok) throw new Error("wasm fetch failed"); })();
```
`??=` cacheia a **promise rejeitada**. Se o primeiro fetch de `/wasm/resvg.wasm` falhasse (deploy frio, blip de rede), **todos** os badges daquela instância morna falhavam pra sempre — sem recuperação até a instância morrer. Reproduzi o padrão isolado:

```
ANTES: 2ª chamada ainda falha (tentativas=1) — instância fritada
DEPOIS: 1ª falhou como esperado: wasm fetch failed: 503
DEPOIS: 2ª chamada -> wasm carregado (tentativas=2 — recuperou)
```

### 3. `URIError` derrubando dois endpoints — `lib/geo.ts`
`decodeURIComponent` joga `URIError: URI malformed` em percent-encoding inválido — confirmado: `decodeURIComponent("S%E3o Paulo")` estoura. Sem try/catch, um `x-vercel-ip-city` malformado virava **500 no `/api/heartbeat`** e, pior, **perda da submissão no `/api/submit-match`**: o jogador terminava a partida e perdia os stats. Agora cai pro valor cru.

### 4. Teto de tamanho checado depois de decodificar — `api/avatar.ts`
```ts
const buf = Buffer.from(b64, "base64");   // aloca primeiro
if (buf.length > 3_000_000) return ...;    // recusa depois
```
Um body grande de base64 alocava dezenas de MB na função só pra ser rejeitado. Agora barra pelo tamanho da string antes (base64 rende ~0,75 byte/char, então 3MB ≈ 4,1M chars — o limite de 3MB real continua valendo depois).

### 5. Maps de rate limit sem expurgo — `api/register.ts`, `api/submit-match.ts`
`regHits` e `hits` acumulavam uma entrada por IP e nunca liberavam nada, crescendo indefinidamente na memória da instância morna. Agora soltam os IPs cuja janela já venceu. O comportamento do rate limit em si não muda — validei que dentro da janela ainda bloqueia e fora da janela libera.

## Teste
- `npm run build` passa.
- Checagem de sintaxe do `public/js` (a que o CI roda) intacta — nenhum arquivo do jogo foi tocado.
- Lógica de cada fix validada isoladamente (decode, prune, cap de base64, recuperação do wasm).

Vem uma segunda PR em seguida, só de remoção de duplicação (`sideOf` duplicado, helper de resposta JSON, componentes compartilhados entre `ranking.astro` e `u/[...path].astro`) — separada pra respeitar o "um fix por PR" do CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)