### PR TITLE
feat(api): valida charset do nick no register (homoglifo, RTL, zero-width)

### DIFF
--- a/docs/seguranca.md
+++ b/docs/seguranca.md
@@ -323,7 +323,66 @@ e é por isso que `/ranking` e `/u/*` já estavam corretos.
 
 ---
 
-## 7. Ofuscação de schema — **entregue pronta, NÃO aplicada**
+## 7. Charset do nick — **API fechada, banco pendente**
+
+**Onde:** `register_player` valida **só o comprimento**
+(`check (char_length(nick) between 2 and 14)`). Caractere nenhum é filtrado.
+
+O que passa hoje, e o que faz:
+
+| entrada | efeito |
+|---|---|
+| `Аdmin` com `А` cirílico (U+0410) | pixel-a-pixel igual a `Admin` e passa no `unique`. Nick squatting invisível. |
+| `U+202E` (RTL override) | inverte a ordem visual do texto e embaralha ranking e badge |
+| `U+200B` (zero-width) | dois nicks visualmente idênticos, distintos pro banco |
+| `U+0000`–`U+001F` | quebra o render de SVG da badge |
+| `<`, `>`, `"` | é por isso que os popups de `/mapa` precisam de `esc()` à mão (§6) |
+
+**O que já está fechado.** `src/pages/api/register.ts` recusa antes de chamar o
+RPC, com `400 nick_invalid` e mensagem legível. A regex mora em
+`src/lib/nick.ts` (`NICK_RE`).
+
+**O que falta, e só o dono pode aplicar** — `/supabase/` está no `.gitignore`,
+o schema é privado. Este é o SQL, na ordem segura:
+
+```sql
+-- 1. NOT VALID: passa a valer pra escrita NOVA sem varrer a tabela nem
+--    quebrar deploy por causa de linha antiga.
+alter table public.players
+  add constraint players_nick_charset
+  check (nick ~ '^[A-Za-z0-9_.\-]{2,14}$') not valid;
+
+-- 2. Relatório: quem já está fora da regra?
+select id, nick, char_length(nick) as chars
+from public.players
+where nick !~ '^[A-Za-z0-9_.\-]{2,14}$'
+order by nick;
+
+-- 2b. Se precisar ver QUAL caractere ofende — homoglifo cirílico e zero-width
+--     não aparecem a olho no resultado acima:
+select nick, string_agg(to_hex(ascii(c)), ' ' order by i) as codepoints_hex
+from public.players,
+     unnest(regexp_split_to_array(nick, '')) with ordinality as t(c, i)
+where nick !~ '^[A-Za-z0-9_.\-]{2,14}$'
+group by nick;
+
+-- 3. Só depois de decidir o que fazer com os inválidos (renomear? esconder
+--    com players.hidden? deixar?), valide o constraint:
+alter table public.players validate constraint players_nick_charset;
+```
+
+**Decisão que sobra pro dono:** o que fazer com nick já registrado que viola.
+Renomear muda a URL pública `/u/<id>/<nick>` de alguém; deixar significa
+conviver com o constraint `not valid` pra sempre. Nenhuma das duas é chamada de
+quem manda a PR.
+
+**Custo conhecido do charset:** rejeita acento. `José` não registra, `Jose` sim.
+É decisão de produto, não de segurança — a issue #40 propôs este charset. Se
+mudar de ideia, `src/lib/nick.ts` e o check do banco mudam **juntos**, sempre.
+
+---
+
+## 8. Ofuscação de schema — **entregue pronta, NÃO aplicada**
 
 `supabase/opcional/` contém o SQL de renomeação de tabelas/colunas/views/RPCs,
 o rollback e o patch das rotas. **Nada foi aplicado.**

