### PR TITLE
ci: smoke de contrato das rotas + conserta o workflow CI inválido

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       # mão ele desatualiza no primeiro commit, e uma tabela de conflito com
       # linha errada é pior que não ter tabela: dois agentes acham que estão em
       # regiões diferentes e não estão.
+      - name: ARCH.md gerado está em dia
         run: npm run arch:check
 
       # ── PORTÃO DE QUALIDADE ───────────────────────────────────────────────
@@ -45,6 +46,14 @@ jobs:
 
       - name: Astro build
         run: npm run build
+
+      # PORTÃO DO SITE. `astro build` verde não prova nada sobre as rotas:
+      # /ranking pode dar 500, /sitemap.xml pode sair vazio e o build passa em
+      # todos os casos. Roda DEPOIS do build porque o arnês sobe o `astro dev`,
+      # que precisa das deps instaladas — e checa o caminho de degradação SEM
+      # Supabase, que é exatamente o estado do CI.
+      - name: Smoke do site (13 rotas, contrato + JSON-LD)
+        run: node tools/eval/site-smoke.mjs
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "eval:vm": "node tools/eval/vm-mint-audit.mjs",
     "eval:kick": "node tools/eval/vm-kick-sim.mjs",
     "eval:bots": "node tools/eval/botsim.mjs 60 all",
+  "//eval:site": "Contrato das 13 rotas do site SEM Supabase (o estado do CI): status, corpo, XML do sitemap e JSON-LD parseável. `astro build` verde não prova nada disso — /ranking pode dar 500 e o build passa. Sobe o astro dev sozinho; SITE_URL aponta pra um alvo externo. --mutante=jsonld prova que morde.",
+  "eval:site": "node tools/eval/site-smoke.mjs",
     "eval:ctfhud": "node tools/eval/ctfhud-check.mjs",
     "eval:mat": "node tools/eval/mat-check.mjs",
     "//eval:seo": "LÊ dist/client/ — o HTML publicado, não o .astro. Rode `npm run build` antes, ou use `npm run check:seo`, que já faz os dois. `--mutate` prova que a régua morde.",

