### PR TITLE
feat(a11y): skip link, foco visível universal e auditoria de contraste

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -217,8 +217,25 @@ body{background:transparent;color:var(--bone);font-family:var(--mono);line-heigh
   -webkit-font-smoothing:antialiased}
 a{color:var(--amber)}
 img{max-width:100%}
-:where(a,button,summary,input,select):focus-visible{outline:2px solid var(--amber-hi);
-  outline-offset:2px}
+/* FOCO. A regra anterior era `:where(a,button,summary,input,select)`, que tem
+   duas limitações: `:where()` zera a especificidade (qualquer regra com peso
+   sobrescreve) e a lista deixa de fora textarea, [tabindex], [contenteditable]
+   e o <main> que o skip link foca. O seletor universal cobre tudo o que o
+   navegador considerar focável, agora e depois. */
+:focus-visible{outline:2px solid var(--amber-hi);outline-offset:2px}
+/* O <main> recebe foco por programa (skip link) e o anel nele não informa nada
+   — o que o leitor precisa é que o cursor foi pro conteúdo, e isso o
+   tabindex="-1" já resolve. */
+main:focus-visible{outline:none}
+
+/* SKIP LINK. Primeiro focável da página: o <header> sticky tem 8 links de
+   navegação antes do conteúdo, e sem isto quem usa teclado ou leitor de tela
+   atravessa os 8 em TODA página. Fora da tela até receber foco — nunca
+   `display:none`, que o tiraria da ordem de tabulação e o tornaria inútil. */
+.skip{position:absolute;left:-9999px;top:0;z-index:100;
+  background:var(--amber);color:#141008;font-weight:bold;letter-spacing:1px;
+  padding:10px 18px;text-decoration:none;border:1px solid var(--amber-hi)}
+.skip:focus{left:8px;top:8px}
 
 /* ---- fundo 3D + vinheta (mesma composição do menu principal) ----
    A vinheta abriu de .72 para .60 no centro: com .72 o mundo 3D que o
@@ -233,6 +250,8 @@ img{max-width:100%}
 #bg-scan{position:fixed;inset:0;z-index:1;pointer-events:none;opacity:.085;
   background:repeating-linear-gradient(0deg,transparent 0 2px,rgba(0,0,0,.8) 2px 4px)}
 body>header,main,body>footer{position:relative;z-index:2}
+/* o topo fixo cobriria o começo do conteúdo depois do salto do skip link */
+main{scroll-margin-top:var(--topo)}
 
 /* ============================ TOPO ============================
    Marca = logo.png + canarinho. O canarinho é RECORTADO do banner de header por
@@ -495,6 +514,7 @@ body>footer a:hover{color:var(--amber)}
 </style>
 </head>
 <body>
+<a class="skip" href="#conteudo">Pular para o conteúdo</a>
 <canvas id="bg-canvas" aria-hidden="true"></canvas>
 <div id="bg-overlay"></div>
 <div id="bg-scan"></div>
@@ -528,7 +548,7 @@ body>footer a:hover{color:var(--amber)}
       um item de texto igual aos outros. É a hierarquia da referência. */}
   <a class="btn-play" href="/">▶ JOGAR</a>
 </header>
