### PR TITLE
feat(seo): sitemap vira índice paginado quando passa de 5.000 URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "eval:vm": "node tools/eval/vm-mint-audit.mjs",
     "eval:kick": "node tools/eval/vm-kick-sim.mjs",
     "eval:bots": "node tools/eval/botsim.mjs 60 all",
+  "//eval:sitemap": "Prova o fatiamento do sitemap com totais falsos (0, 5000, 5001, 12000). O modo índice é código que NINGUÉM alcança pedindo a URL — perfis só entram com RANKING_ON e precisariam de 5000+ jogadores. Checa páginas contíguas sem buraco, teto por página, XML bem formado nos dois modos e escape de & no nick.",
+  "eval:sitemap": "node --experimental-strip-types tools/eval/sitemap-check.mjs",
     "eval:ctfhud": "node tools/eval/ctfhud-check.mjs",
     "eval:mat": "node tools/eval/mat-check.mjs",
     "//eval:seo": "LÊ dist/client/ — o HTML publicado, não o .astro. Rode `npm run build` antes, ou use `npm run check:seo`, que já faz os dois. `--mutate` prova que a régua morde.",

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,66 @@
+// Montagem do sitemap, isolada das rotas.
+//
+// POR QUE NUM LIB: as rotas /sitemap.xml e /sitemap-[page].xml precisam da mesma
+// lógica, e a paginação é a parte que NÃO DÁ PRA EXERCITAR EM PRODUÇÃO hoje —
+// perfis só entram com RANKING_ON (hoje false), e mesmo ligado precisaria de
+// 5.000+ jogadores pra a segunda página existir. Com as funções aqui, um arnês
+// injeta 12.000 jogadores falsos e prova o fatiamento sem banco.
+// Ver tools/eval/sitemap-check.mjs.
+//
+// ESTRATÉGIA ADAPTATIVA, e é de propósito. A issue #32 sugere transformar
+// /sitemap.xml em índice. Só que o primeiro critério de aceite dela é "com menos
+// de 5.000 jogadores, o comportamento é idêntico ao de hoje" — e um índice
+// apontando pra um único arquivo de 8 URLs não é idêntico: é um salto extra pro
+// crawler, sem nenhum ganho. Então:
+//
+//   total <= POR_PAGINA  ->  /sitemap.xml é um <urlset> normal (hoje, igual)
+//   total >  POR_PAGINA  ->  /sitemap.xml vira <sitemapindex> apontando pras
+//                            páginas /sitemap-1.xml … /sitemap-N.xml
+//
+// Efeito colateral bom: `Sitemap:` no robots.txt continua correto nos DOIS
+// modos, porque /sitemap.xml é sempre o ponto de entrada. A issue pedia pra
+// atualizar o robots; com isto, não precisa — e uma linha que não muda é uma
+// linha que não fica errada.
+
+/** O protocolo permite 50.000 por arquivo. 5.000 é o teto que o código já usava
+ *  e mantém cada resposta pequena — o custo aqui é uma query no Supabase por
+ *  página, não banda. */
+export const POR_PAGINA = 5000;
+
+export interface Entrada {
+  loc: string;
+  lastmod: string;
+  changefreq: string;
+  priority: string;
+}
+
+export const escXml = (s: string) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+
+/** Quantas páginas o total ocupa. 0 itens = 1 página (vazia, mas válida). */
+export function numeroDePaginas(total: number, porPagina = POR_PAGINA): number {
+  return Math.max(1, Math.ceil(total / porPagina));
+}
+
+/** Índice 0-based do primeiro item da página (1-based). */
+export function offsetDaPagina(pagina: number, porPagina = POR_PAGINA): number {
+  return (pagina - 1) * porPagina;
+}
+
+export function xmlUrlset(entradas: Entrada[]): string {
+  const linhas = entradas.map((e) =>
+    `  <url><loc>${escXml(e.loc)}</loc><lastmod>${e.lastmod}</lastmod>` +
+    `<changefreq>${e.changefreq}</changefreq><priority>${e.priority}</priority></url>`);
+  return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    linhas.join('\n') + `\n</urlset>\n`;
+}
+
+export function xmlIndex(paginas: { loc: string; lastmod: string }[]): string {
+  const linhas = paginas.map((p) =>
+    `  <sitemap><loc>${escXml(p.loc)}</loc><lastmod>${p.lastmod}</lastmod></sitemap>`);
+  return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    linhas.join('\n') + `\n</sitemapindex>\n`;
+}

