### PR TITLE
feat(seo): página 404 no visual do jogo, com saídas úteis

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,91 @@
+---
+// 404 — quem erra a URL recebia a página padrão da Vercel: fundo branco,
+// tipografia de sistema, zero relação com o jogo e nenhuma saída.
+//
+// DUAS DECISÕES QUE NÃO SÃO ÓBVIAS:
+//
+// 1. A PÁGINA É ESTÁTICA (prerender), e a dica de `/u/` é resolvida no cliente.
+//    Num 404 pré-renderizado, `Astro.url.pathname` é o caminho de BUILD
+//    (`/404`), não o que o visitante pediu — então detectar `/u/` no servidor
+//    daria sempre falso. Fazer a página SSR só pra ler o path custaria uma
+//    invocação de função em cada varredura de bot que bate em URL inexistente,
+//    que é justamente o tráfego mais barato de servir estático. Então a dica sai
+//    por 6 linhas de JS lendo `location.pathname`, e sem JS ela simplesmente não
+//    aparece — o resto da página funciona igual.
+//
+// 2. O RANKING SÓ É OFERECIDO SE ESTIVER LIGADO. A issue #37 pede "Jogar,
+//    Ranking, Como jogar" como saídas, mas com `RANKING_ON = false`
+//    (src/lib/site.ts) o /ranking responde só um aviso de "desligado" — mandar
+//    alguém que já se perdeu pra uma segunda página sem conteúdo é piorar o
+//    problema. Com a flag desligada, a saída vira o mapa ao vivo.
+import Layout from '../layouts/Layout.astro';
+import { BRAND_FULL, RANKING_ON } from '../lib/site';
+---
+<Layout
+  title={`Essa página não existe (404) | ${BRAND_FULL}`}
+  description="A página que você procurou não existe. Volte pra arena, veja como jogar ou procure um jogador no ranking."
+  noindex
+  h1="Errou o tiro"
+  kicker="404 · página não encontrada"
+  heroImg="/img/map-previews/fy_ferrovelho.jpg"
+  heroPos="45%">
+  <Fragment slot="sub">
+    Essa URL não existe. Acontece — <strong>a mira do endereço também abre</strong>.
+  </Fragment>
+
+  <div class="panel">
+    <p>Não tem nada aqui. As saídas que servem:</p>
+    <p class="cta-row" style="margin-top:14px">
+      <a class="btn-cta" href="/">▶ JOGAR</a>
+      <a class="btn-cta btn-2" href="/como-jogar">COMO JOGAR</a>
+      {RANKING_ON
+        ? <a class="btn-cta btn-2" href="/ranking">RANKING</a>
+        : <a class="btn-cta btn-2" href="/mapa">QUEM ESTÁ JOGANDO AGORA</a>}
+    </p>
+  </div>
+
+  {/* Só aparece quando o caminho pedido começa com /u/ — ver a decisão 1 no topo. */}
+  <div class="panel" id="dica-perfil" hidden>
+    <p><strong>Procurando um jogador?</strong> O perfil público fica em
+    <code>/u/&lt;id&gt;/&lt;nick&gt;</code> — o <code>id</code> faz parte do endereço, então
+    digitar só o nick não chega lá.</p>
+    <p style="margin-top:8px">
+      {RANKING_ON
+        ? <Fragment>A lista completa, com o link certo de cada um, está no <a href="/ranking">ranking</a>.</Fragment>
+        : <Fragment>O ranking está desligado durante o alpha, então não há lista pública de
+          perfis agora. Dá pra ver quem está em partida no <a href="/mapa">mapa ao vivo</a>.</Fragment>}
+    </p>
+  </div>
+
+  <p class="lead" style="margin-top:24px">
+    Se você chegou aqui por um link do próprio site, isso é bug —
+    <a href="https://github.com/rubenmarcus/csbrasil/issues">abra uma issue</a> dizendo de onde veio.
+  </p>
+</Layout>
+
+<script is:inline>
+  // A dica de perfil depende do caminho REAL pedido, que a página estática não
+  // conhece em tempo de build. Ver a decisão 1 no topo do arquivo.
+  //
+  // O GATILHO É MAIS LARGO QUE O `/u/` QUE A ISSUE PEDIU, e por um motivo
+  // medido: `/u/<qualquer-coisa>` NÃO chega nesta página. A rota catch-all
+  // src/pages/u/[...path].astro casa com tudo sob /u/ e responde 200 — 302 pra
+  // /ranking quando o Supabase está configurado, ou uma casca de perfil vazia
+  // quando não. Testado: /u, /u/, /u/naoexiste e /u/abc/def devolvem todos 200.
+  // Se a dica só olhasse '/u/', ela nunca apareceria pra ninguém.
+  // Então cobrimos quem DE FATO cai aqui procurando jogador: /perfil/…,
+  // /jogador/… e /u sem barra (que também não casa com o prefixo '/u/').
+  // Quando /u/<desconhecido> passar a responder 404 de verdade, este gatilho já
+  // está pronto pra ele.
+  (function () {
+    var p = location.pathname.toLowerCase();
+    var procurandoJogador =
+      p.startsWith('/u/') || p === '/u' ||
+      p.startsWith('/perfil') || p.startsWith('/jogador') ||
+      p.startsWith('/player') || p.startsWith('/profile');
+    if (procurandoJogador) {
+      var d = document.getElementById('dica-perfil');
+      if (d) d.hidden = false;
+    }
+  })();
+</script>


