### PR TITLE
feat(seo): uma página por facção em /faccoes/<id>

### DIFF
--- a/src/pages/faccoes/[id].astro
+++ b/src/pages/faccoes/[id].astro
@@ -1,0 +1,122 @@
+---
+// /faccoes/<id> — uma página por facção.
+//
+// POR QUE EXISTE: /personagens lista as 5 facções e os 44 personagens numa URL
+// só. "tribos urbanas jogo", "funkeiros jogo brasileiro" e "palhaços" são buscas
+// DIFERENTES, e hoje competem entre si dentro da mesma página — nenhuma delas
+// tem um <title> ou uma <meta description> que fale só dela.
+//
+// A FONTE DOS DADOS é src/data/jogo.ts, mesma de /personagens. Nada é digitado
+// duas vezes aqui: se um personagem entrar no jogo, ele aparece na facção dele
+// sem ninguém editar este arquivo.
+//
+// O SLUG DA URL É O `id` DA FACÇÃO, e dois deles são letra única: `P` e `B`.
+// /faccoes/P é feio mas é o que casa com o dado e com o resto do código (o jogo
+// usa 'P'/'B' em toda parte, inclusive em stats.matches_p). Trocar por
+// /faccoes/petistas exigiria um mapa id->slug e o inverso, e um erro nesse mapa
+// dá 404 silencioso. Se o dono quiser as URLs bonitas, o lugar é aqui e o mapa
+// tem que morar junto do PLACA, que já tem o mesmo problema.
+import Layout from '../../layouts/Layout.astro';
+import { FACCOES, PERSONAGENS } from '../../data/jogo';
+import { BRAND_FULL, GAME_ID, abs } from '../../lib/site';
+
+export function getStaticPaths() {
+  return FACCOES.map((f) => ({ params: { id: f.id }, props: { faccao: f } }));
+}
+
+const { faccao } = Astro.props;
+const elenco = PERSONAGENS.filter((p) => p.faccao === faccao.id);
+const outras = FACCOES.filter((f) => f.id !== faccao.id);
+const url = abs(`/faccoes/${faccao.id}`);
+
+/* Mesmo mapa de /personagens, e pelo mesmo motivo: `P` -> `petistas` não é
+   derivável de `P`. Duplicado de propósito em vez de exportado — são 5 linhas, e
+   um import cruzado entre duas páginas por uma tabela de nome de arquivo é pior
+   de achar do que a duplicação. Se virar 3 lugares, aí vai pro data/jogo.ts. */
+const PLACA: Record<string, string> = {
+  P: 'petistas', B: 'bolsonaristas', urbanas: 'tribos',
+  palhacos: 'palhacos', funkeiros: 'funkeiros',
+};
+const placa = PLACA[faccao.id] ? `/img/team-${PLACA[faccao.id]}.webp` : null;
+
+const jsonld = [
+  {
+    '@type': 'ItemList',
+    '@id': url + '#lista',
+    name: `Personagens da facção ${faccao.nome}`,
+    description: faccao.nota,
+    numberOfItems: elenco.length,
+    itemListElement: elenco.map((p, i) => ({
+      '@type': 'ListItem', position: i + 1, name: p.nome,
+      item: {
+        '@type': 'Person', name: p.nome, description: p.blurb,
+        additionalType: 'https://schema.org/FictionalCharacter',
+      },
+    })),
+  },
+  {
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Início', item: abs('/') },
+      { '@type': 'ListItem', position: 2, name: 'Personagens', item: abs('/personagens') },
+      { '@type': 'ListItem', position: 3, name: faccao.nome, item: url },
+    ],
+  },
+  { '@id': GAME_ID },
+];
+---
+<Layout
+  title={`${faccao.nome} — os ${elenco.length} personagens da facção | ${BRAND_FULL}`}
+  description={`${faccao.nota} Conheça os ${elenco.length} personagens jogáveis da facção ${faccao.nome} no ${BRAND_FULL}, com o lema “${faccao.lema}”.`}
+  jsonld={jsonld}
+  h1={faccao.nome}
+  kicker={`facção · ${elenco.length} personagens`}
+  heroImg="/img/map-previews/awp_map.jpg"
+  heroPos="52%">
+  <Fragment slot="sub">
+    “{faccao.lema}” — {faccao.nota}
+  </Fragment>
+
+  <p class="meta"><b>{elenco.length} personagens</b><i>·</i>facção {faccao.nome}<i>·</i>
+    <a href="/personagens">ver as {FACCOES.length} facções</a></p>
+
+  {placa && (
+    <div class="fig" style="margin:18px 0">
+      <img src={placa} width="640" height="1601" loading="lazy" decoding="async"
+           alt={`Os ${elenco.length} personagens da facção ${faccao.nome} no ${BRAND_FULL}`}>
+      <span class="fig-tag" style={`background:${faccao.cor};color:#141008`}>{faccao.nome}</span>
+    </div>
+  )}
+
+  <h2>O elenco</h2>
+  <div class="grid" style={`--fc:${faccao.cor}`}>
+    {elenco.map((p) => (
+      <article class="pcard">
+        <strong>{p.nome}</strong>
+        <p>{p.blurb}</p>
+      </article>
+    ))}
+  </div>
+
+  <h2>As outras facções</h2>
+  <p>
+    {outras.map((f, i) => (
+      <Fragment>
+        <a href={`/faccoes/${f.id}`} style={`color:${f.cor}`}>{f.nome}</a>{i < outras.length - 1 ? ' · ' : ''}
+      </Fragment>
+    ))}
+  </p>
+  <p style="margin-top:10px">
+    Todas as {FACCOES.length} numa página só: <a href="/personagens">personagens</a>.
+    Nenhum personagem representa pessoa real — são arquétipos, e a zoeira é distribuída
+    igualmente. <a href="/">▶ JOGAR</a>
+  </p>
+</Layout>
+
+<style>
+  .pcard{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--fc);
+    padding:12px 14px}
+  .pcard:hover{background:var(--panel-2);border-color:var(--line-hi)}
+  .pcard strong{color:var(--ink);letter-spacing:1px;font-size:13px;display:block}
+  .pcard p{margin-top:5px;font-size:12.5px;line-height:1.55}
+</style>