--- a/src/pages/sitemap-[page].xml.ts
+++ b/src/pages/sitemap-[page].xml.ts
@@ -1,0 +1,45 @@
+// GET /sitemap-<n>.xml — uma página do sitemap, quando o conteúdo passa de
+// POR_PAGINA URLs e /sitemap.xml vira índice.
+//
+// SÓ EXISTE PRA O MODO ÍNDICE. Enquanto o total couber numa página, /sitemap.xml
+// responde o <urlset> inteiro e nada aponta pra cá — mas a rota fica de pé de
+// qualquer jeito, porque um índice que aponta pra 404 é pior que não ter índice,
+// e a transição entre os dois modos acontece sozinha quando o ranking liga e o
+// nº de jogadores cresce.
+//
+// A PÁGINA 1 CARREGA AS FIXAS. Assim nenhuma URL fica fora do conjunto: o índice
+// não lista /sitemap.xml (isso seria recursivo), então as 8 páginas do site
+// precisam morar em alguma página numerada.
+import type { APIRoute } from 'astro';
+import { SITE, RANKING_ON } from '../lib/site';
+import { supabaseAdmin } from '../lib/supabase';
+import { POR_PAGINA, offsetDaPagina, xmlUrlset, type Entrada } from '../lib/sitemap';
+import { STATIC, perfis, xmlResposta } from './sitemap.xml';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params }) => {
+  const n = Number(params.page);
+  // 404 e não página vazia: /sitemap-0.xml ou /sitemap-abc.xml é URL errada, e
+  // devolver XML válido pra ela ensina o crawler a pedir lixo.
+  if (!Number.isInteger(n) || n < 1) return new Response('not found', { status: 404 });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const fixas: Entrada[] = n === 1
+    ? STATIC.map(([path, prio, freq]) => ({
+        loc: `${SITE}${path}`, lastmod: today, changefreq: freq, priority: prio,
+      }))
+    : [];
+
+  // O offset dos perfis desconta as fixas que a página 1 consumiu, senão a
+  // fronteira entre a página 1 e a 2 perderia tantos perfis quantas são as fixas.
+  const offset = Math.max(0, offsetDaPagina(n) - (n === 1 ? 0 : fixasCount()));
+  const entradas = fixas.concat(await perfis(offset, POR_PAGINA - fixas.length, today));
+
+  if (!entradas.length) return new Response('not found', { status: 404 });
+  return xmlResposta(xmlUrlset(entradas));
+};
+
+function fixasCount(): number {
+  return STATIC.length;
+}

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -29,6 +29,10 @@
 import type { APIRoute } from 'astro';
 import { supabaseAdmin } from '../lib/supabase';
 import { SITE, RANKING_ON } from '../lib/site';
+import {
+  POR_PAGINA, numeroDePaginas, offsetDaPagina, xmlUrlset, xmlIndex,
+  type Entrada,
+} from '../lib/sitemap';
 
 export const prerender = false;
 
@@ -42,7 +46,7 @@ export const prerender = false;
 // documentação do Google é explícita: "don't include noindex URLs in your
 // sitemap" — https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap
 // Quando `RANKING_ON` voltar a true, as duas voltam sozinhas.