### PR DESCRIPTION
Closes #37

Quem errava a URL recebia a 404 padrão da Vercel: fundo branco, tipografia de sistema, zero relação com o jogo, nenhuma saída. Agora usa o `<Layout>`, com `noindex`, humor no tom do jogo e três saídas.

## Critérios de aceite

- [x] `/qualquer-coisa` mostra a 404 com o visual do site
- [x] Status **404**, não 200
- [x] `<meta name="robots" content="noindex, follow">` presente

## Três coisas que a issue não previa

### 1. A página é estática, e a dica sai no cliente

Num 404 pré-renderizado, `Astro.url.pathname` é o caminho de **build** (`/404`), não o que o visitante pediu — detectar `/u/` no servidor daria sempre falso. Fazer a página SSR só pra ler o path custaria uma invocação de função em **cada varredura de bot em URL inexistente**, que é justamente o tráfego mais barato de servir estático. São 6 linhas de JS lendo `location.pathname`; sem JS a dica não aparece e o resto da página funciona igual.

### 2. O ranking só é oferecido se estiver ligado

A issue pede "Jogar, Ranking, Como jogar". Mas com `RANKING_ON = false` o `/ranking` mostra só um aviso de desligado — **mandar quem já se perdeu pra uma segunda página sem conteúdo piora o problema**. Com a flag off, a terceira saída vira `/mapa` ("quem está jogando agora"). Quando religarem, volta a ser o ranking, sem tocar no arquivo.

### 3. A dica de `/u/` não apareceria pra ninguém

Este é o ponto que muda o resultado. A issue motiva a dica com *"isso acontece muito com `/u/<nick>` digitado à mão"* — mas **`/u/` nunca chega na 404**. A rota catch-all `src/pages/u/[...path].astro` casa com tudo sob `/u/` e responde 200. Medido:

```
/u               -> 200
/u/              -> 200
/u/naoexiste     -> 200    (302 pra /ranking quando há Supabase;
/u/abc/def       -> 200     casca de perfil vazia quando não)
/perfil/zeca     -> 404    <- estes CHEGAM aqui
/jogador/zeca    -> 404
/qualquer-coisa  -> 404
```

Se a dica só olhasse `/u/`, seria código morto. Ampliei o gatilho pra cobrir quem **de fato** cai aqui procurando jogador: `/perfil`, `/jogador`, `/player`, `/profile` e `/u` sem barra (que também não casa com o prefixo `/u/`). Quando `/u/<desconhecido>` passar a responder 404, o gatilho já está pronto pra ele — está comentado no arquivo.

## Fica em aberto — não é desta PR

**`/u/<desconhecido>` devolver 200 é soft 404.** O Google trata como conteúdo raso e isso pode afetar a indexação em volta. A correção é trocar o `Astro.redirect(/ranking, 302)` da linha 56 por uma resposta 404 — mas isso muda o comportamento de URLs **já indexadas**, e é decisão sua. Reportado, não mexido. Se quiser, abro como issue ou faço numa PR separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)