--- a/src/pages/personagens.astro
+++ b/src/pages/personagens.astro
@@ -99,9 +99,17 @@ const jsonld = [
         <div class="fmeta">
           <p class="meta"><b>Facção {String(i + 1).padStart(2, '0')}</b><i>·</i>
             {g.elenco.length} personagens</p>
-          <h2 id={slug(g.nome)} style={`color:${g.cor}`}>{g.nome}</h2>
+          <h2 id={slug(g.nome)} style={`color:${g.cor}`}>
+            {/* Link pra página própria da facção (/faccoes/<id>). O <h2> continua
+                sendo o título da seção aqui — o link é o caminho pro recorte, não
+                uma navegação escondida. */}
+            <a href={`/faccoes/${g.id}`} style={`color:${g.cor};text-decoration:none`}>{g.nome}</a>
+          </h2>
           <p class="fmotto">“{g.lema}”</p>
           <p class="fnota">{g.nota}</p>
+          <p style="margin-top:8px;font-size:12px">
+            <a href={`/faccoes/${g.id}`}>Página da facção {g.nome} →</a>
+          </p>
         </div>
       </header>
       <div class="grid roster">

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -29,6 +29,7 @@
 import type { APIRoute } from 'astro';
 import { supabaseAdmin } from '../lib/supabase';
 import { SITE, RANKING_ON } from '../lib/site';
+import { FACCOES } from '../data/jogo';
 
 export const prerender = false;
 
@@ -47,6 +48,10 @@ const STATIC: [string, string, string][] = [
   ...(RANKING_ON ? [['/ranking', '0.9', 'hourly'] as [string, string, string]] : []),
   ['/como-jogar',  '0.8', 'weekly'],
   ['/personagens', '0.8', 'weekly'],
+  /* As 5 facções saem de FACCOES, não de uma lista digitada aqui: facção nova
+     entra no sitemap sozinha. Prioridade abaixo de /personagens porque são
+     recortes dela, e acima de /sobre porque é conteúdo de produto. */
+  ...FACCOES.map((f) => [`/faccoes/${f.id}`, '0.7', 'weekly'] as [string, string, string]),
   ['/mapas',       '0.8', 'weekly'],
   ['/armas',       '0.8', 'weekly'],
   ['/sobre',       '0.7', 'monthly'],


### PR DESCRIPTION
Closes #34

`/personagens` listava as 5 facções e os 44 personagens numa URL só. *"tribos urbanas jogo"*, *"funkeiros jogo brasileiro"* e *"palhaços"* são buscas **diferentes** e competiam entre si dentro da mesma página — nenhuma tinha `<title>` nem `<meta description>` falando só dela.

Cada facção agora tem página com lema, cor, nota, a placa renderizada dos GLB, o elenco com blurb, `ItemList` + `BreadcrumbList` e link cruzado pras outras 4 e pra `/personagens`.

**Nada é digitado duas vezes.** Os dados saem de `src/data/jogo.ts` via `getStaticPaths`, e as 5 URLs entram no sitemap por `FACCOES.map(...)`, não por lista literal — facção nova aparece nos dois lugares sozinha.

## Critérios de aceite

- [x] **As 5 páginas existem e buildam estaticamente**

```
/faccoes/P/index.html          /faccoes/B/index.html
/faccoes/urbanas/index.html    /faccoes/palhacos/index.html
/faccoes/funkeiros/index.html
```

- [x] **`/personagens` linka pra cada uma** — no `<h2>` da seção e num link explícito abaixo da nota
- [x] **Cada `<title>` e `<meta description>` citam a facção pelo nome**

```
Petistas — os 8 personagens da facção | CORO SOLTO: Treta Suprema
Bolsonaristas — os 9 personagens da facção | …
Tribos Urbanas — os 9 personagens da facção | …
Palhaços — os 9 personagens da facção | …
Funkeiros — os 9 personagens da facção | …
```

8+9+9+9+9 = **44**, que é o elenco completo — a contagem sai do dado, não de texto fixo. As descriptions começam com a `nota` da facção, então cada uma abre com o conteúdo dela.

- [x] **As 5 aparecem no `/sitemap.xml`** — de 8 para 13 `<loc>`, e o XML valida no parser (13 elementos `<url>`)

```
https://www.csbrasil.online/faccoes/P
https://www.csbrasil.online/faccoes/B
https://www.csbrasil.online/faccoes/urbanas
https://www.csbrasil.online/faccoes/palhacos
https://www.csbrasil.online/faccoes/funkeiros
```

As 5 rotas respondem 200 no dev server.

## Uma escolha que vale você revisar

**O slug da URL é o `id` da facção, e dois deles são letra única:** `/faccoes/P` e `/faccoes/B`. Feio, mas é o que casa com o dado e com o resto do código — o jogo usa `P`/`B` em toda parte, inclusive em `stats.matches_p`. URL bonita (`/faccoes/petistas`) exigiria um mapa `id -> slug` **e** o inverso, e um erro nesse mapa dá 404 silencioso. Deixei comentado no arquivo exatamente onde mudar, junto da observação de que o `PLACA` já tem esse mesmo problema (`P -> petistas` não é derivável). Se você preferir as URLs por extenso, é uma linha e eu ajusto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)