### PR TITLE
fix(jogo): agachar sai do Ctrl — Ctrl+W fechava o navegador na partida

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm run preview       # serve dist/client estaticamente
 | W A S D | Mover |
 | Mouse | Mirar |
 | Shift | Correr |
-| **Ctrl ou C** | **Agachar — mira mais estável** |
+| **C** | **Agachar — mira mais estável** (Ctrl não: é atalho do navegador) |
 | Espaço | Pular |
 | Clique esq. | Atirar |
 | Clique dir. | Luneta da AWP |

--- a/public/index.html
+++ b/public/index.html
@@ -55,7 +55,7 @@
     { "@type": "Question", "name": "Preciso instalar ou pagar algo?",
       "acceptedAnswer": { "@type": "Answer", "text": "Não. O jogo é 100% gratuito e roda direto no navegador de desktop (Chrome, Edge ou Firefox), sem download nem instalação." } },
     { "@type": "Question", "name": "Quais são os controles?",
-      "acceptedAnswer": { "@type": "Answer", "text": "WASD move, mouse mira, clique esquerdo atira, clique direito abre a luneta da AWP, Ctrl agacha (melhora a mira), Shift corre, Espaço pula, R recarrega, teclas 1/2/3 trocam AWP/pistola/faca, Z/X/C abrem os comandos de voz e Tab mostra o placar." } },
+      "acceptedAnswer": { "@type": "Answer", "text": "WASD move, mouse mira, clique esquerdo atira, clique direito abre a luneta da AWP, C agacha (melhora a mira), Shift corre, Espaço pula, R recarrega, teclas 1/2/3 trocam AWP/pistola/faca, Z/X/C abrem os comandos de voz e Tab mostra o placar." } },
     { "@type": "Question", "name": "Quais são os times e personagens?",
       "acceptedAnswer": { "@type": "Answer", "text": "Dois times fictícios e satíricos: Petistas (Esquerdomacho, Líder do Sindicato, Líder do MST, Doutora do SUS) e Bolsonaristas (Caminhoneiro, Influencer de Dubai, Cantor Sertanejo, Tia Zilá). Todos são arquétipos originais, sem pessoas reais." } },
     { "@type": "Question", "name": "É um jogo oficial da Valve ou do Counter-Strike?",
@@ -205,7 +205,7 @@
       <span>W A S D</span><span>Mover</span>
       <span>MOUSE</span><span>Mirar</span>
       <span>SHIFT</span><span>Correr</span>
-      <span>CTRL ou C</span><span>Agachar (mira mais estável)</span>
+      <span>C</span><span>Agachar (mira mais estável)</span>
       <span>ESPAÇO</span><span>Pular</span>
       <span>CLIQUE ESQ.</span><span>Atirar</span>
       <span>CLIQUE DIR.</span><span>Mira telescópica (AWP)</span>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -220,8 +220,16 @@ export class Game {
     this.keys = {};
     this._kd = e => {
       if (e.code === 'Tab') { e.preventDefault(); this._showScoreboard(true); }
-      // em pointer lock, engole atalhos do navegador (Ctrl+S/D/A/R…) — Ctrl+W o Chrome não deixa prevenir, use C pra agachar
-      if ((e.ctrlKey || e.metaKey) && document.pointerLockElement) e.preventDefault();
+      // Em pointer lock, engole os atalhos que o navegador deixa prevenir
+      // (Ctrl+S/D/A…). Os RESERVADOS não dá: Ctrl+W fecha a aba e Ctrl+R
+      // recarrega mesmo com preventDefault — testado no Chromium. Por isso
+      // agachar NÃO é mais Ctrl (veja _updatePlayer): com só a aba do jogo
+      // aberta, Ctrl+W ao andar agachado pra frente fechava o navegador
+      // inteiro no meio da partida.
+      if ((e.ctrlKey || e.metaKey) && document.pointerLockElement) {
+        e.preventDefault();
+        this._avisaCtrl();
+      }
       this.keys[e.code] = true;
       if (this.radioOpen) {
         const n = { Digit1: 1, Digit2: 2, Digit3: 3 }[e.code];
@@ -756,8 +764,12 @@ export class Game {
       this.camera.rotation.z = Math.min(0.5, (this.camera.rotation.z || 0) + dt * 0.8);
       return;
     }
-    // crouch (CTRL ou C) — slower, steadier aim
-    const wantCrouch = (this.keys.ControlLeft || this.keys.ControlRight || this.keys.KeyC) && p.grounded;
+    // crouch (C) — slower, steadier aim.
+    // Ctrl saiu de propósito: combinado com as teclas do jogo ele dispara
+    // atalhos reservados do navegador que a página não consegue bloquear —
+    // Ctrl+W fecha a aba (e o navegador, se for a única), Ctrl+R recarrega e
+    // perde a partida, Ctrl+1/2/3 troca de aba.
+    const wantCrouch = this.keys.KeyC && p.grounded;
     p.crouchF = Math.max(0, Math.min(1, p.crouchF + (wantCrouch ? dt * 7 : -dt * 7)));
     const sprint = (this.keys.ShiftLeft || this.keys.ShiftRight) && p.crouchF < 0.3;
     const slowMul = this.world.slowAt && this.world.slowAt(p.pos.x, p.pos.z) ? 0.45 : 1;  // água/lago
@@ -1096,6 +1108,13 @@ export class Game {
   }
 
   /* ================= HUD ================= */
+  // quem vem do CS aperta Ctrl por reflexo; avisa uma vez por partida em vez
+  // de simplesmente não agachar sem explicação
+  _avisaCtrl() {
+    if (this._ctrlAvisado) return;
+    this._ctrlAvisado = true;
+    this._banner('AGACHAR É NO C', 'Ctrl é atalho do navegador (Ctrl+W fecha a aba)');
+  }
   _banner(title, sub) {
     this.el.bannerTitle.textContent = title;
     this.el.bannerSub.textContent = sub;


### PR DESCRIPTION
**Causa raiz de "o navegador fecha do nada jogando"** — reproduzido e capturado com log, não teoria.

## O bug

Agachar aceitava `ControlLeft`/`ControlRight` (`game.js:760`). Andar agachado pra frente é **Ctrl+W**, que no Chromium fecha a aba — e quando a aba do jogo é a única, **o navegador inteiro encerra**. O jogador perde a partida e a janela.

A colisão não é só o W. Com Ctrl pressionado, as teclas do jogo viram atalho reservado do navegador:

| no jogo | com Ctrl | efeito |
| --- | --- | --- |
| `W` andar pra frente | `Ctrl+W` | **fecha a aba** → encerra o navegador se for a única |
| `R` recarregar | `Ctrl+R` | recarrega a página, perde a partida |
| `1`/`2`/`3` trocar arma | `Ctrl+1/2/3` | pula pra outra aba |
| `S` andar pra trás | `Ctrl+S` | abre "salvar página" |

## Como cheguei nisso

Capturei uma sessão real com stderr do Brave + journal + amostragem de VRAM a cada 5s. O navegador morreu **66 segundos** depois de abrir, e os dados descartaram as hipóteses óbvias:

```
VRAM      147 -> 157 MiB       (nunca cresceu — não é vazamento de GPU)
RAM       22 GB, 9,5 GB livres (não é OOM)
kernel    sem oom-kill, sem GPU hang/reset
crashpad  nenhum minidump novo
```

E o log do Brave mostrou que **não foi crash — foi saída graciosa**:

```
18:21:18  GET .../audio/game/ut-double-kill.mp3     <- jogando, fez multikill
18:21:32  GET .../audio/game/ut-triple-kill.mp3
18:21:42  [ActorTool]: ActorKeyedService::Shutdown
18:21:42  AccountReconcilor::Shutdown
18:21:42  MutablePO2TS::Shutdown
```

`KeyedService::Shutdown` é o caminho de "o navegador foi *pedido* pra sair". Ninguém pediu — o Ctrl+W pediu.

## Por que a guarda que já existia não resolve

```js
if ((e.ctrlKey || e.metaKey) && document.pointerLockElement) e.preventDefault();
```

Não funciona para atalhos reservados. Testei: página com exatamente essa guarda, despachei Ctrl+W via CDP — **1 aba antes, 0 depois**. O `preventDefault()` não segura.

A Keyboard Lock API (`navigator.keyboard.lock()`) resolveria, mas **o Brave não expõe `navigator.keyboard`** (verificado no teste) e o Firefox não implementa — então não serve como base do fix.

O comentário no código já admitia o problema (*"Ctrl+W o Chrome não deixa prevenir, use C pra agachar"*), mas `ControlLeft`/`ControlRight` seguiam ligados a agachar e a UI, o README e o FAQ do schema.org continuavam ensinando **"CTRL ou C"**. O jogo documentava como controle oficial a tecla que fecha o navegador do jogador.

## O fix

Agachar é só `C`, consistente em todos os lugares: jogo, tabela de controles do `index.html`, FAQ estruturado e README.

Quem vem do CS aperta Ctrl por reflexo. Em vez de simplesmente não agachar sem explicação, aparece um aviso uma vez por partida: **"AGACHAR É NO C — Ctrl é atalho do navegador (Ctrl+W fecha a aba)"**.

## Verificação

Brave headless via CDP, com partida rodando:

```
crouchF ao segurar C     : 1     (agacha)
crouchF ao soltar C      : 0
crouchF ao segurar Ctrl  : 0     (não agacha)
páginas abertas no fim   : 1     (a aba sobreviveu)
estado do jogo           : live
```

`npm run build` passa e a checagem de sintaxe do `public/js` que o CI roda está limpa.

## Nota separada

`docs/development/godot.md:48` e `docs/runbooks/testar-cliente-godot.md:125` documentam `Ctrl` como agachar no **cliente Godot**. Não toquei, porque é outro alvo — mas se o Godot for exportado pra web, herda exatamente o mesmo problema. Vale conferir.

Isso é independente da #28 (vazamento de VRAM nos drops). A #28 é bug real, mas os dados desta captura mostram que **não** era a causa do navegador fechar — deixei isso explícito na descrição dela também.

🤖 Generated with [Claude Code](https://claude.com/claude-code)