### PR TITLE
feat(seo): âncoras, permalink e busca por versão no /changelog

### DIFF
--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -113,11 +113,25 @@ const jsonld = [
     renderizado.
   </Fragment>
 
+  {/* Campo de busca: o conteúdo dentro de um <details> FECHADO é invisível pro
+      Ctrl+F do navegador — é o problema que a issue #44 aponta no bônus. O filtro
+      abaixo procura no texto de TODAS as versões, abre as que casam e esconde as
+      que não. Sem JS ele não aparece (o <input> é inserido pelo script), então
+      nada se perde. */}
+  <div id="cl-busca-slot"></div>
+
   {recentes.map((v, i) => (
-    <details open={i < 2}>
+    /* id por versão = permalink. `v` na frente porque id não pode começar com
+       dígito em HTML4 e ferramenta antiga ainda tropeça nisso. */
+    <details id={`v${v.versao}`} open={i < 3} data-versao={v.versao}>
       <summary>
         <strong>v{v.versao}</strong>
         {v.data && <span style="color:var(--bone-dim);font-size:11px;letter-spacing:2px"> · {v.data}</span>}
+        {/* Âncora REAL, não botão: sem JS ela ainda leva o navegador até a versão
+            certa (o <summary> é visível mesmo com o <details> fechado). O JS
+            transforma o clique em "copia o link" sem sair da página. */}
+        <a class="cl-perma" href={`#v${v.versao}`} title={`Link permanente para a v${v.versao}`}
+           aria-label={`Copiar link permanente da versão ${v.versao}`}>#</a>
       </summary>
       <div class="cl" set:html={v.html} />
     </details>
@@ -132,8 +146,96 @@ const jsonld = [
 </Layout>
 
 <style is:global>
+/* o topo fixo cobriria a versão depois do salto pelo hash */
+#main details[id^="v"]{scroll-margin-top:calc(var(--topo) + 12px)}
+.cl-perma{margin-left:8px;color:var(--bone-dim);text-decoration:none;font-weight:bold;
+  opacity:0;transition:opacity .12s}
+summary:hover .cl-perma,summary:focus-within .cl-perma,.cl-perma:focus-visible{opacity:1}
+.cl-perma.copiado{color:var(--amber);opacity:1}
+#cl-busca{width:100%;max-width:340px;margin-bottom:16px;background:var(--panel-2);
+  border:1px solid var(--line);color:var(--bone);font-family:var(--mono);font-size:12px;
+  padding:8px 10px}
+#cl-busca::placeholder{color:var(--bone-dim)}
+.cl-vazio{color:var(--bone-dim);font-size:13px;margin-bottom:16px}
 .cl h3{margin:16px 0 6px;color:var(--amber);font-size:12px}
 .cl ul{margin:4px 0 4px 4px}
 .cl li{font-size:13px;line-height:1.55}
 .cl p{font-size:13px;margin:6px 0}
 </style>
+
+<script is:inline>
+(function () {
+  var versoes = Array.prototype.slice.call(document.querySelectorAll('details[data-versao]'));
+  if (!versoes.length) return;
+
+  /* ---- hash -> abre e rola até a versão ----
+     getElementById e NÃO querySelector: os ids têm ponto ("v2.0.0-alpha.21") e
+     num seletor CSS o ponto vira classe. Escapar daria na mesma, mas
+     getElementById não precisa. */
+  function abrePeloHash() {
+    var h = location.hash.replace(/^#/, '');
+    if (!h) return;
+    var el = document.getElementById(h);
+    if (!el || el.tagName !== 'DETAILS') return;
+    el.open = true;
+    el.scrollIntoView({ block: 'start', behavior: 'smooth' });
+  }
+  abrePeloHash();
+  addEventListener('hashchange', abrePeloHash);
+
+  /* ---- o # copia o link permanente ----
+     preventDefault + stopPropagation porque o <a> vive dentro do <summary>, e
+     clique em summary alterna o <details>: sem isso, copiar o link FECHARIA a
+     versão que a pessoa acabou de abrir. */
+  versoes.forEach(function (d) {
+    var a = d.querySelector('.cl-perma');
+    if (!a) return;
+    a.addEventListener('click', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      var url = location.origin + location.pathname + '#' + d.id;
+      history.replaceState(null, '', '#' + d.id);
+      d.open = true;
+      var antes = a.textContent;
+      function ok() { a.textContent = 'copiado'; a.classList.add('copiado');
+        setTimeout(function () { a.textContent = antes; a.classList.remove('copiado'); }, 1400); }
+      // clipboard.writeText exige contexto seguro (https/localhost); em http
+      // simples ele nem existe, então mostramos a URL pra copiar à mão.
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).then(ok, function () { prompt('Copie o link:', url); });
+      } else { prompt('Copie o link:', url); }
+    });
+  });
+
+  /* ---- busca ----
+     Injetada por JS de propósito: um campo de filtro que não filtra (JS off) é
+     pior que campo nenhum. */
+  var slot = document.getElementById('cl-busca-slot');
+  if (!slot) return;
+  var input = document.createElement('input');
+  input.type = 'search'; input.id = 'cl-busca';
+  input.placeholder = 'filtrar versões… (ex: bots, viewmodel, 3.3)';
+  input.setAttribute('aria-label', 'Filtrar versões do changelog por texto');
+  var vazio = document.createElement('p');
+  vazio.className = 'cl-vazio'; vazio.hidden = true;
+  slot.appendChild(input); slot.appendChild(vazio);
+
+  var textos = versoes.map(function (d) {
+    return (d.getAttribute('data-versao') + ' ' + (d.textContent || '')).toLowerCase();
+  });
+  var abertoAntes = versoes.map(function (d) { return d.open; });
+
+  input.addEventListener('input', function () {
+    var q = input.value.trim().toLowerCase();
+    var achou = 0;
+    versoes.forEach(function (d, i) {
+      if (!q) { d.hidden = false; d.open = abertoAntes[i]; achou++; return; }
+      var casa = textos[i].indexOf(q) !== -1;
+      d.hidden = !casa;
+      if (casa) { d.open = true; achou++; }
+    });
+    vazio.hidden = !q || achou > 0;
+    if (!vazio.hidden) vazio.textContent = 'Nenhuma versão menciona "' + input.value.trim() + '".';
+  });
+})();
+</script>


### PR DESCRIPTION
Closes #44

## O que muda

- `id="v<versao>"` em cada `<details>`, com `scroll-margin-top` pro topo fixo não cobrir depois do salto
- `#` ao lado do número da versão, que copia o link permanente
- script: hash na URL abre e rola até a versão (também no `hashchange`, então funciona ao colar link na mesma aba)
- **3** versões abertas por padrão, em vez de 2

E o bônus que a issue sugeria — porque é o problema de verdade: **texto dentro de `<details>` fechado é invisível pro Ctrl+F**. Um `<input type="search">` filtra as 12 versões por texto, abre as que casam e esconde as que não.

## Critérios de aceite

- [x] `/changelog#v3.3.0` abre a versão certa e rola até ela
- [x] Clicar no `#` copia a URL completa
- [x] Funciona sem JS (o `<details>` continua abrindo no clique)

```
1. /changelog/#v3.1.0
   abriu a versão certa   true      (é a 4ª — nasce FECHADA no HTML)
   hash                   #v3.1.0

2. clique no #
   continua aberta        true      <- não fechou
   hash atualizado        #v3.2.0
   url copiada            .../changelog/#v3.2.0

3. busca "viewmodel"      7 de 12 visíveis, todas abertas
   busca inexistente      0 visíveis + aviso de vazio
   limpar o campo         12 visíveis, 3 abertas (volta ao estado inicial)
```

## Quatro detalhes que mudaram a implementação

**`getElementById`, não `querySelector`.** Os ids têm ponto (`v2.0.0-alpha.4`) e num seletor CSS o ponto vira classe. `#v2.0.0-alpha.4` como seletor não casa nada.

**O `#` é uma `<a href="#v...">` de verdade, não um `<button>`.** Sem JS ela ainda leva o navegador até a versão certa — o `<summary>` é visível mesmo com o `<details>` fechado. O JS só transforma o clique em "copia sem sair da página". É o que atende o critério "funciona sem JS".

**`preventDefault` + `stopPropagation` no clique do `#`.** A âncora vive dentro do `<summary>`, e clique em summary alterna o `<details>`. Sem isso, **copiar o link fecharia a versão que a pessoa acabou de abrir** — testei, é o que acontecia.

**A busca é injetada por JS.** Um campo de filtro que não filtra (JS desligado) é pior que campo nenhum, então ele só existe quando funciona. E `clipboard.writeText` exige contexto seguro: em http simples nem existe, aí cai num `prompt()` com a URL, em vez de falhar calado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)