### PR TITLE
fix(jogo): libera as geometrias das armas largadas no chão (vazamento de VRAM)

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -24,6 +24,15 @@ const RADIO = {
 const MK_TIERS = { 2: 'doublekill', 3: 'triplekill', 4: 'multikill', 5: 'megakill' };
 const MK_LABELS = { doublekill: 'DOUBLE KILL', triplekill: 'TRIPLE KILL', multikill: 'MULTI KILL', megakill: 'MEGA KILL', killingspree: 'KILLING SPREE', godlike: 'GODLIKE' };
 
+// scene.remove() NÃO libera a VRAM: o buffer da geometria fica vivo na GPU até
+// alguém chamar dispose(). Sem isso, cada arma largada no chão vazava as
+// geometrias dela pro resto da partida.
+// SÓ geometria: os materiais vêm do matCache compartilhado de characters.js
+// (M()), então dar dispose neles apagaria o material de bots e drops vivos.
+function freeGeometries(obj) {
+  if (obj) obj.traverse(o => { if (o.geometry) o.geometry.dispose(); });
+}
+
 export class Game {
   constructor({ renderer, textures, sfx, settings, playerCharId, playerTeam, nickname, mapId, testMode = false, onQuit, onMatchEnd }) {
     this.renderer = renderer;
@@ -239,7 +248,7 @@ export class Game {
       if (e.code === 'KeyE' && this.nearPickup) {
         const { pk, dropIdx } = this.nearPickup;
         this._grabPickup(pk, this.player, true);
-        if (dropIdx >= 0) { this.scene.remove(pk.mesh); this.drops.splice(dropIdx, 1); }
+        if (dropIdx >= 0) { this.scene.remove(pk.mesh); freeGeometries(pk.mesh); this.drops.splice(dropIdx, 1); }
         this.nearPickup = null;
       }
       if (e.code === 'KeyM') { if (this.onRequestSwitch) this.onRequestSwitch(); else this._switchTeam(); }
@@ -369,7 +378,7 @@ export class Game {
       this.player.weapon = 'awp';
     }
     this.player.scoped = false; this.player.reloadUntil = 0;
-    for (const d of this.drops) this.scene.remove(d.mesh);
+    for (const d of this.drops) { this.scene.remove(d.mesh); freeGeometries(d.mesh); }
     this.drops = [];
     for (const k in this.vm.models) this.vm.models[k].visible = k === this.player.weapon;
     this.el.weaponName.textContent = WEAPONS[this.player.weapon].name;
@@ -482,7 +491,7 @@ export class Game {
       const newDef = defs[(Math.random() * defs.length) | 0];
       swapBot.def = newDef; swapBot.name = newDef.name;
       this.scene.remove(swapBot.mesh.group);
-      swapBot.mesh.group.traverse(o => { if (o.geometry) o.geometry.dispose(); });
+      freeGeometries(swapBot.mesh.group);
       swapBot.mesh = buildCharacter(newDef);
       swapBot.mesh.group.traverse(o => { o.userData.botOwner = swapBot; });
       this.scene.add(swapBot.mesh.group);
@@ -883,7 +892,7 @@ export class Game {
       for (const b of this.bots) {
         if (!b.alive) continue;
         const dx = pk.x - b.pos.x, dz = pk.z - b.pos.z;
-        if (dx * dx + dz * dz <= 1.7 * 1.7) { this._grabPickup(pk, b, false); this.scene.remove(pk.mesh); this.drops.splice(i, 1); break; }
+        if (dx * dx + dz * dz <= 1.7 * 1.7) { this._grabPickup(pk, b, false); this.scene.remove(pk.mesh); freeGeometries(pk.mesh); this.drops.splice(i, 1); break; }
       }
     }
   }
@@ -1189,7 +1198,7 @@ export class Game {
     this.el.lockHint.classList.add('hidden');
     this.el.scoreboard.classList.add('hidden');
     this.el.vignette.style.opacity = 0;
-    this.scene.traverse(o => { if (o.geometry) o.geometry.dispose(); });
+    freeGeometries(this.scene);
     this.scene.clear();
   }
 }


### PR DESCRIPTION
Achado investigando um relato de navegador fechando durante a partida. **Não reproduzi o fechamento** (ver a seção honesta no fim), mas no caminho achei e corrigi um vazamento de VRAM real e medível.

## O bug

`scene.remove()` não libera VRAM — o buffer da geometria continua vivo na GPU até alguém chamar `dispose()`. Toda arma largada no chão era removida da cena **sem dispose** em 3 pontos:

- `game.js:242` — jogador pega o drop com `E`
- `game.js:886` — bot pega andando por cima
- `game.js:372` — reset de round limpa o chão

Então as geometrias de cada arma largada vazavam pelo resto da sessão.

## Como medi

Brave headless via CDP (WebSocket nativo do Node, zero deps), lendo `renderer.info.memory` numa partida real com tiro automático contínuo:

```
geometrias vivas na GPU : 472 -> 662 em 61s  (+186/min, monotônico)
objetos na cena         : 429 -> 494
folga órfã (geom - obj) :  44 -> 161         <- removidas e nunca liberadas
heap JS                 : estável (13-27MB)  <- não era vazamento de JS
```

O heap JS ficar estável foi o que apontou pra GPU em vez de JS. Casando cada remoção da cena com um `dispose()`, sobraram **126 BoxGeometry + 60 CylinderGeometry em 58s** — exatamente o que `_dropWeapon` produz (drop comum = 2 boxes; drop de AWP = `buildRifle()` = 4 boxes + 2 cylinders).

> Detalhe de medição: a contagem crua acusava 643 `BufferGeometry` a mais, mas era artefato — `Sprite` no Three.js compartilha **uma** geometria interna, então a mesma instância reaparece em toda remoção de puff/flash. Depois de deduplicar por identidade, sobram só os drops. O sistema de FX (`_updateFx`) libera tudo corretamente e está limpo.

## A/B, forçando o fim de um round (o reset limpa os drops)

| | pico | após reset | geometrias devolvidas |
| --- | --- | --- | --- |
| **sem o fix** | 636 | 653 | **−17** (subiu) |
| **com o fix** | 549 | 499 | **+50** |

Sem o fix, o reset tira 47 objetos da cena e a contagem na GPU *sobe* — a folga órfã explode de 139 pra 203. Com o fix a folga fica estável (40 → 49), e o que ainda cresce durante o round são só os drops de fato no chão, que o reset limpa. Confirmei isso com um tally da cena: o crescimento restante é `Group +10`, casando exatamente com `drops 0 -> 10`.

## O cuidado que o fix respeita

Libera **só geometria**. Os materiais vêm do `matCache` compartilhado de `characters.js` (`M()`), então o fix "óbvio" de dar `traverse` + dispose em geometria *e* material apagaria o material de bots e drops ainda vivos — regressão visual feia. Geometria é sempre construída nova (`new THREE.BoxGeometry(...)`, nunca cacheada), por isso é seguro.

De passada, os dois pontos que já liberavam geometria à mão (troca de time em `:485` e teardown em `:1192`) passam a usar o mesmo helper.

## Sendo honesto sobre o escopo

Isto **não** é comprovadamente a causa do navegador fechar. ~1500 geometrias pequenas numa partida de 8 min é da ordem de 10–20 MB de VRAM — bug real, mas provavelmente não o suficiente pra derrubar um navegador sozinho. O que também investiguei e **não** confirmou:

- **`Sfx._sample()` cria um `new Audio()` por som** (`audio.js:20`), sem pool nem cache. Medi 9 elementos/s com arma automática, ~4300 numa partida de 8 min — mas o GC do Chromium dá conta (os vivos ficam em 6–34 e não crescem) e nenhum erro de mídia apareceu. É desperdício (4300 pipelines de mídia e decodes de mp3 por partida), não vazamento. Vale uma issue separada.
- **Custo de frame / shadow map**: cada drop entra no shadow map (`castShadow = true` em `:926`), mas não consigo medir isso de forma útil em headless, que roda em swiftshader (software). Fica em aberto.
- **Não existe handler de `webglcontextlost`** em nenhum lugar do jogo. Se o driver resetar (comum no Linux sob carga), a página quebra sem chance de recuperar. Vale uma issue.

## Teste
- `npm run build` passa; checagem de sintaxe do `public/js` (a que o CI roda) limpa.
- Partidas completas rodando no harness: round termina, reset acontece, drops limpam, sem exceção no console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)