-<main>
+<main id="conteudo" tabindex="-1">
   {h1 && (
     <section class:list={['phead', { semarte: !heroImg }]}>
       {heroImg && <div class="phead-art" style={`--hero:url('${heroImg}');--heropos:${heroPos}`}></div>}


### PR DESCRIPTION
Closes #36

> Base é `v2/alpha`. Um arquivo, +23/−3.

## 1. Skip link

`<a class="skip" href="#conteudo">` como **primeiro focável do body**, com `<main id="conteudo" tabindex="-1">` como alvo. O header sticky tem 8 links de navegação antes do conteúdo — sem isto, quem usa teclado ou leitor de tela atravessa os 8 em **toda** página.

Fora da tela via `left:-9999px`, **não** `display:none`: display:none tiraria o link da ordem de tabulação e o tornaria inútil, que é o erro clássico desse padrão.

## 2. Foco

A regra existente era `:where(a,button,summary,input,select):focus-visible`. Duas limitações: `:where()` **zera a especificidade** (qualquer regra com peso sobrescreve) e a lista deixa de fora `textarea`, `[tabindex]`, `[contenteditable]` e o próprio `<main>` que o skip link foca. Agora é `:focus-visible` universal, mais `main:focus-visible{outline:none}` — o `<main>` recebe foco por programa e o anel nele não informa nada ao usuário.

Junto: `main{scroll-margin-top:var(--topo)}`, senão o topo fixo cobre o começo do conteúdo depois do salto.

## Critérios de aceite

- [x] **Tab a partir da barra de endereço revela o skip link**
- [x] **Todo elemento focável tem anel visível**
- [x] **Nenhum par de cor abaixo de 4,5:1** (valores abaixo)

Verificado em Brave via CDP, contra o **build**:

```
skip link existe, é o primeiro focável   ok
escondido em repouso                     ok  (left:-9999px)
1 Tab põe o foco nele e o revela         ok  (left:8px top:8px)
anel visível nele                        ok  (2px solid #ffd479)
Enter move o foco pro <main>             ok  (activeElement = MAIN)
focáveis visíveis SEM anel               0 de 24
```

## 3. Contraste — a suspeita da issue não se confirmou

A issue apontava `--bone-dim` (#8f866d) e um rodapé `#5f5a48`. Medi todos os pares (WCAG 2.1):

| ratio | par | veredito |
|---|---|---|
| **12,70** | corpo `--bone` #d8cfae / `--bg` #0a0a08 | passa |
| **16,55** | títulos `--ink` #f2ead8 | passa |
| **10,36** | links e h2 `--amber` #e8b34b | passa |
| **5,47** | nav e **rodapé** `--bone-dim` #8f866d | **passa** — era o suspeito |
| **5,22** | link do rodapé `--amber-dim` #9c7f45 | **passa** |
| **9,92** | `.btn-play` #141008 sobre `--amber` | passa |
| **9,81** | `.kicker` #171106 sobre `--amber` | passa |
| **14,10** | anel de foco `--amber-hi` #ffd479 | passa |
| 6,52 / 5,94 | `--green` / `--purple` | passam |

`#5f5a48` **não existe mais** no CSS da v2 — o rodapé usa `--bone-dim`. A dica da issue vinha de uma versão anterior.

### Por que não mexi na paleta

Três pares ficam abaixo do mínimo teórico, e nenhum é reprovação real:

| ratio | cor | por que não conta |
|---|---|---|
| 1,52 | `--line` #3a3018 | separador **decorativo** (borda de painel, `hr`, sublinhado de h2). WCAG 1.4.11 vale pra componente de UI e gráfico significativo — decoração é isenta. |
| 2,32 | `--line-hi` #5c4a22 | idem |
| 4,41 | `--red` #e03232 | **não é usado como cor de texto** em lugar nenhum — só borda, fundo e gradiente. Conferi. |

Clarear `--line` pra bater 3:1 exigiria `#827860`, o que mudaria o visual do site inteiro. É decisão de design sua, não correção de bug — por isso deixei como está e trouxe o número.

## Nota de método (pode te economizar tempo)

O **dev server do Astro serviu CSS obsoleto** durante o teste: o HTML SSR já trazia o `.skip`, mas o módulo de CSS do Vite não. `CSS.getMatchedStylesForNode` mostrava a regra simplesmente ausente enquanto regras vizinhas do mesmo bloco funcionavam — passei um tempo caçando erro de sintaxe que não existia. Testar contra `dist/client` resolveu na hora. **Valide a11y no build, não no dev.**

## Ressalva que não dá pra medir com fórmula

O fundo real não é `#0a0a08` chapado: tem o canvas 3D com a vinheta em `rgba(10,10,8,.60)` no centro. Os números acima são contra a cor declarada. Onde a vinheta está mais transparente, o contraste efetivo é **pior** que o da tabela. Se quiser rigor total, o caminho é amostrar pixel do screenshot atrás do texto — posso fazer se valer a pena.

🤖 Generated with [Claude Code](https://claude.com/claude-code)