--- a/tools/eval/site-smoke.mjs
+++ b/tools/eval/site-smoke.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+// ============================================================================
+// SMOKE DO SITE — portão de contrato das rotas.
+//
+// POR QUE ISTO EXISTE
+// O CI tem quatro portões excelentes para o JOGO e um `astro build` para o site.
+// Build verde não prova nada sobre o site: `/ranking` pode dar 500 por causa de
+// uma coluna renomeada, `/sitemap.xml` pode sair vazio, `/u/*` pode entrar em
+// loop de redirect — e o build fica verde nos três casos. Este arnês fecha esse
+// buraco: bate em cada rota e checa CONTRATO, não aparência.
+//
+// O caminho testado é o de DEGRADAÇÃO: sem Supabase configurado, que é o estado
+// do CI. É justamente o caminho que ninguém exercita à mão, e onde um 500 passa
+// meses sem ser notado — a página só quebra pra quem clona o repo ou pra um
+// deploy com env faltando.
+//
+// SOBRE O SERVIDOR
+// Mais da metade do contrato é SSR (`/ranking`, `/sitemap.xml`, `/api/*`, o 404),
+// então `npm run preview` — que é `python3 -m http.server -d dist/client` — não
+// serve: ele só tem os 7 HTML pré-renderizados. Por isso este script sobe o
+// `astro dev` sozinho e o derruba no fim. Se você já tem um alvo no ar (um
+// preview da Vercel, por exemplo), passe SITE_URL e ele usa o seu.
+//
+// DIFERENÇA CONHECIDA: dev não minifica e não passa pelos headers do
+// `vercel.json` (CSP, HSTS, cache). Este arnês checa contrato de rota — status,
+// corpo, JSON-LD válido —, nada que dependa de header de CDN. Se um dia precisar
+// checar CSP, aponte SITE_URL pro preview da Vercel.
+//
+// USO
+//   node tools/eval/site-smoke.mjs                  # sobe o astro dev sozinho
+//   SITE_URL=https://... node tools/eval/site-smoke.mjs
+//   node tools/eval/site-smoke.mjs --json
+//   node tools/eval/site-smoke.mjs --mutante=jsonld # prova que o portão morde
+//
+// Sai 1 se qualquer checagem falhar, então serve de gate no CI sem parser.
+// ============================================================================
+import { spawn, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+// O CONTRATO DEPENDE DE UMA FLAG. `RANKING_ON` (src/lib/site.ts) muda o que
+// duas rotas devem responder, e a issue #45 escreveu o contrato assumindo ela
+// ligada. Hardcodar um dos dois estados deixaria o portão errado metade do
+// tempo — e errado do pior jeito: vermelho por engano quando alguém religar o
+// ranking, o que treina a equipe a ignorar o portão. Então lemos a flag.
+// Leitura por regex, não import: o arquivo é .ts e este arnês roda em node puro.
+const RANKING_ON = /export const RANKING_ON\s*=\s*true/.test(
+  readFileSync(new URL('../../src/lib/site.ts', import.meta.url), 'utf8'),
+);
+
+const args = process.argv.slice(2);
+const JSON_OUT = args.includes('--json');
+const MUTANTE = (args.find((a) => a.startsWith('--mutante=')) || '').split('=')[1] || null;
+const PORTA = 4325;
+const EXTERNO = process.env.SITE_URL || null;
+const BASE = EXTERNO || `http://localhost:${PORTA}`;
+
+// ---------------------------------------------------------------------------
+// O CONTRATO. Uma linha por rota. `checa` recebe { status, corpo, headers }.
+// ---------------------------------------------------------------------------
+// 8 páginas indexáveis hoje; /ranking entra na conta só com o ranking ligado —
+// desligado ele é noindex (ranking.astro), e noindex no sitemap é contradição.
+const XML_LOC_MIN = RANKING_ON ? 9 : 8;
+
+const CONTRATO = [
+  { rota: '/', esperado: '200 + <title> com "CORO SOLTO"',
+    checa: ({ status, corpo }) => {
+      if (status !== 200) return `status ${status}`;
+      const t = corpo.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+      if (!t) return 'sem <title>';
+      if (!t[1].includes('CORO SOLTO')) return `<title> = ${JSON.stringify(t[1].trim().slice(0, 60))}`;
+      return null;
+    } },
+
+  // O contrato da issue #45 pedia o texto "não configurado". Hoje RANKING_ON
+  // (src/lib/site.ts) é false, então a página responde com o aviso de
+  // "desligado durante o alpha" — outro texto, MESMA propriedade: degrada com
+  // recado em vez de estourar. Aceita os dois; o que não passa é 500.
+  { rota: '/ranking', esperado: '200 + aviso de degradação (nunca 500)',
+    checa: ({ status, corpo }) => {
+      if (status >= 500) return `status ${status} — é exatamente o que este portão existe pra pegar`;
+      if (status !== 200) return `status ${status}`;
+      const avisos = ['não configurado', 'desligado', 'Ainda ninguém na arena'];
+      if (!avisos.some((a) => corpo.includes(a)))
+        return `200 mas sem nenhum aviso de degradação (${avisos.map((a) => JSON.stringify(a)).join(' | ')})`;
+      return null;
+    } },
+
+  ...['/como-jogar', '/mapas', '/armas', '/personagens', '/sobre', '/changelog'].map((rota) => ({
+    rota, esperado: '200',
+    checa: ({ status }) => (status === 200 ? null : `status ${status}`),
+  })),
+
+  { rota: '/sitemap.xml', esperado: `200 + XML válido + >= ${XML_LOC_MIN} <loc>`,
+    checa: ({ status, corpo }) => {
+      if (status !== 200) return `status ${status}`;
+      if (!/^\s*<\?xml/.test(corpo)) return 'não começa com declaração XML';
+      const locs = corpo.match(/<loc>/g) || [];
+      if (locs.length < XML_LOC_MIN) return `${locs.length} <loc>, mínimo ${XML_LOC_MIN}`;
+      // XML mal formado é o modo de falha silenciosa aqui: um & solto derruba o
+      // parse de quem consome e o status continua 200.
+      const abertas = (corpo.match(/<url>/g) || []).length;
+      const fechadas = (corpo.match(/<\/url>/g) || []).length;
+      if (abertas !== fechadas) return `<url> desbalanceado: ${abertas} abre, ${fechadas} fecha`;
+      const amp = corpo.match(/&(?!amp;|lt;|gt;|quot;|apos;|#\d+;|#x[0-9a-f]+;)/i);
+      if (amp) return `& não escapado perto de ${JSON.stringify(corpo.slice(Math.max(0, amp.index - 30), amp.index + 30))}`;
+      return null;
+    } },
+
+  ...['/robots.txt', '/llms.txt'].map((rota) => ({
+    rota, esperado: '200',
+    checa: ({ status }) => (status === 200 ? null : `status ${status}`),
+  })),
+
+  // Com o ranking DESLIGADO a rota responde 200 {disabled:true} de propósito —
+  // está comentado nela: `disabled` diz "de propósito", um erro diria "quebrou",
+  // e o jogador entenderia bug onde é escolha. O 503 not_configured que a issue
+  // pede é o contrato do ranking LIGADO sem envs.
+  { rota: '/api/leaderboard',
+    esperado: RANKING_ON ? '503 not_configured' : '200 {disabled:true}',
+    checa: ({ status, corpo }) => {
+      let j;
+      try { j = JSON.parse(corpo); } catch { return `corpo não é JSON: ${corpo.slice(0, 60)}`; }
+      if (RANKING_ON) {
+        if (status !== 503) return `status ${status} (esperado 503 sem envs, ranking ligado)`;
+        if (j.error !== 'not_configured') return `body.error = ${JSON.stringify(j.error)}`;
+      } else {
+        if (status !== 200) return `status ${status} (esperado 200 com ranking desligado)`;
+        if (j.disabled !== true) return `esperado {disabled:true}, veio ${JSON.stringify(j).slice(0, 60)}`;
+      }
+      return null;
+    } },
+
+  { rota: '/naoexiste', esperado: '404',
+    checa: ({ status }) => (status === 404 ? null : `status ${status}`),
+  },
+];
+
+// Páginas que precisam ter todo bloco JSON-LD parseável. JSON-LD quebrado é
+// invisível: some do resultado rico e ninguém percebe por meses.
+const PAGINAS_JSONLD = ['/', '/ranking', '/como-jogar', '/mapas', '/armas', '/personagens', '/sobre', '/changelog'];
+
+// ---------------------------------------------------------------------------
+const RE_JSONLD = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+
+async function pegar(rota) {
+  const r = await fetch(BASE + rota, { redirect: 'follow' });
+  return { status: r.status, corpo: await r.text(), headers: r.headers };
+}
+
+function checaJsonLd(rota, corpo) {
+  let m, n = 0;
+  const erros = [];
+  RE_JSONLD.lastIndex = 0;
+  while ((m = RE_JSONLD.exec(corpo))) {
+    n++;
+    let bruto = m[1].trim();
+    // --mutante: corrompe o primeiro bloco pra provar que o portão morde
+    if (MUTANTE === 'jsonld' && rota === '/' && n === 1) bruto = bruto.replace(/}\s*$/, '');
+    try {
+      const j = JSON.parse(bruto);
+      if (j == null || (typeof j !== 'object')) erros.push(`bloco ${n}: parseou mas não é objeto`);
+    } catch (e) {
+      erros.push(`bloco ${n}: ${String(e.message).slice(0, 90)}`);
+    }
+  }
+  return { n, erros };
+}
+
+// ---------------------------------------------------------------------------
+// servidor
+// ---------------------------------------------------------------------------
+let subiuAqui = false;
+async function noAr(ms = 90_000) {
+  const fim = Date.now() + ms;
+  while (Date.now() < fim) {
+    try { const r = await fetch(BASE + '/robots.txt'); if (r.status) return true; } catch { /* ainda não */ }
+    await new Promise((r) => setTimeout(r, 700));
+  }
+  return false;
+}
+async function sobeServidor() {
+  if (EXTERNO) return true;
+  // `astro dev` daemoniza e o processo lançador sai — não dá pra segurar o pid.
+  // Quem derruba é `astro dev stop`, no finally.
+  spawn('npx', ['astro', 'dev', '--port', String(PORTA)], { stdio: 'ignore', detached: false })
+    .on('error', () => {});
+  subiuAqui = true;
+  return noAr();
+}
+function derrubaServidor() {
+  if (!subiuAqui) return;
+  spawnSync('npx', ['astro', 'dev', 'stop'], { stdio: 'ignore' });
+}
+
+// ---------------------------------------------------------------------------
+const resultados = [];
+try {
+  if (!(await sobeServidor())) {
+    console.error(`✗ SMOKE0  o site não subiu em ${BASE} (90 s de espera)`);
+    process.exit(1);
+  }
+
+  for (const c of CONTRATO) {
+    let falha = null;
+    try {
+      const res = await pegar(c.rota);
+      falha = c.checa(res);
+      if (!falha && PAGINAS_JSONLD.includes(c.rota) && /text\/html/i.test(res.headers.get('content-type') || '')) {
+        const { n, erros } = checaJsonLd(c.rota, res.corpo);
+        if (erros.length) falha = `JSON-LD inválido (${n} bloco(s)): ${erros.join(' · ')}`;
+        else c.jsonld = n;
+      }
+    } catch (e) {
+      falha = `erro de rede: ${String(e.message).slice(0, 80)}`;
+    }
+    resultados.push({ rota: c.rota, esperado: c.esperado, jsonld: c.jsonld ?? null, ok: !falha, motivo: falha });
+  }
+} finally {
+  derrubaServidor();
+}
+
+const falhas = resultados.filter((r) => !r.ok);
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ base: BASE, mutante: MUTANTE, total: resultados.length, falhas: falhas.length, resultados }, null, 2));
+} else {
+  console.log('\n=============== SMOKE DO SITE — CORO SOLTO ===============');
+  console.log(`alvo: ${BASE}${EXTERNO ? ' (externo, via SITE_URL)' : ' (astro dev, subido por este script)'}`);
+  console.log(`RANKING_ON: ${RANKING_ON} (src/lib/site.ts) — muda o contrato de /api/leaderboard e do sitemap`);
+  if (MUTANTE) console.log(`MUTANTE ATIVO: ${MUTANTE} — este run DEVE falhar`);
+  console.log('');
+  for (const r of resultados) {
+    const marca = r.ok ? '✓ PASSA ' : '✗ FALHA ';
+    const ld = r.jsonld ? `  [${r.jsonld} JSON-LD ok]` : '';
+    console.log(`${marca} ${r.rota.padEnd(18)} ${r.esperado}${ld}`);
+    if (!r.ok) console.log(`${' '.repeat(9)}└─ ${r.motivo}`);
+  }
+  console.log('\n----------------------------------------------------------');
+  console.log(`${resultados.length - falhas.length}/${resultados.length} rotas cumprem o contrato` +
+    (falhas.length ? `  ← ${falhas.map((r) => r.rota).join(', ')} VERMELHAS` : '  ← tudo verde'));
+  console.log('----------------------------------------------------------\n');
+}
+
+process.exit(falhas.length ? 1 : 0);