--- a/src/lib/nick.ts
+++ b/src/lib/nick.ts
@@ -1,0 +1,30 @@
+// Charset permitido no nick. Espelho EXATO do check `players_nick_charset` no
+// banco (a fonte da verdade) — ver docs/seguranca.md §8. Existe aqui pra
+// devolver erro legível em vez de deixar o Postgres responder um 409 genérico
+// de constraint violada.
+//
+// A lista é um ALLOWLIST de ASCII de propósito, não um blocklist. Blocklist de
+// caractere hostil não fecha: são milhares de codepoints e cada versão do
+// Unicode acrescenta mais. O que isso barra, e por quê:
+//
+//   homoglifo   `Аdmin` com "А" cirílico (U+0410) é pixel-a-pixel igual a
+//               `Admin` e passa no unique do Postgres. Nick squatting invisível.
+//   RTL override U+202E inverte a ordem visual do texto e embaralha a exibição
+//               do ranking e da badge.
+//   zero-width  U+200B cria nicks visualmente idênticos e distintos pro banco.
+//   controle    U+0000-001F quebra render de SVG na badge.
+//   `<` `>` `"` sobra de XSS: hoje o mapa escapa à mão (docs/seguranca.md §6)
+//               justamente porque isso passava.
+//
+// CUSTO CONHECIDO: rejeita acento. `José` não registra, `Jose` sim. Para um
+// público brasileiro isso é decisão de produto, não de segurança — a issue #40
+// propôs este charset e é o que está implementado. Aceitar `À-ÿ` é trocar a
+// classe aqui e no check do banco, juntos, sempre.
+export const NICK_RE = /^[A-Za-z0-9_.\-]{2,14}$/;
+
+export function isValidNick(nick: string): boolean {
+  return NICK_RE.test(nick);
+}
+
+// Mensagem pro jogador. Curta: aparece no menu do jogo, não num formulário.
+export const NICK_HINT = 'nick aceita só letras sem acento, números, ponto, hífen e _ (2 a 14)';

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
 import { buildSocialUrl } from '../../lib/social';
 import { isAllowedAvatarUrl } from '../../lib/safe-url';
 import { rateLimit } from '../../lib/ratelimit';
+import { isValidNick, NICK_HINT } from '../../lib/nick';
 
 export const prerender = false;
 
@@ -27,8 +28,19 @@ export const POST: APIRoute = async ({ request }) => {
   const { nick, token, social, socials, accessToken, avatarUrl } = body ?? {};
   if (typeof nick !== 'string' || typeof token !== 'string' || nick.trim().length < 2)
     return new Response(JSON.stringify({ error: 'missing_fields' }), { status: 400, headers: { 'content-type': 'application/json' } });
+
+  // Charset do nick. O check no banco é a fonte da verdade (players_nick_charset,
+  // docs/seguranca.md §8); isto aqui é o espelho, e existe por dois motivos:
+  // devolver erro legível em vez do 409 genérico de constraint violada, e recusar
+  // ANTES de gastar uma chamada de RPC. Valida o nick já cortado em 14, que é o
+  // que de fato vai pro banco — validar o original e gravar o truncado deixaria
+  // passar lixo depois do 14º caractere.
+  const nickLimpo = nick.trim().slice(0, 14);
+  if (!isValidNick(nickLimpo))
+    return new Response(JSON.stringify({ error: 'nick_invalid', message: NICK_HINT }), { status: 400, headers: { 'content-type': 'application/json' } });
+
   const { error } = await supabaseAdmin.rpc('register_player', {
-    p_nick: nick.trim().slice(0, 14), p_token: token,
+    p_nick: nickLimpo, p_token: token,
     p_social: typeof social === 'string' ? social.slice(0, 60) : null,
   });
   if (error)
@@ -44,7 +56,7 @@ export const POST: APIRoute = async ({ request }) => {
     if (list.length) {
       await supabaseAdmin.from('players')
         .update({ socials: list, social_link: list[0].url.slice(0, 60) })
-        .eq('nick', nick.trim().slice(0, 14)).eq('token', token);
+        .eq('nick', nickLimpo).eq('token', token);
     }
   }
 
@@ -63,11 +75,11 @@ export const POST: APIRoute = async ({ request }) => {
       await supabaseAdmin.from('players').update({
         auth_user: user.id,
         avatar_url: safeAvatar(avatarUrl) ?? safeAvatar(meta.avatar_url) ?? safeAvatar(meta.picture),
-      }).eq('nick', nick.trim().slice(0, 14)).eq('token', token);
+      }).eq('nick', nickLimpo).eq('token', token);
     }
   } else if (safeAvatar(avatarUrl)) {
     await supabaseAdmin.from('players').update({ avatar_url: safeAvatar(avatarUrl) })
-      .eq('nick', nick.trim().slice(0, 14)).eq('token', token);
+      .eq('nick', nickLimpo).eq('token', token);
   }
   return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
 };