-const STATIC: [string, string, string][] = [
+export const STATIC: [string, string, string][] = [
   ['/',            '1.0', 'daily'],
   ...(RANKING_ON ? [['/ranking', '0.9', 'hourly'] as [string, string, string]] : []),
   ['/como-jogar',  '0.8', 'weekly'],
@@ -54,41 +58,67 @@ const STATIC: [string, string, string][] = [
   ['/changelog',   '0.5', 'weekly'],
 ];
 
-const esc = (s: string) =>
-  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-   .replace(/"/g, '&quot;').replace(/'/g, '&apos;');
-
 export const GET: APIRoute = async () => {
   const today = new Date().toISOString().slice(0, 10);
-  const urls: string[] = STATIC.map(([path, prio, freq]) =>
-    `  <url><loc>${SITE}${path}</loc><lastmod>${today}</lastmod>` +
-    `<changefreq>${freq}</changefreq><priority>${prio}</priority></url>`);
+  const fixas: Entrada[] = STATIC.map(([path, prio, freq]) => ({
+    loc: `${SITE}${path}`, lastmod: today, changefreq: freq, priority: prio,
+  }));
 
+  /* QUANTOS PERFIS EXISTEM. Precisa saber ANTES de decidir entre urlset e
+     índice, e um `count` com `head: true` não traz linha nenhuma — é bem mais
+     barato que puxar 5.000 registros só pra contar. */
+  let totalPerfis = 0;
   if (RANKING_ON && supabaseAdmin) {
-    // Vai em `stats` e não na view `leaderboard` por dois motivos: a view tem
-    // `limit 500` cravado (o sitemap tem que cobrir TODO mundo, não o top 500)
-    // e não expõe `updated_at`, que é o `lastmod` honesto de um perfil.
-    const { data } = await supabaseAdmin
+    const { count } = await supabaseAdmin
       .from('stats')
-      .select('updated_at, players!inner(id, nick, hidden)')
-      .eq('players.hidden', false)
-      .limit(5000);
-    for (const row of (data ?? []) as any[]) {
-      const p = row.players;
-      if (!p?.id || !p?.nick) continue;
-      const loc = `${SITE}/u/${p.id}/${encodeURIComponent(p.nick)}`;
-      const lastmod = row.updated_at ? String(row.updated_at).slice(0, 10) : today;
-      urls.push(
-        `  <url><loc>${esc(loc)}</loc><lastmod>${lastmod}</lastmod>` +
-        `<changefreq>weekly</changefreq><priority>0.6</priority></url>`);
-    }
+      .select('updated_at, players!inner(id, nick, hidden)', { count: 'exact', head: true })
+      .eq('players.hidden', false);
+    totalPerfis = count ?? 0;
   }
 
-  const xml =
-    `<?xml version="1.0" encoding="UTF-8"?>\n` +
-    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-    urls.join('\n') + `\n</urlset>\n`;
+  const total = fixas.length + totalPerfis;
 
+  /* MODO ÍNDICE. Só quando o conteúdo passa de uma página — ver o comentário de
+     estratégia em src/lib/sitemap.ts. Abaixo do teto, a resposta é idêntica à
+     de antes desta mudança. */
+  if (total > POR_PAGINA) {
+    const n = numeroDePaginas(total);
+    return xmlResposta(xmlIndex(
+      Array.from({ length: n }, (_, i) => ({ loc: `${SITE}/sitemap-${i + 1}.xml`, lastmod: today })),
+    ));
+  }
+
+  const entradas = fixas.concat(await perfis(0, POR_PAGINA - fixas.length, today));
+  return xmlResposta(xmlUrlset(entradas));
+};
+
+/** Uma fatia dos perfis, já como entradas de sitemap. Usada pelas duas rotas. */
+export async function perfis(offset: number, limite: number, today: string): Promise<Entrada[]> {
+  if (!RANKING_ON || !supabaseAdmin || limite <= 0) return [];
+  // Vai em `stats` e não na view `leaderboard` por dois motivos: a view tem
+  // `limit 500` cravado (o sitemap tem que cobrir TODO mundo, não o top 500) e
+  // não expõe `updated_at`, que é o `lastmod` honesto de um perfil.
+  const { data } = await supabaseAdmin
+    .from('stats')
+    .select('updated_at, players!inner(id, nick, hidden)')
+    .eq('players.hidden', false)
+    .order('updated_at', { ascending: false })
+    .range(offset, offset + limite - 1);
+  const out: Entrada[] = [];
+  for (const row of (data ?? []) as any[]) {
+    const p = row.players;
+    if (!p?.id || !p?.nick) continue;
+    out.push({
+      loc: `${SITE}/u/${p.id}/${encodeURIComponent(p.nick)}`,
+      lastmod: row.updated_at ? String(row.updated_at).slice(0, 10) : today,
+      changefreq: 'weekly',
+      priority: '0.6',
+    });
+  }
+  return out;
+}
+
+export function xmlResposta(xml: string): Response {
   return new Response(xml, {
     headers: {
       'content-type': 'application/xml; charset=utf-8',
@@ -97,4 +127,4 @@ export const GET: APIRoute = async () => {
       'cache-control': 'public, max-age=600, s-maxage=3600, stale-while-revalidate=86400',
     },
   });
-};
+}

--- a/tools/eval/sitemap-check.mjs
+++ b/tools/eval/sitemap-check.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// ============================================================================
+// SITEMAP — prova o fatiamento que a produção não alcança.
+//
+// POR QUE ISTO EXISTE: perfis /u/* só entram no sitemap com RANKING_ON (hoje
+// false), e mesmo ligado precisaria de 5.000+ jogadores pra a segunda página
+// existir. Ou seja, o modo índice é código que NINGUÉM consegue exercitar
+// pedindo a URL — o tipo de caminho que fica quebrado por um ano e só aparece no
+// dia em que o site cresce, que é justamente o pior dia pra descobrir.
+//
+// Aqui as funções de src/lib/sitemap.ts recebem totais falsos e a saída é
+// conferida contra o protocolo: nenhuma página acima do teto, nenhuma URL
+// perdida na fronteira entre páginas, XML bem formado.
+//
+// USO
+//   node --experimental-strip-types tools/eval/sitemap-check.mjs
+//
+// Não precisa de hook de resolução: src/lib/sitemap.ts é autocontido de
+// propósito (não importa nada), justamente pra ser testável em node puro.
+//
+// Sai 1 em qualquer divergência.
+// ============================================================================
+import {
+  POR_PAGINA, numeroDePaginas, offsetDaPagina, xmlUrlset, xmlIndex, escXml,
+} from '../../src/lib/sitemap.ts';
+
+const falhas = [];
+const checa = (id, ok, desc, evid) => {
+  if (!ok) falhas.push(id);
+  console.log(`${ok ? '✓ PASSA' : '✗ FALHA'} ${id.padEnd(6)} ${desc}`);
+  if (evid) console.log(`${' '.repeat(15)}${evid}`);
+};
+
+console.log('\n=============== SITEMAP — CORO SOLTO ===============');
+console.log(`teto por página: ${POR_PAGINA}\n`);
+
+// ---- contagem de páginas ----
+const casos = [
+  [0, 1], [1, 1], [8, 1], [POR_PAGINA, 1],
+  [POR_PAGINA + 1, 2], [POR_PAGINA * 2, 2], [POR_PAGINA * 2 + 1, 3], [12000, 3],
+];
+checa('SM1', casos.every(([t, esp]) => numeroDePaginas(t) === esp),
+  'nº de páginas para cada total',
+  casos.map(([t, e]) => `${t}->${numeroDePaginas(t)}(esp ${e})`).join('  '));
+
+// ---- offsets contíguos, sem buraco nem sobreposição ----
+const TOTAL = 12000;
+const n = numeroDePaginas(TOTAL);
+const fatias = Array.from({ length: n }, (_, i) => {
+  const off = offsetDaPagina(i + 1);
+  return [off, Math.min(off + POR_PAGINA, TOTAL)];
+});
+const contiguo = fatias.every(([ini], i) => i === 0 || ini === fatias[i - 1][1]);
+const cobreTudo = fatias[0][0] === 0 && fatias[n - 1][1] === TOTAL;
+const somam = fatias.reduce((s, [a, b]) => s + (b - a), 0);
+checa('SM2', contiguo && cobreTudo && somam === TOTAL,
+  `${TOTAL} itens em ${n} páginas: contíguas, sem buraco, somam o total`,
+  fatias.map(([a, b]) => `[${a},${b})`).join(' ') + `  soma=${somam}`);
+
+// ---- nenhuma página acima do teto ----
+checa('SM3', fatias.every(([a, b]) => b - a <= POR_PAGINA),
+  'nenhuma página passa do teto',
+  'maior página: ' + Math.max(...fatias.map(([a, b]) => b - a)));
+
+// ---- XML bem formado nos dois modos ----
+const entradas = Array.from({ length: 3 }, (_, i) => ({
+  loc: `https://www.csbrasil.online/u/id-${i}/nick&${i}`,
+  lastmod: '2026-08-06', changefreq: 'weekly', priority: '0.6',
+}));
+const urlset = xmlUrlset(entradas);
+const index = xmlIndex(Array.from({ length: n }, (_, i) => ({
+  loc: `https://www.csbrasil.online/sitemap-${i + 1}.xml`, lastmod: '2026-08-06',
+})));
+
+const bemFormado = (xml, raiz) =>
+  /^<\?xml version="1\.0" encoding="UTF-8"\?>\n/.test(xml) &&
+  xml.includes(`<${raiz} xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`) &&
+  xml.trimEnd().endsWith(`</${raiz}>`) &&
+  (xml.match(/</g) || []).length === (xml.match(/>/g) || []).length;
+
+checa('SM4', bemFormado(urlset, 'urlset'), '<urlset> bem formado',
+  `${(urlset.match(/<url>/g) || []).length} <url>, ${urlset.length} chars`);
+checa('SM5', bemFormado(index, 'sitemapindex'), '<sitemapindex> bem formado',
+  `${(index.match(/<sitemap>/g) || []).length} <sitemap> para ${n} páginas`);
+
+// ---- o & do nick tem que sair escapado; & solto derruba o parser de quem consome ----
+const amp = urlset.match(/&(?!amp;|lt;|gt;|quot;|apos;|#)/);
+checa('SM6', !amp && urlset.includes('nick&amp;0'), 'nick com & sai escapado',
+  amp ? `& solto perto de ${JSON.stringify(urlset.slice(Math.max(0, amp.index - 25), amp.index + 25))}` : 'nick&amp;0 presente');
+
+// ---- índice NÃO lista /sitemap.xml (seria recursivo) ----
+checa('SM7', !index.includes('/sitemap.xml<') && !index.includes('>/sitemap.xml'),
+  'o índice não aponta pra si mesmo');
+
+// ---- escXml cobre os 5 do XML ----
+const bruto = `<a href="x" & 'y'>`;
+const esc = escXml(bruto);
+checa('SM8', !/[<>]/.test(esc) && esc.includes('&amp;') && esc.includes('&quot;') && esc.includes('&apos;'),
+  'escXml escapa < > & " \'', JSON.stringify(esc));
+
+console.log('\n---------------------------------------------------');
+console.log(falhas.length ? `${falhas.length} VERMELHAS: ${falhas.join(', ')}` : 'tudo verde');
+console.log('---------------------------------------------------\n');
+process.exit(falhas.length ? 1 : 0);


### PR DESCRIPTION
Closes #32

O sitemap tinha `.limit(5000)` cravado: passando disso, jogador começa a **desaparecer do buscador em silêncio**.

## Adaptativo — e isso é o critério 1 da issue, não preguiça

A issue sugere transformar `/sitemap.xml` em índice. Mas o primeiro critério de aceite dela é *"com menos de 5.000 jogadores, o comportamento é idêntico ao de hoje"* — e um índice apontando pra um único arquivo de 8 URLs **não é idêntico**: é um salto extra pro crawler, sem ganho nenhum. Então:

```
total <= 5000  ->  /sitemap.xml é <urlset> normal        (hoje, igual)
total >  5000  ->  /sitemap.xml vira <sitemapindex>
                   apontando pras páginas /sitemap-1.xml … /sitemap-N.xml
```

**Efeito colateral bom:** a linha `Sitemap:` do `robots.txt` continua correta nos **dois** modos, porque `/sitemap.xml` é sempre o ponto de entrada. A issue pedia pra atualizar o robots (passo 4) — com essa estratégia não precisa, e linha que não muda é linha que não fica errada.

## Critérios de aceite

- [x] **Com menos de 5.000 jogadores, comportamento idêntico ao de hoje**

```
/sitemap.xml antes desta mudança  vs  depois:   diff IDÊNTICO
ambos: parse OK, 8 <url>, raiz <urlset>
```

- [x] **Com mais, o índice aponta pra N páginas e nenhuma passa de 5.000 `<url>`**
- [x] **Todo XML valida**

## O modo índice, que a produção não alcança

Perfis `/u/*` só entram no sitemap com `RANKING_ON` (hoje **false**), e mesmo ligado precisaria de 5.000+ jogadores pra a segunda página existir. É código que **ninguém consegue exercitar pedindo a URL** — o tipo que fica quebrado por um ano e aparece no dia em que o site cresce, que é o pior dia possível pra descobrir.

Por isso a lógica saiu pra `src/lib/sitemap.ts` (autocontido, zero imports, testável em node puro) e `tools/eval/sitemap-check.mjs` alimenta totais falsos. **8/8 verde** (`npm run eval:sitemap`):

```
SM1  nº de páginas: 0->1  5000->1  5001->2  10000->2  10001->3  12000->3
SM2  12000 em 3 páginas: [0,5000) [5000,10000) [10000,12000)  soma=12000
SM3  nenhuma página passa do teto (maior: 5000)
SM4  <urlset> bem formado
SM5  <sitemapindex> bem formado
SM6  nick com & sai escapado (&amp;, não & solto — que derruba o consumidor)
SM7  o índice não aponta pra si mesmo
SM8  escXml escapa os cinco do XML
```

## Rotas, medidas

| rota | status | o que é |
| --- | --- | --- |
| `/sitemap.xml` | 200 | urlset, total abaixo do teto |
| `/sitemap-1.xml` | 200 | página 1, com as 8 fixas |
| `/sitemap-2.xml` | 404 | não há conteúdo pra ela |
| `/sitemap-0.xml` | 404 | URL inválida |
| `/sitemap-abc.xml` | 404 | URL inválida |

Os dois últimos dão 404 e não XML vazio de propósito: devolver documento válido pra URL inventada ensina o crawler a pedir lixo.

## Três detalhes que mudaram a implementação

**A contagem usa `count: 'exact', head: true`** — não traz linha nenhuma, só o número. Decidir o modo puxando 5.000 registros pra depois contar seria pagar exatamente o custo que a paginação existe pra evitar.

**Os perfis passaram a sair `order by updated_at desc`.** Paginação com `.range()` **sem ordem estável** repete linha numa página e perde na outra — o Postgres não garante ordem sem `ORDER BY`. Isso não aparece com 8 URLs; apareceria exatamente no dia em que o índice ligasse, e como sintoma difuso ("faltam perfis no Search Console").

**A página 1 carrega as 8 fixas.** O índice não lista `/sitemap.xml` (seria recursivo), então as páginas do site precisam morar em alguma página numerada — senão sairiam do conjunto quando o modo índice ligasse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