### PR DESCRIPTION
Closes #45

> ⚠️ **Leia a primeira seção antes do resto** — achei algo maior que a issue.

## 1. O workflow `CI` está inválido e não roda

Ao abrir o `ci.yml` pra adicionar o passo, encontrei isto:

```yaml
      - name: Syntax check do jogo (public/js)
        run: npm run syntax          # <- sobrescrito
      # comentário sobre o ARCH.md...
        run: npm run arch:check      # <- chave `run` DUPLICADA (linha 26)
```

O passo do `arch:check` ficou **sem o `-` e sem `name`**, então virou uma segunda chave `run:` dentro do mesmo passo. Validando com um detector de chave duplicada:

```
original (v2/alpha) : INVÁLIDO -> CHAVE DUPLICADA: run na linha 26
depois deste commit : VÁLIDO, sem chave duplicada
```

E o GitHub concorda. Toda execução do workflow `CI` na `v2/alpha` termina com:

> **This run likely failed because of a workflow file issue.**

**Consequência:** os cinco portões de qualidade — sintaxe, invariantes, viewmodel, coice, botsim — **e o `astro build` não executaram nenhuma vez**. O que roda hoje é só o workflow `pr-gates`, que é outro arquivo. Aquele comentário no `ci.yml` dizendo *"o `run` já reprova o job sozinho"* está correto em intenção e nunca teve chance de valer.

