### PR TITLE
feat(seo): hreflang pt-BR + x-default no Layout e na home

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -157,6 +157,20 @@ const NAV: [string, string][] = [
 <title>{title}</title>
 <meta name="description" content={description}>
 <link rel="canonical" href={canonical}>
+{/* HREFLANG. Declara explicitamente que o site é pt-BR e só. `x-default` aponta
+    pro mesmo destino: é o alvo pra quem não casa com nenhum idioma declarado, e
+    sem ele o buscador escolhe sozinho qual versão mostrar a esse público.
+    As duas linhas apontam pro canonical, ou seja, sempre o host com `www` e sem
+    barra final — mesmo motivo do canonical acima: apex e www são a MESMA página,
+    e emitir hreflang com host divergente reintroduz a diluição que o canonical
+    acabou de resolver.
+    Auto-referência é obrigatória pelo protocolo: toda página do conjunto tem que
+    listar a si mesma, senão o Google ignora o grupo inteiro. Como aqui o
+    conjunto é de um idioma só, a auto-referência é o conjunto completo.
+    Quando as páginas EN entrarem, isto vira um map de idioma -> href e cada
+    página passa a listar as duas. */}
+<link rel="alternate" hreflang="pt-BR" href={canonical}>
+<link rel="alternate" hreflang="x-default" href={canonical}>
 {noindex && <meta name="robots" content="noindex, follow">}
 <meta name="theme-color" content="#0a0a08">
 <meta property="og:type" content={ogType}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,6 +40,14 @@
      estava no host sem www e brigava com o canonical das outras páginas
      (que sai de astro.config.mjs) — dois hosts, sinal diluído. -->
 <link rel="canonical" href="https://www.csbrasil.online/">
+<!-- HREFLANG. Repetido aqui porque esta página tem <head> PRÓPRIO e não passa
+     pelo Layout.astro — a home é o jogo, não uma página de conteúdo. Deixar de
+     fora justamente a URL mais importante do site é o tipo de buraco que só
+     aparece quando alguém compara página por página.
+     Mesmo host e mesma forma do canonical acima. Ver Layout.astro pro porquê
+     de `x-default` e da auto-referência. -->
+<link rel="alternate" hreflang="pt-BR" href="https://www.csbrasil.online/">
+<link rel="alternate" hreflang="x-default" href="https://www.csbrasil.online/">
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="CORO SOLTO: Treta Suprema">


### PR DESCRIPTION
Closes #31

## O que muda

`<link rel="alternate" hreflang="pt-BR">` e `hreflang="x-default"`, os dois apontando pro `canonical` — ou seja, sempre o host com `www` e sem barra final. Emitir hreflang com host divergente reintroduziria exatamente a diluição que o canonical resolve.

## O que a issue não menciona, e mudou o escopo

A issue diz "em `src/layouts/Layout.astro`". Só que **`src/pages/index.astro` tem `<html>` e `<head>` próprios** — a home é o jogo, não uma página de conteúdo, e não passa pelo Layout. Mexer só no Layout deixaria de fora **justamente a URL mais importante do site**.

Duplicei as duas linhas lá, com comentário explicando por que a duplicação existe (pra ninguém "limpar" depois).

## Verificação

Build, página por página — as 7 páginas do site têm as duas linhas, e em todas `canonical == hreflang[pt-BR]`:

```
/            hreflang="pt-BR" hreflang="x-default"   canonical==hreflang ✓
/armas       hreflang="pt-BR" hreflang="x-default"   canonical==hreflang ✓
/sobre       hreflang="pt-BR" hreflang="x-default"   canonical==hreflang ✓
/mapas /personagens /como-jogar /changelog           idem
```

## Critérios de aceite

- [x] `curl -s ... | grep hreflang` mostra as duas linhas
- [x] `npm run build` passa
- [~] **apex faz 301** — já redireciona, mas com **308**

Esse último merece precisão:

```
$ curl -sI https://csbrasil.online/
HTTP/2 308
location: https://www.csbrasil.online/
```

**308 é redirect permanente** (preserva o método) e o Google o trata como o 301 para canonicalização — então o objetivo da issue está cumprido, o apex não compete mais com o `www`. Mas o número não é o `301` literal que o critério pede. Se você quiser 301 exato, é configuração no painel da Vercel, fora do repo — não mexi.

## Fora de escopo, registrando

As páginas em `/docs/*` (Docusaurus buildado em `public/docs/`) **não** têm hreflang: são estáticos de outro build e não passam pelo Layout. Se quiser cobri-las, é na config do Docusaurus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)