### PR DESCRIPTION
Aborda #40 — a parte que dá pra fazer no repo. **A migration fica pro dono, e o motivo não é preguiça:** veja a seção "O que não está aqui".

## O que muda

`src/lib/nick.ts` traz `NICK_RE = /^[A-Za-z0-9_.\-]{2,14}$/`, e `src/pages/api/register.ts` recusa com `400 nick_invalid` + mensagem legível **antes** de gastar a chamada de RPC.

Allowlist, não blocklist — são milhares de codepoints hostis e cada versão do Unicode acrescenta mais.

Um detalhe que muda o resultado: a validação roda no nick **já cortado em 14**, que é o que de fato vai pro banco. Validar o original e gravar o truncado deixaria passar lixo depois do 14º caractere. De passagem, os 3 lookups que recalculavam `nick.trim().slice(0, 14)` agora usam a variável — recalcular a chave em 4 lugares é como divergência entra sem ninguém notar.

## Verificação

19 casos, todos conforme esperado:

```
 ok  "Zeca"                     aceita
 ok  "ze_ca-99"                 aceita
 ok  "a.b" / "Ab" / 14 chars    aceita
 ok  "Аdmin"                    recusa   <- А cirílico U+0410, idêntico a "Admin"
 ok  RTL override U+202E        recusa
 ok  zero-width U+200B          recusa
 ok  NUL U+0000 / U+001F        recusa
 ok  "<svg/>" / aspas / espaço  recusa
 ok  emoji / combining acute    recusa

homoglifo: "Admin" vs "Аdmin" — iguais pro banco? false | aceitos? true / false
```

E ponta a ponta na rota, com dev server:

| entrada | resposta |
|---|---|
| nick válido | passa a validação e chega no RPC ✓ |
| homoglifo cirílico | `400 nick_invalid` |
| RTL override | `400 nick_invalid` |
| zero-width | `400 nick_invalid` |
| acento | `400 nick_invalid` |
| tag HTML | `400 nick_invalid` |
| 1 caractere | `400 missing_fields` (check de comprimento, inalterado) |

## O que NÃO está aqui, e por quê

A issue pede migration com `check (nick ~ ...)` no banco — que é, corretamente, a fonte da verdade. **Não dá pra fazer numa PR:** `.gitignore:143` ignora `/supabase/` inteiro. Schema e migrations são **privados, fora do repo** por decisão de segurança (`docs/docs/comecando.md:202` confirma: *"banco: schema/migrations são PRIVADOS — fora do repo"*). Um contribuidor externo não tem onde commitar esse arquivo.

Então o SQL foi pra **`docs/seguranca.md` §7** (nova seção, entre o XSS do mapa e a ofuscação), na ordem segura que a própria issue pede:

1. `add constraint ... NOT VALID` — vale pra escrita nova sem varrer a tabela nem quebrar deploy por linha antiga
2. relatório dos nicks já inválidos — **mais** uma segunda query que dumpa os codepoints em hex, porque homoglifo e zero-width **não aparecem a olho** no resultado da primeira
3. só então `validate constraint`

**A decisão que sobra é sua, e está marcada como tal na doc:** o que fazer com nick já registrado que viola. Renomear muda a URL pública `/u/<id>/<nick>` de alguém; deixar significa conviver com o constraint `not valid`. Não é chamada de quem manda a PR.

⚠️ **O SQL não foi executado** — não tenho acesso ao banco. Escrevi na versão mais simples possível justamente por isso, pra maximizar a chance de estar correto sem poder testar.

## Custo conhecido do charset

Rejeita acento: **`José` não registra, `Jose` sim.** Para um público brasileiro isso é decisão de produto, não de segurança. A issue propôs este charset e é o que está implementado — mas se você quiser aceitar `À-ÿ`, é trocar a classe em `src/lib/nick.ts` **e** no check do banco, juntos. Está anotado nos dois lugares.

Se quiser, transformo os 19 casos num portão em `tools/eval/` no padrão dos outros — não fiz porque a issue não pediu e eu não quis inventar convenção no seu harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)