### PR TITLE
refactor(site): remove duplicação nas API routes e nas páginas

### DIFF
--- a/src/components/PlayerAvatar.astro
+++ b/src/components/PlayerAvatar.astro
@@ -1,0 +1,46 @@
+---
+// Avatar do jogador, com a cascata de fallback: foto → avatar da rede social →
+// retrato do personagem que ele joga → inicial do nick.
+// Essa cascata estava duplicada em /ranking e /u/<id>/<nick>.
+//
+// Os estilos vêm por prop porque as duas telas usam medidas diferentes
+// (24px alinhado na tabela × 72px com borda no perfil) e a ideia aqui é
+// centralizar a LÓGICA sem mexer no visual de nenhuma das duas.
+import { socialAvatar } from '../lib/social';
+import { CHARS, charSvg } from '../lib/charsvg';
+import { sideOf } from '../lib/side';
+
+interface Props {
+  nick: string;
+  avatarUrl?: string | null;
+  socialLink?: string | null;
+  character?: string | null;
+  matchesP?: number;
+  matchesB?: number;
+  size: number;
+  /** id único do clipPath — precisa ser distinto por retrato na mesma página */
+  clipId: string;
+  alt?: string;
+  imgStyle?: string;
+  svgStyle?: string;
+  /** se vazio, não desenha o fallback de inicial (a tabela do ranking não usa) */
+  initialStyle?: string;
+}
+const {
+  nick, avatarUrl, socialLink, character, matchesP = 0, matchesB = 0,
+  size, clipId, alt = '', imgStyle = '', svgStyle = '', initialStyle = '',
+} = Astro.props;
+
+const photo = avatarUrl || socialAvatar(socialLink);
+const hasChar = !!(character && CHARS[character]);
+const [, sideColor] = sideOf(matchesP, matchesB);
+---
+{photo && <img src={photo} alt={alt} width={size} height={size} style={imgStyle} />}
+{!photo && hasChar && (
+  <svg width={size} height={size} viewBox="688 36 120 120" style={svgStyle}>
+    <Fragment set:html={charSvg(character!, sideColor, clipId)} />
+  </svg>
+)}
+{!photo && !hasChar && initialStyle && (
+  <div style={initialStyle}>{(nick[0] || '?').toUpperCase()}</div>
+)}

--- a/src/components/SocialChips.astro
+++ b/src/components/SocialChips.astro
@@ -1,0 +1,28 @@
+---
+// Ícones das redes do jogador. Usa a lista nova (`socials`) e cai pro
+// `social_link` legado quando o jogador só tem uma rede — mesma lógica que
+// estava duplicada em /ranking e /u/<id>/<nick>.
+import { normalizeSocialUrl, socialNet, NET_INFO, netIcon } from '../lib/social';
+
+interface Props {
+  socials?: { net?: string; url: string }[] | null;
+  socialLink?: string | null;
+  size?: number;
+  /** estilo de cada <a> (a cor da rede é acrescentada depois) */
+  linkStyle?: string;
+}
+const { socials, socialLink, size = 15, linkStyle = '' } = Astro.props;
+
+const list = socials?.length
+  ? socials
+  : (socialLink ? [{ net: socialNet(socialLink), url: socialLink }] : []);
+---
+{list.map((s) => {
+  const net = s.net || socialNet(s.url);
+  const info = NET_INFO[net] || NET_INFO.site;
+  return (
+    <a href={normalizeSocialUrl(s.url)} target="_blank" rel="noopener" title={info.label}
+       style={`${linkStyle};color:${info.color};text-decoration:none`}
+       set:html={netIcon(net, size)} />
+  );
+})}

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -1,6 +1,13 @@
 // Geo a partir dos headers da Vercel (grátis, sem API externa).
 export interface Geo { city: string | null; country: string | null; lat: number | null; lon: number | null; }
 
