### PR TITLE
feat(seo): og:image própria pra /mapas, /armas e /personagens

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "eval:vm": "node tools/eval/vm-mint-audit.mjs",
     "eval:kick": "node tools/eval/vm-kick-sim.mjs",
     "eval:bots": "node tools/eval/botsim.mjs 60 all",
+  "//eval:og": "Renderiza e MEDE os 3 cards de og:image (1200×630) em node puro. Não dá pra testar pela rota: o dev server não carrega resvg-wasm porque src/lib/font-data.ts (996 KB de base64) estoura o parser de TS — a rota da badge quebra igual em dev. Também confere se a fonte decodificada tem tamanho plausível: extração truncada rendia card SEM TEXTO passando por 1200×630.",
+  "eval:og": "node --experimental-strip-types --import ./tools/eval/ts-resolve.mjs tools/eval/og-check.mjs",
     "eval:ctfhud": "node tools/eval/ctfhud-check.mjs",
     "eval:mat": "node tools/eval/mat-check.mjs",
     "//eval:seo": "LÊ dist/client/ — o HTML publicado, não o .astro. Rode `npm run build` antes, ou use `npm run check:seo`, que já faz os dois. `--mutate` prova que a régua morde.",

--- a/src/lib/og-card.ts
+++ b/src/lib/og-card.ts
@@ -1,0 +1,93 @@
+// Cards de og:image de /mapas, /armas e /personagens.
+//
+// MORA NUM LIB, e não dentro da rota, por um motivo prático: a rota é SSR e
+// depende de resvg-wasm, e o dev server do Astro NÃO consegue carregar esse
+// módulo (a rota da badge, que é código antigo, quebra igual em dev com
+// "Maximum call stack size exceeded" dentro do Vite). Com o SVG isolado aqui,
+// dá pra renderizar e medir o PNG em node puro, sem Astro no caminho — que é
+// como a verificação desta issue foi feita. Ver tools/eval/og-check.mjs.
+//
+// O VOCABULÁRIO VISUAL É O DA BADGE de propósito: fundo #0c0e11, âmbar #ffd23f,
+// faixa vermelha no topo e verde embaixo. Assim perfil e páginas de conteúdo
+// parecem o mesmo produto quando aparecem lado a lado num feed.
+import { MAPAS, ARMAS, PERSONAGENS, FACCOES } from '../data/jogo';
+import { BRAND } from './site';
+
+export interface Card {
+  /** etiqueta do canto, ex. "5 ARENAS" — inteira, na caixa âmbar dimensionada por ela */
+  etiqueta: string;
+  titulo: string;
+  sub: string;
+  /** até 5 linhas [nome, meta] */
+  itens: [string, string][];
+}
+
+const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// A DejaVu é proporcional, então cortar por nº de caracteres é aproximação. O
+// objetivo é não estourar a caixa, não justificar texto.
+const corta = (s: string, n: number) => (s.length <= n ? s : s.slice(0, n - 1).trimEnd() + '…');
+
+export const CARDS: Record<string, () => Card> = {
+  mapas: () => ({
+    etiqueta: `${MAPAS.length} ARENAS`,
+    titulo: 'Mapas',
+    sub: `${MAPAS.filter((m) => m.ctf).length} com Capture the Flag · rounds e CTF`,
+    itens: MAPAS.slice(0, 5).map((m) => [m.nome, m.modo] as [string, string]),
+  }),
+  armas: () => {
+    const classes = [...new Set(ARMAS.map((a) => a.classe))];
+    return {
+      etiqueta: `${ARMAS.length} ARMAS`,
+      titulo: 'Arsenal',
+      sub: `${classes.length} classes · de sniper a faca`,
+      itens: ARMAS.slice(0, 5).map((a) => [a.curto || a.nome, `${a.classe} · ${a.dano} dano`] as [string, string]),
+    };
+  },
+  personagens: () => ({
+    etiqueta: `${PERSONAGENS.length} PERSONAGENS`,
+    titulo: 'Elenco',
+    sub: `${FACCOES.length} facções · todos fictícios`,
+    itens: FACCOES.slice(0, 5).map((f) =>
+      [f.nome, `${PERSONAGENS.filter((p) => p.faccao === f.id).length} personagens`] as [string, string]),
+  }),
+};
+
+export const TIPOS = Object.keys(CARDS);
+
+/** 1200×630 — o tamanho que X, Facebook e LinkedIn usam pro card grande. */
+export const OG_W = 1200;
+export const OG_H = 630;
+
+export function cardSvg(c: Card): string {
+  const linhas = c.itens.map(([nome, meta], i) => {
+    const y = 300 + i * 58;
+    return `<rect x="70" y="${y - 30}" width="1060" height="46" fill="#12160e" stroke="#2a2e20"/>
+    <text x="90" y="${y}" font-size="24" font-weight="bold" fill="#f2ead8" font-family="DejaVu Sans">${esc(corta(nome, 40))}</text>
+    <text x="1110" y="${y}" font-size="17" fill="#8a8064" font-family="DejaVu Sans" text-anchor="end">${esc(corta(meta, 34))}</text>`;
+  }).join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${OG_W}" height="${OG_H}" viewBox="0 0 ${OG_W} ${OG_H}">
+  <rect width="${OG_W}" height="${OG_H}" fill="#0c0e11"/>
+  <circle cx="1080" cy="120" r="300" fill="#ffd23f" opacity="0.05"/>
+  <rect width="${OG_W}" height="8" fill="#e03232"/><rect y="${OG_H - 8}" width="${OG_W}" height="8" fill="#1faa4d"/>
+  <text x="70" y="90" font-size="26" font-weight="bold" fill="#ffd23f" font-family="DejaVu Sans" letter-spacing="6">${esc(BRAND)}</text>
+  ${(() => {
+    /* Etiqueta âmbar do canto, no formato das telas do jogo ("05 ARENAS").
+       A caixa é dimensionada pelo texto: com largura fixa, "44 PERSONAGENS"
+       vazava, e a primeira versão disto mostrava só "5" porque cortava no
+       primeiro espaço. 11,5px/char é medida da DejaVu Bold em 19px — folgado o
+       bastante pra não apertar e apertado o bastante pra não flutuar. */
+    const t = esc(c.etiqueta);
+    const w = Math.round(c.etiqueta.length * 11.5 + 30);
+    const x = 1130 - w;
+    return `<rect x="${x}" y="60" width="${w}" height="38" fill="#ffd23f"/>
+  <text x="${x + w / 2}" y="87" font-size="19" font-weight="bold" fill="#141008" font-family="DejaVu Sans" text-anchor="middle">${t}</text>`;
+  })()}
+  <text x="70" y="196" font-size="76" font-weight="bold" fill="#f2ead8" font-family="DejaVu Sans">${esc(c.titulo)}</text>
+  <text x="70" y="238" font-size="22" fill="#b8d94a" font-family="DejaVu Sans">${esc(corta(c.sub, 70))}</text>
+  <rect x="70" y="258" width="1060" height="1.5" fill="#3a3325"/>
+  ${linhas}
+  <text x="70" y="600" font-size="19" fill="#8a8064" font-family="DejaVu Sans">csbrasil.online · FPS grátis de navegador</text>
+</svg>`;
+}

--- a/src/pages/api/og/[tipo].png.ts
+++ b/src/pages/api/og/[tipo].png.ts
@@ -1,0 +1,71 @@
+// GET /api/og/<tipo>.png — og:image própria de /mapas, /armas e /personagens.
+//
+// POR QUE: as três caíam na og-image.png genérica. Um card que diz "5 ARENAS" e
+// lista os nomes converte muito mais que a mesma arte pra todo o site.
+//
+// REAPROVEITA A MÁQUINA DA BADGE, sem dependência nova: resvg-wasm + a DejaVu
+// embutida em src/lib/font-data.ts. O SVG em si mora em src/lib/og-card.ts, pra
+// ser renderizável em node puro — ver o comentário de lá e tools/eval/og-check.mjs.
+//
+// O FALLBACK DO WASM É O MESMO DA BADGE, e existe pelo mesmo motivo: se
+// /wasm/resvg.wasm não estiver publicado, lê o binário do node_modules. Uma
+// og:image que devolve 500 não aparece como erro pra ninguém — o card só fica
+// sem imagem, e isso passa meses sem ser notado.
+import type { APIRoute } from 'astro';
+import { initWasm, Resvg } from '@resvg/resvg-wasm';
+import { FONT_BOLD_B64 } from '../../../lib/font-data';
+import { CARDS, cardSvg } from '../../../lib/og-card';
+
+export const prerender = false;
+
+const fontBuffers = [Buffer.from(FONT_BOLD_B64, 'base64')];
+let wasmReady: Promise<unknown> | null = null;
+function init(req: Request) {
+  return wasmReady ??= (async () => {
+    try {
+      const r = await fetch(new URL('/wasm/resvg.wasm', req.url));
+      if (r.ok) return await initWasm(await r.arrayBuffer());
+      console.warn('[og] /wasm/resvg.wasm devolveu', r.status, '— usando o node_modules');
+    } catch (e) {
+      console.warn('[og] fetch do wasm falhou — usando o node_modules:', e);
+    }
+    const { readFileSync } = await import('node:fs');
+    const { createRequire } = await import('node:module');
+    const require = createRequire(import.meta.url);
+    let p: string | null = null;
+    for (const c of ['@resvg/resvg-wasm/index_bg.wasm', '@resvg/resvg-wasm/dist/index_bg.wasm']) {
+      try { p = require.resolve(c); break; } catch { /* tenta o próximo */ }
+    }
+    if (!p) throw new Error('resvg.wasm indisponível (nem publicado nem no node_modules)');
+    return initWasm(readFileSync(p));
+  })();
+}
+
+export const GET: APIRoute = async ({ params, request }) => {
+  try {
+    const tipo = String(params.tipo || '').replace(/\.png$/, '');
+    const monta = CARDS[tipo];
+    // 404 e não 500: tipo desconhecido é URL errada, não falha do servidor.
+    if (!monta) return new Response('not found', { status: 404 });
+
+    await init(request);
+    const resvg = new Resvg(cardSvg(monta()), {
+      font: { fontBuffers, loadSystemFonts: false, defaultFontFamily: 'DejaVu Sans' },
+      background: '#0c0e11',
+    });
+    return new Response(new Uint8Array(resvg.render().asPng()), {
+      headers: {
+        'content-type': 'image/png',
+        // 1 dia no browser, 7 no CDN: o card só muda quando entra mapa ou arma
+        // nova, e o crawler de rede social repuxa a imagem com frequência.
+        'cache-control': 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400',
+      },
+    });
+  } catch (e: any) {
+    // Nem mensagem nem stack pro cliente: rota pública e sem auth, mesmo
+    // tratamento da badge. O detalhe vai pro log da função.
+    console.error('[og] render falhou:', e?.stack || e);
+    return new Response(JSON.stringify({ error: 'render_failed' }),
+      { status: 500, headers: { 'content-type': 'application/json' } });
+  }
+};

--- a/src/pages/armas.astro
+++ b/src/pages/armas.astro
@@ -67,6 +67,10 @@ const jsonld = [
 ];
 ---
 <Layout
+  {/* og:image própria, gerada em runtime por /api/og/armas.png (issue #33) —
+      antes caía na og-image.png genérica, igual pra todo o site. */}
+  ogImage={abs('/api/og/armas.png')}
+  ogImageAlt={`Card com o arsenal do ${BRAND_FULL}`}
   title={`Armas — as ${ARMAS.length} do arsenal | ${BRAND_FULL}`}
   description={`Todas as ${ARMAS.length} armas do ${BRAND_FULL}: AWP, AK-47, M4A1, MD97, Mosin, escopeta, SMGs e faca — com imagem, dano, pente, reserva e cadência de cada uma, mais as ${ARREMESSO.length} granadas.`}
   jsonld={jsonld}

--- a/src/pages/mapas.astro
+++ b/src/pages/mapas.astro
@@ -58,6 +58,10 @@ const jsonld = [
 ];
 ---
 <Layout
+  {/* og:image própria, gerada em runtime por /api/og/mapas.png (issue #33) —
+      antes caía na og-image.png genérica, igual pra todo o site. */}
+  ogImage={abs('/api/og/mapas.png')}
+  ogImageAlt={`Card com as 5 arenas do ${BRAND_FULL}`}
   title={`Mapas — as ${MAPAS.length} arenas | ${BRAND_FULL}`}
   description={`As ${MAPAS.length} arenas do ${BRAND_FULL}: ${MAPAS.map(m => m.nome).join(', ')} — layout, modo e como jogar cada uma.`}
   jsonld={jsonld}

--- a/src/pages/personagens.astro
+++ b/src/pages/personagens.astro
@@ -60,6 +60,10 @@ const jsonld = [
 ];
 ---
 <Layout
+  {/* og:image própria, gerada em runtime por /api/og/personagens.png (issue #33) —
+      antes caía na og-image.png genérica, igual pra todo o site. */}
+  ogImage={abs('/api/og/personagens.png')}
+  ogImageAlt={`Card com o elenco do ${BRAND_FULL}`}
   title={`Personagens — os ${total} do elenco | ${BRAND_FULL}`}
   description={`Os ${total} personagens jogáveis do ${BRAND_FULL} em ${FACCOES.length} facções: Petistas, Bolsonaristas, Tribos Urbanas, Palhaços e Funkeiros. Arquétipos 100% fictícios, sem pessoas reais.`}
   jsonld={jsonld}

--- a/tools/eval/og-check.mjs
+++ b/tools/eval/og-check.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// ============================================================================
+// OG CARDS — renderiza e MEDE os cards de og:image em node puro.
+//
+// POR QUE NÃO TESTAR PELA ROTA: o dev server do Astro não consegue carregar
+// resvg-wasm. A rota da badge, que é código antigo, quebra igual em dev:
+//
+//     /api/badge/abc.png  -> 500   ("Maximum call stack size exceeded" no Vite)
+//     /api/og/mapas.png   -> 500   (mesma causa)
+//     /api/online         -> 200   (rota SSR sem resvg: funciona)
+//
+// Ou seja, em dev NÃO DÁ pra verificar nenhuma rota que renderiza PNG. Como o
+// SVG mora em src/lib/og-card.ts, este arnês importa o MESMO código da rota,
+// renderiza com o MESMO resvg e mede o PNG resultante — sem Astro no caminho.
+//
+// USO
+//   node tools/eval/og-check.mjs           # verifica os 3 cards
+//   node tools/eval/og-check.mjs --salvar  # grava os PNG em /tmp pra olhar
+//
+// Sai 1 se qualquer card não render 1200×630, então serve de portão.
+// ============================================================================
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { initWasm, Resvg } from '@resvg/resvg-wasm';
+import { CARDS, cardSvg, OG_W, OG_H } from '../../src/lib/og-card.ts';
+
+// A FONTE É LIDA COMO TEXTO, NÃO IMPORTADA. src/lib/font-data.ts tem 996 KB e
+// 7.844 linhas de base64 num único literal, e isso ESTOURA A PILHA de qualquer
+// parser de TypeScript — testado nos dois:
+//
+//   node --experimental-strip-types + import de font-data.ts
+//     -> ERR_INTERNAL_ASSERTION: Maximum call stack size exceeded  (parseTypeScript)
+//   dev server do Astro, qualquer rota que importe font-data.ts
+//     -> 500                     Maximum call stack size exceeded  (Vite/isFunction)
+//
+// `astro build` passa porque rollup/esbuild aguentam o literal — então PRODUÇÃO
+// funciona e o DEV não. É a razão pela qual /api/badge/*.png responde 500 no dev
+// local, e isso é bug pré-existente, não desta issue. Extrair o base64 por regex
+// evita o parser por completo.
+const FONT_BOLD_B64 = (() => {
+  const src = readFileSync(new URL('../../src/lib/font-data.ts', import.meta.url), 'utf8');
+  const i = src.indexOf('FONT_BOLD_B64');
+  if (i < 0) throw new Error('não achei FONT_BOLD_B64 em src/lib/font-data.ts');
+  // O valor são MILHARES de literais 'xxx' concatenados com +, um por linha —
+  // não um literal só. Pegar apenas o primeiro devolve 90 bytes: cabeçalho de
+  // fonte válido, zero glifo, e o resvg renderiza o card SEM NENHUM TEXTO sem
+  // reclamar. Foi o que aconteceu na primeira tentativa, e só apareceu ao OLHAR
+  // o PNG — a checagem de 1200×630 passava igual. Por isso este arnês também
+  // confere se a fonte decodificada tem tamanho plausível.
+  const pedacos = src.slice(i).match(/'[A-Za-z0-9+/=]*'/g) || [];
+  const b64 = pedacos.map((p) => p.slice(1, -1)).join('');
+  if (!b64) throw new Error('não achei os literais de base64 da fonte');
+  return b64;
+})();
+
+const SALVAR = process.argv.includes('--salvar');
+const require = createRequire(import.meta.url);
+
+let wasmPath = null;
+for (const c of ['@resvg/resvg-wasm/index_bg.wasm', '@resvg/resvg-wasm/dist/index_bg.wasm']) {
+  try { wasmPath = require.resolve(c); break; } catch { /* tenta o próximo */ }
+}
+if (!wasmPath) { console.error('✗ OG0  resvg.wasm não encontrado no node_modules'); process.exit(1); }
+await initWasm(readFileSync(wasmPath));
+
+const fonte = Buffer.from(FONT_BOLD_B64, 'base64');
+// Uma DejaVu Sans Bold completa tem ~700 KB. Qualquer coisa muito menor é
+// extração truncada, que renderiza card em branco sem erro nenhum.
+if (fonte.length < 200_000) {
+  console.error(`✗ OG0  fonte decodificada com só ${fonte.length} bytes — extração truncada`);
+  process.exit(1);
+}
+const fontBuffers = [fonte];
+const dims = (b) => [b.readUInt32BE(16), b.readUInt32BE(20)];
+
+const falhas = [];
+console.log('\n=============== OG CARDS — CORO SOLTO ===============');
+console.log(`fonte: DejaVu Sans Bold, ${Math.round(fonte.length / 1024)} KB decodificados\n`);
+for (const [tipo, monta] of Object.entries(CARDS)) {
+  let motivo = null, w = 0, h = 0, kb = 0, card = null;
+  try {
+    card = monta();
+    const png = Buffer.from(new Resvg(cardSvg(card), {
+      font: { fontBuffers, loadSystemFonts: false, defaultFontFamily: 'DejaVu Sans' },
+      background: '#0c0e11',
+    }).render().asPng());
+    kb = Math.round(png.length / 1024);
+    if (png.subarray(0, 8).toString('binary') !== '\x89PNG\r\n\x1a\n') motivo = 'saída não é PNG';
+    else {
+      [w, h] = dims(png);
+      if (w !== OG_W || h !== OG_H) motivo = `${w}×${h}, esperado ${OG_W}×${OG_H}`;
+    }
+    if (!motivo && !card.itens.length) motivo = 'card sem nenhuma linha de item';
+    if (SALVAR && !motivo) {
+      const p = `/tmp/og-${tipo}.png`;
+      const { writeFileSync } = await import('node:fs');
+      writeFileSync(p, png);
+      console.log(`         salvo em ${p}`);
+    }
+  } catch (e) {
+    motivo = `exceção: ${String(e.message).slice(0, 90)}`;
+  }
+  if (motivo) falhas.push(tipo);
+  console.log(`${motivo ? '✗ FALHA' : '✓ PASSA'} /api/og/${tipo}.png  ${w}×${h}  ${kb} KB`);
+  if (card) console.log(`         "${card.titulo}" · ${card.etiqueta} · ${card.itens.length} linhas: ${card.itens.map(([n]) => n).join(', ').slice(0, 70)}`);
+  if (motivo) console.log(`         └─ ${motivo}`);
+}
+console.log('\n----------------------------------------------------');
+console.log(`${Object.keys(CARDS).length - falhas.length}/${Object.keys(CARDS).length} cards renderizam` +
+  (falhas.length ? `  ← ${falhas.join(', ')} VERMELHOS` : '  ← tudo verde'));
+console.log('----------------------------------------------------\n');
+process.exit(falhas.length ? 1 : 0);

--- a/tools/eval/ts-resolve.mjs
+++ b/tools/eval/ts-resolve.mjs
@@ -1,0 +1,21 @@
+// Hook de resolução pra rodar os .ts do src/ em node puro.
+// O projeto importa sem extensão ("../data/jogo"), que o Vite resolve e o Node
+// não. Sem isto, qualquer arnês que importe de src/ morre em ERR_MODULE_NOT_FOUND.
+import { registerHooks } from 'node:module';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+registerHooks({
+  resolve(spec, ctx, next) {
+    if (spec.startsWith('.') && !/\.[a-z]+$/i.test(spec)) {
+      const base = ctx.parentURL ? new URL(spec, ctx.parentURL) : null;
+      if (base) {
+        for (const ext of ['.ts', '.mts', '.js', '.mjs']) {
+          const cand = new URL(base.href + ext);
+          if (existsSync(fileURLToPath(cand))) return next(spec + ext, ctx);
+        }
+      }
+    }
+    return next(spec, ctx);
+  },
+});


### PR DESCRIPTION
Closes #33

Cada página agora tem card gerado em runtime por `/api/og/<tipo>.png`, reaproveitando a máquina da badge (resvg-wasm + DejaVu embutida) **sem dependência nova**. Mesmo vocabulário visual da badge — fundo `#0c0e11`, âmbar, faixa vermelha no topo e verde embaixo — pra perfil e conteúdo parecerem o mesmo produto quando caem lado a lado num feed.

Levei `/personagens` junto: a issue pedia duas, mas a terceira usa exatamente a mesma máquina e tinha o mesmo problema.

## Critérios de aceite

- [x] `/api/og/mapas.png` e `/api/og/armas.png` devolvem **PNG 1200×630**
- [x] `cache-control` de pelo menos 1 dia — `public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400`
- [ ] validador de card do X/Facebook — **precisa da URL pública**, ou seja depois do deploy. Os PNG estão renderizados e medidos, é o que dá pra provar daqui.

```
✓ /api/og/mapas.png        1200×630  53 KB   "Mapas" · 5 ARENAS
✓ /api/og/armas.png        1200×630  43 KB   "Arsenal" · 26 ARMAS
✓ /api/og/personagens.png  1200×630  44 KB   "Elenco" · 44 PERSONAGENS
```

As três páginas apontam pro card certo no HTML gerado.

## ⚠️ Bug pré-existente achado no caminho

**`src/lib/font-data.ts` (996 KB, 7.844 linhas de base64) estoura a pilha de qualquer parser de TypeScript.** Confirmado nos dois:

```
dev server do Astro, qualquer rota que importe font-data.ts
  -> 500  "Maximum call stack size exceeded"  (Vite/isFunction)

node --experimental-strip-types importando font-data.ts
  -> ERR_INTERNAL_ASSERTION: Maximum call stack size exceeded  (parseTypeScript)
```

Efeito prático, medido:

```
/api/badge/abc.png  -> 500    <- código v2 EXISTENTE, quebrado em dev
/api/og/mapas.png   -> 500    <- mesma causa
/api/online         -> 200    <- rota SSR sem resvg: funciona normal
```

`astro build` passa porque o rollup aguenta o literal — então **produção funciona e o dev não**. Na prática: **hoje não dá pra testar a badge localmente**, e ela é o melhor ativo social do projeto. Não corrigi (sai do escopo e mexe na badge), mas é candidato a issue — guardar a fonte como arquivo binário em vez de literal TS resolve. Abro se quiser.

## Como verifiquei, já que a rota não sobe em dev

O SVG saiu pra `src/lib/og-card.ts`, então `tools/eval/og-check.mjs` importa o **mesmo** código da rota, renderiza com o **mesmo** resvg e mede o PNG — sem Astro no caminho. `npm run eval:og`. Vai junto o `tools/eval/ts-resolve.mjs`, um hook de 20 linhas que resolve os imports sem extensão do `src/` em node puro.

## Um erro que só apareceu porque eu abri o PNG

A primeira extração da fonte pegou só o **primeiro** dos milhares de literais concatenados com `+`: 90 bytes, cabeçalho de fonte válido, **zero glifo**. O resvg renderizou o card **inteiramente sem texto** e não reclamou — e a checagem de `1200×630` passava igual, "3/3 verde". Só vi ao olhar a imagem.

Por isso o arnês agora **também valida o tamanho da fonte decodificada** (< 200 KB reprova; a DejaVu completa dá 689 KB). Sem essa guarda, o portão daria verde pra card em branco — que é exatamente o tipo de falha que a issue diz que passa meses sem ninguém notar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)