Consertei dando ao `arch:check` o próprio passo. Efeito colateral bom: **`npm run syntax` passa a rodar de verdade** — e passa (exit 0), então não estou destravando um portão vermelho.

⚠️ **`npm run arch:check` sai 1** (ARCH.md espera 6528 linhas em `game.js`). Com o workflow válido, isso vai reprovar o CI. `npm run arch` conserta em um comando, mas **não fiz** pra não misturar assunto nem gerar conflito com o seu trabalho na branch. Mesma coisa com `docs:check`, que também sai 1. Se preferir que eu inclua a regeneração aqui, é um commit.

## 2. O portão da issue

`tools/eval/site-smoke.mjs` — 13 rotas, contrato e não aparência:

```
✓ /                  200 + <title> com "CORO SOLTO"        [2 JSON-LD ok]
✓ /ranking           200 + aviso de degradação, nunca 500  [1 JSON-LD ok]
✓ /como-jogar /mapas /armas /personagens /sobre /changelog   200
✓ /sitemap.xml       200 + XML válido + >= 8 <loc>
✓ /robots.txt /llms.txt   200
✓ /api/leaderboard   200 {disabled:true}
✓ /naoexiste         404

13/13 rotas cumprem o contrato  ← tudo verde
```

Mais: **todo bloco `application/ld+json` de 8 páginas tem que fazer `JSON.parse`**. O sitemap também é checado além do status — `<url>` balanceado e `&` escapado, que é como XML quebra devolvendo 200.