+// a cidade vem percent-encoded ("S%C3%A3o%20Paulo"); se vier malformada,
+// decodeURIComponent joga URIError e derruba o endpoint inteiro (500) — aí
+// vale mais devolver o valor cru do que perder a partida do jogador.
+function decodeCity(raw: string): string {
+  try { return decodeURIComponent(raw); } catch { return raw; }
+}
+
 export function geoFrom(request: Request): Geo | null {
   const h = request.headers;
   const country = h.get('x-vercel-ip-country');
@@ -9,7 +16,7 @@ export function geoFrom(request: Request): Geo | null {
   const lat = parseFloat(h.get('x-vercel-ip-latitude') || '');
   const lon = parseFloat(h.get('x-vercel-ip-longitude') || '');
   return {
-    city: cityRaw ? decodeURIComponent(cityRaw) : null,
+    city: cityRaw ? decodeCity(cityRaw) : null,
     country,
     lat: Number.isFinite(lat) ? lat : null,
     lon: Number.isFinite(lon) ? lon : null,

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,11 @@
+// Respostas JSON das API routes. O par JSON.stringify + header
+// 'content-type' estava repetido ~30 vezes nos endpoints.
+export function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+// atalho pro caso mais comum: { error: '...' } com status de erro
+export const jsonError = (error: string, status: number): Response => json({ error }, status);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -8,7 +8,8 @@ const key = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
 export const supabaseAdmin: SupabaseClient | null =
   url && key ? createClient(url, key, { auth: { persistSession: false } }) : null;
 
-export const NOT_CONFIGURED = JSON.stringify({
+// objeto (não string): quem responde é o json() de lib/http
+export const NOT_CONFIGURED = {
   error: 'not_configured',
   message: 'Ranking global ainda não configurado (defina SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY).',
-});
+};

--- a/src/pages/api/avatar.ts
+++ b/src/pages/api/avatar.ts
@@ -23,6 +23,11 @@ export const POST: APIRoute = async ({ request }) => {
     return new Response(JSON.stringify({ error: 'token inválido' }), { status: 403, headers: { 'content-type': 'application/json' } });
 
   const b64 = image.replace(/^data:image\/[a-zA-Z0-9.+-]+;base64,/, '');
+  // barra pelo tamanho da string ANTES de decodificar: base64 rende ~0,75 byte
+  // por char, então 3MB ≈ 4M chars. Decodificar primeiro alocava o buffer
+  // inteiro (dezenas de MB na função) só pra recusar depois.
+  if (b64.length > 4_100_000)
+    return new Response(JSON.stringify({ error: 'imagem muito grande (máx ~3MB)' }), { status: 400, headers: { 'content-type': 'application/json' } });
   let png: Buffer;
   try {
     const buf = Buffer.from(b64, 'base64');

--- a/src/pages/api/avatar.ts
+++ b/src/pages/api/avatar.ts
@@ -3,45 +3,38 @@
 import type { APIRoute } from 'astro';
 import sharp from 'sharp';
 import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
+import { json, jsonError } from '../../lib/http';
 
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request }) => {
-  if (!supabaseAdmin)
-    return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
+  if (!supabaseAdmin) return json(NOT_CONFIGURED, 503);
   let body: any;
-  try { body = await request.json(); } catch {
-    return new Response(JSON.stringify({ error: 'bad_json' }), { status: 400, headers: { 'content-type': 'application/json' } });
-  }
+  try { body = await request.json(); } catch { return jsonError('bad_json', 400); }
   const { nick, token, image } = body ?? {};
   if (typeof nick !== 'string' || typeof token !== 'string' || typeof image !== 'string')
-    return new Response(JSON.stringify({ error: 'missing_fields' }), { status: 400, headers: { 'content-type': 'application/json' } });
+    return jsonError('missing_fields', 400);
 
   const { data: player } = await supabaseAdmin
     .from('players').select('id, nick').eq('nick', nick.slice(0, 14)).eq('token', token).maybeSingle();
-  if (!player)
-    return new Response(JSON.stringify({ error: 'token inválido' }), { status: 403, headers: { 'content-type': 'application/json' } });
+  if (!player) return jsonError('token inválido', 403);
 
   const b64 = image.replace(/^data:image\/[a-zA-Z0-9.+-]+;base64,/, '');
   // barra pelo tamanho da string ANTES de decodificar: base64 rende ~0,75 byte
   // por char, então 3MB ≈ 4M chars. Decodificar primeiro alocava o buffer
   // inteiro (dezenas de MB na função) só pra recusar depois.
-  if (b64.length > 4_100_000)
-    return new Response(JSON.stringify({ error: 'imagem muito grande (máx ~3MB)' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  if (b64.length > 4_100_000) return jsonError('imagem muito grande (máx ~3MB)', 400);
   let png: Buffer;
   try {
     const buf = Buffer.from(b64, 'base64');
-    if (buf.length > 3_000_000)
-      return new Response(JSON.stringify({ error: 'imagem muito grande (máx ~3MB)' }), { status: 400, headers: { 'content-type': 'application/json' } });
+    if (buf.length > 3_000_000) return jsonError('imagem muito grande (máx ~3MB)', 400);
     png = await sharp(buf).resize(128, 128, { fit: 'cover' }).png().toBuffer();
-  } catch {
-    return new Response(JSON.stringify({ error: 'imagem inválida' }), { status: 400, headers: { 'content-type': 'application/json' } });
-  }
+  } catch { return jsonError('imagem inválida', 400); }
 
   const path = `${player.id}.png`;
   await supabaseAdmin.storage.from('avatars').upload(path, png, { upsert: true, contentType: 'image/png' });
   const { data } = supabaseAdmin.storage.from('avatars').getPublicUrl(path);
   const url = `${data.publicUrl}?v=${Date.now()}`;
   await supabaseAdmin.from('players').update({ avatar_url: url }).eq('nick', player.nick);
-  return new Response(JSON.stringify({ ok: true, url }), { headers: { 'content-type': 'application/json' } });
+  return json({ ok: true, url });
 };

--- a/src/pages/api/badge/[...path].png.ts
+++ b/src/pages/api/badge/[...path].png.ts
@@ -15,11 +15,13 @@ export const prerender = false;
 const fontBuffers = [Buffer.from(FONT_BOLD_B64, 'base64')];
 let wasmReady: Promise<unknown> | null = null;
 function init(req: Request) {
+  // NÃO deixar a promise rejeitada no cache: com `??=` puro, um blip de rede no
+  // primeiro badge fritava TODOS os badges daquela instância morna pra sempre.
   return wasmReady ??= (async () => {
     const r = await fetch(new URL('/wasm/resvg.wasm', req.url));
     if (!r.ok) throw new Error('wasm fetch failed: ' + r.status);
     return initWasm(await r.arrayBuffer());
-  })();
+  })().catch(err => { wasmReady = null; throw err; });
 }
 
 const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -87,7 +89,9 @@ export const GET: APIRoute = async (ctx) => {
   try {
     return await handle(ctx);
   } catch (e: any) {
-    return new Response(JSON.stringify({ error: String(e?.message || e), stack: String(e?.stack || '').slice(0, 600) }),
+    // stack fica no log da Vercel, nunca na resposta (vazava caminho interno)
+    console.error('[badge] falhou:', e);
+    return new Response(JSON.stringify({ error: 'erro ao gerar a badge' }),
       { status: 500, headers: { 'content-type': 'application/json' } });
   }
 };

--- a/src/pages/api/badge/[...path].png.ts
+++ b/src/pages/api/badge/[...path].png.ts
@@ -9,6 +9,8 @@ import { FONT_BOLD_B64 } from '../../../lib/font-data';
 import { displayTime } from '../../../lib/fmt';
 import { CHARS, charSvg, charName } from '../../../lib/charsvg';
 import { socialAvatar } from '../../../lib/social';
+import { sideOf } from '../../../lib/side';
+import { json } from '../../../lib/http';
 
 export const prerender = false;
 
@@ -35,13 +37,6 @@ async function avatarDataUri(url?: string | null): Promise<string | null> {
     const png = await sharp(buf).resize(120, 120, { fit: 'cover' }).png().toBuffer();
     return 'data:image/png;base64,' + png.toString('base64');
   } catch { return null; }
-}
-
-// lado do jogador: P > B = PETISTA, B > P = BOLSONARISTA, empate = NEUTRO
-export function sideOf(mp: number, mb: number): [string, string] {
-  if (mp > mb) return ['PETISTA', '#e03232'];
-  if (mb > mp) return ['BOLSONARISTA', '#1faa4d'];
-  return ['NEUTRO', '#ffd23f'];
 }
 
 function badgeSvg(p: any, avatarUri: string | null, charId: string | null): string {
@@ -91,14 +86,12 @@ export const GET: APIRoute = async (ctx) => {
   } catch (e: any) {
     // stack fica no log da Vercel, nunca na resposta (vazava caminho interno)
     console.error('[badge] falhou:', e);
-    return new Response(JSON.stringify({ error: 'erro ao gerar a badge' }),
-      { status: 500, headers: { 'content-type': 'application/json' } });
+    return json({ error: 'erro ao gerar a badge' }, 500);
   }
 };
 
 const handle: APIRoute = async ({ params, request }) => {
-  if (!supabaseAdmin)
-    return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
+  if (!supabaseAdmin) return json(NOT_CONFIGURED, 503);
   const parts = (params.path || '').split('/').filter(Boolean);
   let query = supabaseAdmin.from('stats').select('*, players!inner(id, nick, social_link, avatar_url)');
   const first = parts[0] || '';

--- a/src/pages/api/config.ts
+++ b/src/pages/api/config.ts
@@ -1,15 +1,13 @@
 // GET /api/config — expõe URL + anon key do Supabase (públicas por design;
 // a segurança é o RLS). O client usa pra ligar OAuth/storage.
 import type { APIRoute } from 'astro';
+import { json, jsonError } from '../../lib/http';
 
 export const prerender = false;
 
 export const GET: APIRoute = async () => {
   const url = import.meta.env.SUPABASE_URL;
   const anonKey = import.meta.env.SUPABASE_ANON_KEY;
-  if (!url || !anonKey)
-    return new Response(JSON.stringify({ error: 'not_configured' }), { status: 503, headers: { 'content-type': 'application/json' } });
-  return new Response(JSON.stringify({ url, anonKey }), {
-    headers: { 'content-type': 'application/json', 'cache-control': 'public, max-age=3600' },
-  });
+  if (!url || !anonKey) return jsonError('not_configured', 503);
+  return json({ url, anonKey }, 200, { 'cache-control': 'public, max-age=3600' });
 };

--- a/src/pages/api/heartbeat.ts
+++ b/src/pages/api/heartbeat.ts
@@ -2,29 +2,25 @@
 import type { APIRoute } from 'astro';
 import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
 import { geoFrom } from '../../lib/geo';
+import { json, jsonError } from '../../lib/http';
 
 export const prerender = false;
 
 export const POST: APIRoute = async ({ request }) => {
-  if (!supabaseAdmin)
-    return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
+  if (!supabaseAdmin) return json(NOT_CONFIGURED, 503);
   let body: any;
-  try { body = await request.json(); } catch {
-    return new Response(JSON.stringify({ error: 'bad_json' }), { status: 400, headers: { 'content-type': 'application/json' } });
-  }
+  try { body = await request.json(); } catch { return jsonError('bad_json', 400); }
   const { nick, token } = body ?? {};
-  if (typeof nick !== 'string' || typeof token !== 'string')
-    return new Response(JSON.stringify({ error: 'missing_fields' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  if (typeof nick !== 'string' || typeof token !== 'string') return jsonError('missing_fields', 400);
 
   const { data: player } = await supabaseAdmin
     .from('players').select('nick').eq('nick', nick.slice(0, 14)).eq('token', token).maybeSingle();
-  if (!player)
-    return new Response(JSON.stringify({ error: 'token inválido' }), { status: 403, headers: { 'content-type': 'application/json' } });
+  if (!player) return jsonError('token inválido', 403);
 
   const g = geoFrom(request);
   await supabaseAdmin.from('presence').upsert({
     nick: player.nick, last_seen: new Date().toISOString(),
     city: g?.city ?? null, country: g?.country ?? null, lat: g?.lat ?? null, lon: g?.lon ?? null,
   });
-  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  return json({ ok: true });
 };

--- a/src/pages/api/leaderboard.ts
+++ b/src/pages/api/leaderboard.ts
@@ -1,16 +1,13 @@
 // GET /api/leaderboard — ranking global (top 100) via service key no servidor.
 import type { APIRoute } from 'astro';
 import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
+import { json, jsonError } from '../../lib/http';
 
 export const prerender = false;
 
 export const GET: APIRoute = async () => {
-  if (!supabaseAdmin)
-    return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
+  if (!supabaseAdmin) return json(NOT_CONFIGURED, 503);
   const { data, error } = await supabaseAdmin.from('leaderboard').select('*');
-  if (error)
-    return new Response(JSON.stringify({ error: error.message }), { status: 500, headers: { 'content-type': 'application/json' } });
-  return new Response(JSON.stringify({ players: data }), {
-    headers: { 'content-type': 'application/json', 'cache-control': 'public, max-age=30' },
-  });
+  if (error) return jsonError(error.message, 500);
+  return json({ players: data }, 200, { 'cache-control': 'public, max-age=30' });
 };

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -5,7 +5,15 @@ import { buildSocialUrl } from '../../lib/social';
 
 export const prerender = false;
 
+const REG_WINDOW_MS = 60_000;
 const regHits = new Map<string, number[]>();
+
+// o Map só crescia: um IP visto uma vez ficava na memória da instância morna
+// pra sempre. Varre e solta os IPs cuja janela já venceu.
+function prune(now: number) {
+  for (const [k, ts] of regHits)
+    if (ts.every(t => now - t >= REG_WINDOW_MS)) regHits.delete(k);
+}
 
 export const POST: APIRoute = async ({ request }) => {
   if (!supabaseAdmin)
@@ -14,8 +22,9 @@ export const POST: APIRoute = async ({ request }) => {
   // rate limit de registro: 10/min por IP (anti nick-farming)
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'unknown';
   const now = Date.now();
+  prune(now);
   const prev = regHits.get(ip) || [];
-  const recent = prev.filter(t => now - t < 60_000);
+  const recent = prev.filter(t => now - t < REG_WINDOW_MS);
   if (recent.length >= 10)
     return new Response(JSON.stringify({ error: 'rate_limited' }), { status: 429, headers: { 'content-type': 'application/json' } });
   recent.push(now); regHits.set(ip, recent);

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -2,6 +2,7 @@
 import type { APIRoute } from 'astro';
 import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
 import { buildSocialUrl } from '../../lib/social';
+import { json, jsonError } from '../../lib/http';
 
 export const prerender = false;
 
@@ -16,8 +17,7 @@ function prune(now: number) {
 }
 
 export const POST: APIRoute = async ({ request }) => {
-  if (!supabaseAdmin)
-    return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
+  if (!supabaseAdmin) return json(NOT_CONFIGURED, 503);
 
   // rate limit de registro: 10/min por IP (anti nick-farming)
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'unknown';
@@ -25,23 +25,26 @@ export const POST: APIRoute = async ({ request }) => {
   prune(now);
   const prev = regHits.get(ip) || [];
   const recent = prev.filter(t => now - t < REG_WINDOW_MS);
-  if (recent.length >= 10)
-    return new Response(JSON.stringify({ error: 'rate_limited' }), { status: 429, headers: { 'content-type': 'application/json' } });
+  if (recent.length >= 10) return jsonError('rate_limited', 429);
   recent.push(now); regHits.set(ip, recent);
 
   let body: any;
-  try { body = await request.json(); } catch {
-    return new Response(JSON.stringify({ error: 'bad_json' }), { status: 400, headers: { 'content-type': 'application/json' } });
-  }
+  try { body = await request.json(); } catch { return jsonError('bad_json', 400); }
   const { nick, token, social, socials, accessToken, avatarUrl } = body ?? {};
   if (typeof nick !== 'string' || typeof token !== 'string' || nick.trim().length < 2)
-    return new Response(JSON.stringify({ error: 'missing_fields' }), { status: 400, headers: { 'content-type': 'application/json' } });
+    return jsonError('missing_fields', 400);
+
+  // o nick normalizado é a chave de tudo daqui pra baixo (era recalculado 4×)
+  const n = nick.trim().slice(0, 14);
   const { error } = await supabaseAdmin.rpc('register_player', {
-    p_nick: nick.trim().slice(0, 14), p_token: token,
+    p_nick: n, p_token: token,
     p_social: typeof social === 'string' ? social.slice(0, 60) : null,
   });
-  if (error)
-    return new Response(JSON.stringify({ error: error.message }), { status: 409, headers: { 'content-type': 'application/json' } });
+  if (error) return jsonError(error.message, 409);
+
+  // atualiza só a linha do dono do par nick+token
+  const updateOwn = (patch: Record<string, unknown>) =>
+    supabaseAdmin!.from('players').update(patch).eq('nick', n).eq('token', token);
 
   // multi-redes: [{net, handle}] → [{net, url}] + social_link = primeira
   if (Array.isArray(socials) && socials.length) {
@@ -50,11 +53,8 @@ export const POST: APIRoute = async ({ request }) => {
       .slice(0, 5)
       .map((s: any) => ({ net: s.net.slice(0, 12), url: buildSocialUrl(s.net, s.handle.slice(0, 40)) }))
       .filter((s: any) => s.url);
-    if (list.length) {
-      await supabaseAdmin.from('players')
-        .update({ socials: list, social_link: list[0].url.slice(0, 60) })
-        .eq('nick', nick.trim().slice(0, 14)).eq('token', token);
-    }
+    if (list.length)
+      await updateOwn({ socials: list, social_link: list[0].url.slice(0, 60) });
   }
 
   // se veio sessão OAuth, vincula auth_user + avatar do provedor/custom
@@ -62,15 +62,14 @@ export const POST: APIRoute = async ({ request }) => {
     const { data: { user } } = await supabaseAdmin.auth.getUser(accessToken);
     if (user) {
       const meta: any = user.user_metadata || {};
-      await supabaseAdmin.from('players').update({
+      await updateOwn({
         auth_user: user.id,
         avatar_url: typeof avatarUrl === 'string' ? avatarUrl.slice(0, 300)
           : (meta.avatar_url || meta.picture || null),
-      }).eq('nick', nick.trim().slice(0, 14)).eq('token', token);
+      });
     }
   } else if (typeof avatarUrl === 'string' && avatarUrl.length > 10) {
-    await supabaseAdmin.from('players').update({ avatar_url: avatarUrl.slice(0, 300) })
-      .eq('nick', nick.trim().slice(0, 14)).eq('token', token);
+    await updateOwn({ avatar_url: avatarUrl.slice(0, 300) });
   }
-  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  return json({ ok: true });
 };

--- a/src/pages/api/submit-match.ts
+++ b/src/pages/api/submit-match.ts
@@ -3,6 +3,7 @@
 import type { APIRoute } from 'astro';
 import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
 import { geoFrom } from '../../lib/geo';
+import { json, jsonError } from '../../lib/http';
 
 export const prerender = false;
 
@@ -17,22 +18,17 @@ function prune(now: number) {
 }
 
 export const POST: APIRoute = async ({ request, clientAddress }) => {
-  if (!supabaseAdmin)
-    return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
+  if (!supabaseAdmin) return json(NOT_CONFIGURED, 503);
 
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() || clientAddress || 'unknown';
   const now = Date.now();
   prune(now);
-  if (hits.get(ip) && now - hits.get(ip)! < WINDOW_MS)
-    return new Response(JSON.stringify({ error: 'rate_limited' }), { status: 429, headers: { 'content-type': 'application/json' } });
+  if (hits.get(ip) && now - hits.get(ip)! < WINDOW_MS) return jsonError('rate_limited', 429);
 
   let body: any;
-  try { body = await request.json(); } catch {
-    return new Response(JSON.stringify({ error: 'bad_json' }), { status: 400, headers: { 'content-type': 'application/json' } });
-  }
+  try { body = await request.json(); } catch { return jsonError('bad_json', 400); }
   const { nick, token, won, kills, deaths, headshots, bestStreak, rounds, team, seconds, character } = body ?? {};
-  if (typeof nick !== 'string' || typeof token !== 'string')
-    return new Response(JSON.stringify({ error: 'missing_fields' }), { status: 400, headers: { 'content-type': 'application/json' } });
+  if (typeof nick !== 'string' || typeof token !== 'string') return jsonError('missing_fields', 400);
 
   const n = nick.slice(0, 14);
   // cascata de compatibilidade: se a função do banco está desatualizada
@@ -49,15 +45,15 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     error = r.error;
     if (!/could not find the function|schema cache/i.test(r.error.message)) break; // erro real (token, rate limit…)
   }
-  if (error)
-    return new Response(JSON.stringify({ error: error.message }), { status: 403, headers: { 'content-type': 'application/json' } });
+  if (error) return jsonError(error.message, 403);
 
   hits.set(ip, now);
   // geo: presença + histórico agregado por cidade (nunca IP bruto)
   const g = geoFrom(request);
-  if (g) {    const today = new Date().toISOString().slice(0, 10);
+  if (g) {
+    const today = new Date().toISOString().slice(0, 10);
     await supabaseAdmin.from('presence').upsert({
-      nick: nick.slice(0, 14), last_seen: new Date().toISOString(),
+      nick: n, last_seen: new Date().toISOString(),
       city: g.city, country: g.country, lat: g.lat, lon: g.lon,
     });
     if (g.city) {
@@ -70,7 +66,7 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       });
     }
   }
-  return new Response(JSON.stringify(degraded
+  return json(degraded
     ? { ok: true, warn: 'banco desatualizado — rode supabase/schema.sql (perdeu rounds/time/tempo desta partida)' }
-    : { ok: true }), { headers: { 'content-type': 'application/json' } });
+    : { ok: true });
 };

--- a/src/pages/api/submit-match.ts
+++ b/src/pages/api/submit-match.ts
@@ -11,12 +11,18 @@ export const prerender = false;
 const hits = new Map<string, number>();
 const WINDOW_MS = 30_000;
 
+// idem register.ts: sem expurgo o Map acumulava um registro por IP pra sempre.
+function prune(now: number) {
+  for (const [k, t] of hits) if (now - t >= WINDOW_MS) hits.delete(k);
+}
+
 export const POST: APIRoute = async ({ request, clientAddress }) => {
   if (!supabaseAdmin)
     return new Response(NOT_CONFIGURED, { status: 503, headers: { 'content-type': 'application/json' } });
 
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() || clientAddress || 'unknown';
   const now = Date.now();
+  prune(now);
   if (hits.get(ip) && now - hits.get(ip)! < WINDOW_MS)
     return new Response(JSON.stringify({ error: 'rate_limited' }), { status: 429, headers: { 'content-type': 'application/json' } });
 

--- a/src/pages/ranking.astro
+++ b/src/pages/ranking.astro
@@ -2,9 +2,8 @@
 import Layout from '../layouts/Layout.astro';
 import { supabaseAdmin } from '../lib/supabase';
 import { displayTime } from '../lib/fmt';
-import { normalizeSocialUrl, socialAvatar, socialNet, NET_INFO, netIcon } from '../lib/social';
-import { CHARS, charSvg } from '../lib/charsvg';
-import { sideOf } from '../lib/side';
+import PlayerAvatar from '../components/PlayerAvatar.astro';
+import SocialChips from '../components/SocialChips.astro';
 
 export const prerender = false;
 
@@ -38,29 +37,16 @@ const rows = players.slice((curPage - 1) * PAGE_SIZE, curPage * PAGE_SIZE);
           <tr style={`${(curPage - 1) * PAGE_SIZE + i < 3 ? 'color:#ffd23f;font-weight:bold' : 'color:#c9bfa4'}`}>
             <td>{(curPage - 1) * PAGE_SIZE + i + 1}</td>
             <td>
-              {(() => {
-                const av = p.avatar_url || socialAvatar(p.social_link);
-                if (av) return <img src={av} alt="" width="24" height="24" style="border-radius:50%;vertical-align:-6px;margin-right:6px;object-fit:cover">;
-                if (p.last_character && CHARS[p.last_character]) {
-                  const [, sc] = sideOf(p.matches_p, p.matches_b);
-                  return (
-                    <svg width="24" height="24" viewBox="688 36 120 120" style="vertical-align:-5px;margin-right:6px;border-radius:50%">
-                      <Fragment set:html={charSvg(p.last_character, sc, `cav-r${i}`)} />
-                    </svg>
-                  );
-                }
-                return null;
-              })()}
+              <PlayerAvatar
+                nick={p.nick} avatarUrl={p.avatar_url} socialLink={p.social_link}
+                character={p.last_character} matchesP={p.matches_p} matchesB={p.matches_b}
+                size={24} clipId={`cav-r${i}`}
+                imgStyle="border-radius:50%;vertical-align:-6px;margin-right:6px;object-fit:cover"
+                svgStyle="vertical-align:-5px;margin-right:6px;border-radius:50%" />
               {onlineNicks.has(p.nick) && <span title="online agora" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#3fdd57;box-shadow:0 0 6px #3fdd57;margin-right:6px;vertical-align:1px"></span>}
               <a href={p.id ? `/u/${p.id}/${encodeURIComponent(p.nick)}` : `/u/${encodeURIComponent(p.nick)}`} style="color:inherit">{p.nick}</a>
-              {(p.socials?.length ? p.socials : (p.social_link ? [{ net: socialNet(p.social_link), url: p.social_link }] : [])).map((s: any) => {
-                const net = s.net || socialNet(s.url), info = NET_INFO[net] || NET_INFO.site;
-                return (
-                  <a href={normalizeSocialUrl(s.url)} target="_blank" rel="noopener" title={info.label}
-                     style={`display:inline-block;margin-left:6px;vertical-align:-3px;color:${info.color};text-decoration:none`}
-                     set:html={netIcon(net, 15)} />
-                );
-              })}
+              <SocialChips socials={p.socials} socialLink={p.social_link} size={15}
+                           linkStyle="display:inline-block;margin-left:6px;vertical-align:-3px" />
             </td>
             <td>{p.matches}</td>
             <td>{p.wins > 0 ? p.wins : "—"}</td>

--- a/src/pages/u/[...path].astro
+++ b/src/pages/u/[...path].astro
@@ -2,9 +2,8 @@
 import Layout from '../../layouts/Layout.astro';
 import { supabaseAdmin } from '../../lib/supabase';
 import { displayTime } from '../../lib/fmt';
-import { normalizeSocialUrl, socialAvatar, socialNet, NET_INFO, netIcon } from '../../lib/social';
-import { CHARS, charSvg } from '../../lib/charsvg';
-import { sideOf } from '../../lib/side';
+import PlayerAvatar from '../../components/PlayerAvatar.astro';
+import SocialChips from '../../components/SocialChips.astro';
 
 export const prerender = false;
 
@@ -51,30 +50,18 @@ const desc = p ? `${p.kills} kills · K/D ${kd} · ${p.wins > 0 ? p.wins : "—"
   {p && (
     <>
       <div style="display:flex;align-items:center;gap:16px">
-        {(() => {
-          const av = p.players.avatar_url || socialAvatar(p.players.social_link);
-          if (av) return <img src={av} alt={`Avatar de ${nick}`} width="72" height="72" style="border-radius:50%;border:2px solid #4a5a2a;object-fit:cover">;
-          if (p.last_character && CHARS[p.last_character]) {
-            const [, sc] = sideOf(p.matches_p, p.matches_b);
-            return (
-              <svg width="72" height="72" viewBox="688 36 120 120" style="border-radius:50%;border:2px solid #4a5a2a;background:#161a12">
-                <Fragment set:html={charSvg(p.last_character, sc, 'cav-head')} />
-              </svg>
-            );
-          }
-          return <div style="width:72px;height:72px;border-radius:50%;border:2px solid #4a5a2a;background:#161a12;display:flex;align-items:center;justify-content:center;font-size:34px;color:var(--cs);font-family:'Arial Black',sans-serif">{p.nick[0].toUpperCase()}</div>;
-        })()}
+        <PlayerAvatar
+          nick={p.nick} avatarUrl={p.players.avatar_url} socialLink={p.players.social_link}
+          character={p.last_character} matchesP={p.matches_p} matchesB={p.matches_b}
+          size={72} clipId="cav-head" alt={`Avatar de ${nick}`}
+          imgStyle="border-radius:50%;border:2px solid #4a5a2a;object-fit:cover"
+          svgStyle="border-radius:50%;border:2px solid #4a5a2a;background:#161a12"
+          initialStyle="width:72px;height:72px;border-radius:50%;border:2px solid #4a5a2a;background:#161a12;display:flex;align-items:center;justify-content:center;font-size:34px;color:var(--cs);font-family:'Arial Black',sans-serif" />
         <div>
           <h1 style="margin-bottom:4px">{nick}</h1>
           <div>
-            {(p.players.socials?.length ? p.players.socials : (p.players.social_link ? [{ net: socialNet(p.players.social_link), url: p.players.social_link }] : [])).map((s: any) => {
-              const net = s.net || socialNet(s.url), info = NET_INFO[net] || NET_INFO.site;
-              return (
-                <a href={normalizeSocialUrl(s.url)} target="_blank" rel="noopener" title={info.label}
-                   style={`display:inline-block;margin-right:8px;color:${info.color};text-decoration:none`}
-                   set:html={netIcon(net, 20)} />
-              );
-            })}
+            <SocialChips socials={p.players.socials} socialLink={p.players.social_link} size={20}
+                         linkStyle="display:inline-block;margin-right:8px" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
> ⚠️ **Empilhada na #26.** Ela mexe nos mesmos arquivos (`register.ts`, `submit-match.ts`, `badge/[...path].png.ts`), então nasceu em cima daquela branch pra não gerar conflito. **O diff aqui inclui o commit da #26** — quando a #26 entrar, o GitHub recalcula e sobra só o commit de refactor. Se preferir, dá pra mergear as duas na ordem #26 → esta.

Só remoção de duplicação. **Nenhuma mudança de comportamento nem de markup renderizado** — validei isso, ver a seção de teste. Não toca em `public/`, então não conflita com as PRs de armas/mapas/gráficos.

## O que sai daqui

### `sideOf` duplicada byte a byte
`api/badge/[...path].png.ts` reimplementava a função inteira:
```ts
// lado do jogador: P > B = PETISTA, B > P = BOLSONARISTA, empate = NEUTRO
export function sideOf(mp: number, mb: number): [string, string] { ... }
```
…com `src/lib/side.ts` já existindo com exatamente esse código, e já sendo importada por `ranking.astro` e `u/[...path].astro`. Agora importa do lib. De passagem, deixa de `export`ar uma função que não tinha por que sair de uma API route.

### ~30 respostas JSON montadas à mão
O mesmo `new Response(JSON.stringify(x), { status, headers: { "content-type": "application/json" } })` repetido nos 7 endpoints. Vira `json()` / `jsonError()` em `src/lib/http.ts`:

```ts
if (!supabaseAdmin) return json(NOT_CONFIGURED, 503);
try { body = await request.json(); } catch { return jsonError("bad_json", 400); }
```

`NOT_CONFIGURED` deixa de ser string pré-serializada e passa a ser objeto, já que agora quem serializa é o helper.

### Cascata de avatar e chips de rede duplicados entre duas páginas
`ranking.astro` e `u/[...path].astro` tinham o mesmo bloco: foto → avatar da rede social → retrato do personagem → inicial do nick, mais o mesmo `.map()` dos ícones. Viram `<PlayerAvatar>` e `<SocialChips>` em `src/components/`.

Os estilos continuam vindo por prop porque as duas telas usam medidas diferentes (24px alinhado na tabela × 72px com borda no perfil). Foi de propósito: centralizei a **lógica** sem encostar no visual de nenhuma das duas.

### `register.ts` recalculando a mesma coisa
`nick.trim().slice(0, 14)` aparecia em 4 lugares (com o risco de divergirem numa edição futura) e o mesmo `.eq("nick", …).eq("token", …)` em 3 updates. Agora é um `n` só e um `updateOwn()`.

## Teste

**1. Paridade do markup.** Escrevi um comparador que roda a lógica antiga (copiada do HEAD anterior) e a nova lado a lado, usando as libs reais, em 9 casos:

```
✓ foto propria           avatar=igual chips=igual
✓ avatar do github       avatar=igual chips=igual
✓ avatar do x            avatar=igual chips=igual
✓ personagem (lado P)    avatar=igual chips=igual
✓ personagem (lado B)    avatar=igual chips=igual
✓ personagem (empate)    avatar=igual chips=igual
✓ personagem invalido    avatar=igual chips=igual
✓ sem nada               avatar=igual chips=igual
✓ socials multi          avatar=igual chips=igual
```

**2. Endpoints de verdade**, com dev server no ar:

| caso | antes | agora |
| --- | --- | --- |
| 503 sem Supabase (6 endpoints) | `{"error":"not_configured","message":"…"}` | idêntico, byte por byte |
| json quebrado | 400 `bad_json` | 400 `bad_json` |
| campos faltando | 400 `missing_fields` | 400 `missing_fields` |
| token inválido | 403 | 403 |
| rate limit do register (12 requests) | — | `400 ×10` depois `429 429` (teto de 10/min intacto) |

**3.** `npm run build` passa e a checagem de sintaxe do `public/js` que o CI roda continua limpa (nenhum arquivo do jogo foi tocado).

## Um efeito colateral positivo
No perfil, a inicial do nick usava `p.nick[0].toUpperCase()` sem guarda. O componente usa `(nick[0] || "?")`, então um nick vazio não estoura mais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)