Zero dependência nova: `fetch`, `JSON.parse` e regex do próprio Node.

## 3. Duas decisões que valem explicar

**Sobe o `astro dev`, não o `npm run preview`.** Mais da metade do contrato é SSR (`/ranking`, `/sitemap.xml`, `/api/*`, o 404) e o preview é `python3 -m http.server -d dist/client`, que só tem os 7 HTML pré-renderizados — não daria pra testar justamente as rotas que podem dar 500. `SITE_URL=https://... node tools/eval/site-smoke.mjs` aponta pra um alvo externo quando você quiser testar um preview da Vercel. *Diferença conhecida:* dev não passa pelos headers do `vercel.json`, então este arnês não checa nada que dependa de CDN (CSP, HSTS, cache).

**O portão lê `RANKING_ON` de `src/lib/site.ts`.** O contrato da issue foi escrito assumindo o ranking **ligado**. Com ele desligado, duas rotas mudam de contrato **legitimamente**:

| rota | issue pedia | realidade com `RANKING_ON=false` |
|---|---|---|
| `/api/leaderboard` | `503 not_configured` | `200 {disabled:true}` — deliberado, a própria rota comenta: *"`disabled` diz de propósito, um erro diria quebrou"* |
| `/sitemap.xml` | ≥ 9 `<loc>` | 8 — `/ranking` é `noindex` nesse estado, e noindex no sitemap é contradição |
| `/ranking` | texto "não configurado" | "desligado durante o alpha" — outro texto, mesma propriedade |

Hardcodar um dos dois estados deixaria o portão **vermelho por engano** no dia em que vocês religarem o ranking — que é exatamente como se ensina uma equipe a ignorar portão. Então ele lê a flag e ajusta o contrato.

## Critérios de aceite

- [x] `node tools/eval/site-smoke.mjs` sai **0** no repo atual
- [x] Quebrar um JSON-LD de propósito sai **1** com mensagem clara
- [x] Roda no CI e é **bloqueante** (passo após o `astro build`, sem `if`)

```
node tools/eval/site-smoke.mjs                   -> exit 0
node tools/eval/site-smoke.mjs --mutante=jsonld  -> exit 1

✗ FALHA  /   JSON-LD inválido (2 bloco(s)): bloco 1: Expected , or }
             after property value in JSON at position 2667 (line 48 column 1)
```

O `--mutante=jsonld` segue a convenção que vi no `eval:ctflabels` (*"`--mutante=vaza` prova que morde"*). Também adicionei `npm run eval:site` com a linha `//eval:site` de explicação, no padrão dos outros scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)