### PR TITLE
Dois defeitos de jogador: a trava anti-fraude do #87 e o Ctrl+W que fecha a aba

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ algo está errado e o quality gate está verde, o defeito é do quality gate.
 
 | Zona | O que é | Tamanho medido | Regra |
 |---|---|---|---|
-| `public/` | o **jogo** | 30 arquivos `.js`, 26.644 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
+| `public/` | o **jogo** | 30 arquivos `.js`, 27.173 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
 | `src/` | o **site** | 17 páginas `.astro`, 12 rotas `/api` · Astro `^7.1.1` | framework é bem-vindo; `service_role` só no servidor |
-| `tools/` | o **arnês** | 159 scripts em `tools/eval/`, 44 em `tools/` | node puro: sobe o jogo real sem browser |
+| `tools/` | o **arnês** | 161 scripts em `tools/eval/`, 44 em `tools/` | node puro: sobe o jogo real sem browser |
 
 **Não existe `public/index.html`.** O HTML do jogo é `src/pages/index.astro`, servido na rota `/`. Servir `public/` estaticamente entrega os arnêses visuais, **não o jogo** — é a pegadinha que custa a primeira hora de todo mundo.
 
@@ -139,7 +139,7 @@ npm run check        # npm run syntax && npm run audio:check && npm run eval:ctf
 npm run check:fast   # npm run syntax && npm run docs:check && npm run arch:check && npm run audio:check && npm run feet:check && npm run eval:ctfhud && npm run eval:pause && npm run eval:ctfround && npm run eval:ctfwin && npm run eval:spawn && npm run eval:regen && npm run eval:pegada && npm run eval:ctflabels && npm run eval:faccao && npm run anims:check
 ```
 
-`package.json` tem **48 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
+`package.json` tem **50 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `node -p "Object.keys(require('./package.json').scripts)"`
 

--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -44,6 +44,158 @@ lista de "balão" do CHR1 tem os mesmos 13 antes e depois).
 
 ## P0 — quebram o jogo ou mentem para quem mede
 
+### ~~BUG-35 · "partida rápida demais pra ser verdade" numa partida legítima~~ · RESOLVIDO 07/08 (issue #87)
+
+**Palavras de quem reportou** (maurodesouza, issue #87): *"Durante uma partida no modo
+Captura de Bandeira, recebi a mensagem `stats não enviados: partida rápida demais pra ser
+verdade`. A partida foi totalmente legítima. Eu estava jogando no mapa Quebrada (8x8) e
+fiquei de AWP cobrindo a viela. O time inimigo acabou avançando praticamente inteiro por
+esse mesmo corredor, então foi uma sequência de eliminações relativamente fácil."*
+
+**Causa raiz.** A cláusula (b) do `submit_match` (`~/db-privado/supabase/schema.sql:252`)
+exigia 80 s por rodada. O objetivo escrito no comentário estava certo — *"speed hack não
+produz partida instantânea"* — mas o NÚMERO veio do modo ABATE, onde a rodada É uma janela
+de tempo (`ROUND_TIME = 99`, `public/js/game.js:77`). **No CAPTURA a rodada não tem janela
+de tempo nenhuma**: fecha por alvo de bandeiras ou por dominação (`_ctfWin`,
+`game.js:4150`), e bastam 2 rodadas pra partida (`CTF_ROUNDS_TO_WIN`, `game.js:114`). O
+modo herdou uma premissa que nunca foi dele.
+
+**A parte que a issue não viu, e é a grave.** Antes do `raise`, a cláusula chamava
+`_flag(p_nick)` (`schema.sql:183-188`), que faz `flagged_count + 1` e, em
+`flagged_count >= 3`, `hidden = true`. A view `leaderboard` filtra por `not p.hidden`.
+**Três partidas rápidas legítimas escondiam o jogador do ranking, em silêncio.**
+
+**Medido antes × depois** (`node tools/eval/submit-guard-check.mjs --amostra`, 5 mapas ×
+10 sementes de CAPTURA jogadas até `matchEnd` no motor real, 07/08):
+
+| | piso 80 (antes) | piso por modo (depois) |
+|---|---|---|
+| partidas legítimas recusadas (SG2) | **6 de 50** | 0 de 50 |
+| abandonos legítimos recusados (SG3) | 4 de 50 | 0 de 50 |
+| mapas onde o piso recusa o fisicamente possível (SG1) | **5 de 5** | 0 de 5 |
+| a cláusula dá strike (SG4) | sim | não |
+
+Menor s/rodada de partida inteira: 48,0 s (awp_map, semente 64). Menor rodada individual:
+31,1 s (fy_pool_day, semente 99). Abandono mais curto que o jogo produz: `rounds 1,
+seconds 33`. **E o simulador é o caso LENTO — o jogador dele é passivo.**
+
+**O palpite óbvio, medido e morto.** *"É só baixar 80 para 40."* Rodado
+(`--piso=40 --amostra`): a **amostra passaria** (0/50 em SG2), e mesmo assim 40 reprova
+SG1 nos 5 mapas e recusa 4 de 50 abandonos. É por isso que a régua tem cláusula de FÍSICA
+além da de amostra — sozinha, a amostra teria aprovado o palpite errado.
+
+**De onde vem o número novo.** Tempo físico mínimo de uma rodada de captura: caminho ótimo
+em linha reta do spawn por todas as bandeiras (força bruta sobre as permutações), a
+`PLAYER_SPEED = 5,35 m/s`, mais permanência no anel com esquadrão cheio
+(`CAP_NEUTRAL/2`, `game.js:4099-4112`). Ignora parede, desvio e combate — tudo que a
+realidade cobra a mais. awp_map 20,1 s · fy_pool_day 12,3 s · fy_havan 35,6 s ·
+fy_ferrovelho 24,6 s · fy_quebrada 24,9 s. O piso do CAPTURA ficou em **6 s/rodada**,
+metade do mais apertado. O do ABATE continua 80 (lá a rodada não desce de ~99 s).
+
+**Conserto.** `p_mode` novo no RPC (`~/db-privado/supabase/migrations/015_submit_guard_modo.sql`),
+`mode: matchMode` nos dois payloads do `public/js/main.js` (fim de partida e abandono),
+`p_mode` na cascata de compatibilidade de `src/pages/api/submit-match.ts`. Modo
+desconhecido cai no piso BAIXO de propósito — cliente com JS em cache não pode ser punido.
+Espelho `opcional/012_ofuscacao_schema.sql` atualizado junto: ele é cópia byte-a-byte, e se
+ficasse pra trás, aplicar a ofuscação um dia reintroduziria este defeito.
+
+**Anistia.** A migration zera `flagged_count`/`hidden` de todo mundo, e o motivo está
+escrito nela: **não existe coluna de auditoria dizendo qual cláusula gerou cada strike**, e
+punição não atribuível vinda de regra defeituosa se desfaz inteira.
+
+**Régua nova:** `tools/eval/submit-guard-check.mjs` (`npm run eval:submitguard`). SG1
+física · SG2 amostra · SG3 abandono · SG4 sem strike · SG5 o ramo default é o brando.
+Mutações executadas: `--mutante=piso80` (SG1 vermelha nos 5 mapas), `--mutante=comflag`
+(SG4 vermelha nos 3 arquivos), `--mutante=defaultduro` (SG5 vermelha nos 3 — é a mais
+fina: sem ela dava pra "consertar" o #87 deixando no defeito quem está com JS em cache).
+**Fica fora do `check`**, como o `eval:boot`: o piso é LIDO do SQL, que mora em
+`~/db-privado/` (`.gitignore:145-148`), e sem esse insumo a régua fica VERMELHA em vez de
+passar calada.
+
+**NÃO VERIFICADO:**
+- **A migration não foi aplicada** — migration deste projeto é manual (`~/db-privado/COMO-MIGRAR.md`).
+  Até rodar, produção continua com o piso de 80 e continua escondendo gente.
+- **Quantos jogadores estão escondidos hoje.** O `raise notice` da anistia imprime o número
+  ao aplicar; é ele que vai no comentário de fechamento da issue.
+- A partida de captura curta de verdade, no navegador, com nick registrado, contra o banco
+  já migrado. A régua mede o motor e o SQL, não o caminho HTTP inteiro.
+
+### BUG-36 · Ctrl+W fecha a aba no meio da partida (Windows/Linux)
+
+**Palavras de quem reportou** (Daniel Diniz, 07/08, LinkedIn): *"quando fica muito tempo
+com a tecla Control pressionada a página fecha"* · *"Testei no Windows, mas posso ver no
+Mac"* · *"Não acontece no Mac 🤔, mas pode ser o chrome desatualizado!"* · *"testei em
+outros Browser e tem o mesmo problema. É alguma treta do Windows mesmo"*.
+
+**Não é treta do Windows, e não é o Control sozinho.** Agachar é
+`ControlLeft`/`ControlRight` e andar pra frente é `W` (`game.js`, `wantCrouch`). **Agachar
+andando pra frente É Ctrl+W**, que no Windows e no Linux fecha a aba. No Mac o atalho é
+Cmd+W — por isso o dono, que joga no Mac, nunca reproduziu. Mesma família: Ctrl+1/2/3 troca
+de aba do navegador, e 1/2/3 é a troca de arma.
+
+**Por que o código já sabia e não resolvia.** O `_kd` (`game.js:1969`) engolia
+`ctrlKey`/`metaKey` em pointer lock, e o comentário dele registrava a derrota: *"Ctrl+W o
+Chrome não deixa prevenir, use C pra agachar"*. Ctrl+W é atalho RESERVADO — `preventDefault`
+não alcança. Dizer ao jogador pra não usar a tecla padrão de FPS não é conserto, é aviso.
+
+**Conserto, duas camadas porque nenhuma sozinha cobre todo mundo.**
+1. `_travaAtalhos()` (`game.js`, dentro do `_requestLock`): `navigator.keyboard.lock()` com
+   `KeyW`/`KeyT`/`KeyN`/`KeyR`/`Digit1-3`. É a única API que captura Ctrl+W — e **só
+   funciona em tela cheia**, por isso a tela cheia entra junto, pedida cedo no `startGame`
+   (`main.js`), enquanto o clique ainda vale como gesto do usuário: depois do
+   `await sfxReady` e do `Promise.all` dos GLBs a ativação transiente já queimou. Escape
+   fica fora da lista de propósito (travado, exigiria toque longo, e Escape é o menu de
+   pausa). Solta no `dispose()` e no `setPaused(true)` — segurar o navegador de quem está
+   tentando sair seria hostil. Chromium só.
+2. O `beforeunload` do `main.js` passa a pedir confirmação **enquanto a partida está viva**.
+   Cobre Firefox, Safari e todo caso em que a tela cheia não pegou.
+
+**De quebra:** o `requestPointerLock` estava duplicado (`main.js:596` e o `_requestLock` do
+`game.js`), e era a duplicata que deixava a trava sem lugar pra morar no COMEÇO da partida
+— o RETOMAR passava pelo funil, o COMEÇAR não. Agora é um funil só.
+
+**Régua nova:** `tools/eval/ctrlw-check.mjs` (`npm run eval:ctrlw`), quatro cláusulas:
+
+| | o que mede | estado em 07/08 | mutação |
+|---|---|---|---|
+| CW4 | `_travaAtalhos` chama `keyboard.lock` com as teclas certas (node puro) | **VERDE** — pediu `KeyW,KeyT,KeyN,KeyR,Digit1-3` | `semtravar` → `[]`, FALHA ✓ |
+| CW3 | no MENU o `beforeunload` fica calado | **VERDE** | `promptsempre` → FALHA ✓ |
+| CW2 | com partida viva o `beforeunload` confirma | verde numa corrida, **não reproduzido** | `semprompt` (não executada) |
+| CW1 | tela cheia + trava ao ENTRAR na partida | **não medida** | `semlock` (não executada) |
+
+A CW3 é a que protege o conserto de si mesmo: confirmação que aparece sempre vira praga, e
+praga alguém arranca inteira em duas semanas, levando o conserto junto. A CW4 nasceu porque
+o caminho de navegador não fechava nesta máquina e a pergunta mais direta — *a trava chama
+mesmo a API, e com quais teclas?* — não podia ficar sem resposta esperando por ele. As
+mutações de arquivo servido morrem se não casarem o texto (`MUTANTE NÃO APLICOU`): mutação
+que passa de largo devolve verde, e esse verde é lido como "o guarda funciona".
+
+**O arnês fornece o ambiente, e isso está às claras no cabeçalho da régua:** Chrome
+headless não concede tela cheia de verdade nem expõe `navigator.keyboard`, então a régua
+planta os dois e mede o CÓDIGO DO JOGO. Ela não prova nada sobre o navegador hospedeiro.
+
+**QUATRO DEFEITOS DE INSTRUMENTO pagos escrevendo esta régua** (lei 7 da `bug-hunt`, e os
+quatro acusaram código inocente):
+1. media no `state` do jogo em vez do fim do `startGame` — `game.start()` põe `countdown`
+   ~20 linhas ANTES do `_requestLock`, então CW1 reprovava algo que ainda não tinha sido
+   tentado;
+2. `getElementById('loading')` quando o overlay é `load-overlay` — o `?.` devolvia
+   `undefined` e a condição nunca fechava;
+3. `waitForFunction` polla em `requestAnimationFrame` por padrão, e o rAF fica estrangulado
+   justamente durante o preload pesado que se está esperando (`polling: 250` resolve);
+4. `.catch(() => false)` cego no `waitForFunction`, que transformou exceção do Playwright
+   em "não ficou pronto" e escondeu (3) por três corridas.
+
+**NÃO VERIFICADO — e o primeiro item é o que fecha o defeito, não a régua:**
+- **Windows + Chrome com Ctrl+W de verdade.** Só quem tem Windows fecha isto: entrar na
+  partida, segurar Ctrl e andar com W por vários segundos, e a aba não pode fechar. **Pedir
+  ao Daniel Diniz**, que reportou.
+- Firefox e Safari: espera-se o diálogo de confirmação, não o fechamento seco. Não testado.
+- CW1 e CW2 não fecharam nesta máquina: o `/` em dev leva minutos pra compilar e o preload
+  do elenco derruba o renderer headless. A régua reprova por isso e **diz que reprovou** —
+  não conta como aprovação. Rodar em máquina mais folgada, ou com `BASE=` apontando pra um
+  preview já construído.
+
 ### ~~BUG-29 · "o jogo tá reiniciando do nada, estava num CTF no ferro velho do Zé"~~ · RESOLVIDO 05/08
 
 **NÃO era o BUG-00 de volta.** O menu de pausa continua consertado: `pause-check.mjs`
@@ -1412,6 +1564,41 @@ publicação em potencial, e o `.gitignore` não protege de um deploy local.
 ---
 
 ## Relatados, ainda não reproduzidos
+
+- **BUG-37 · Tarja vermelha de CRASH por um erro que não é crash.** Print do dono, 07/08,
+  com o menu de pausa aberto (`RESUME ▶` no canto):
+  *"⚠ CRASH (promise): The fetching process for the media resource was aborted by the user
+  agent at the user's request."*
+  **Régua: nenhuma.**
+  Essa mensagem é o `AbortError` padrão de um `<audio>` cujo `play()` estava pendente
+  quando alguém chamou `pause()` ou trocou o `src` — acontece em toda troca de faixa e em
+  todo fade de saída. **O defeito não é o áudio: é o overlay de crash tratar isso como
+  crash.** O handler está em `src/pages/index.astro:27` e mostra QUALQUER
+  `unhandledrejection` numa tarja vermelha pedindo print. Um jogador levando "CRASH" na
+  cara por causa de música que trocou é ruído que ainda por cima treina todo mundo a
+  ignorar a tarja — inclusive quando ela for de verdade.
+  **O que já foi conferido e NÃO é a origem:** os `play()` do `startMenuMusic`
+  (`main.js:206-216`) têm todos tratamento de rejeição, e o `_sample` do `audio.js:46`
+  também (`.catch(() => off())`). Falta achar quem produz a promessa solta — o
+  `stopMenuMusic` pausa por fade (`main.js:222-228`) e é candidato, mas não foi medido.
+  **Próximo passo:** régua que abra a rota, force troca de faixa/pausa e exija zero
+  `unhandledrejection`; depois filtrar `AbortError` de mídia no overlay, mantendo tudo o
+  mais visível.
+
+- **BUG-38 · "Andando não consigo mexer a mira, só quando para" — touchpad de notebook.**
+  Palavras de quem reportou (Matheus Paz, 07/08): *"Andando não consigo mexer a mira, só
+  quando para. Isso usando touchpad do notebook!"*
+  **Régua: nenhuma. NÃO REPRODUZIDO** — quem investigar precisa de um notebook com
+  touchpad; no mouse do dono isso não aparece.
+  **Palpite óbvio, e ele precisa ser REFUTADO antes de virar conserto:** "é a supressão de
+  toque enquanto digita" (Windows Precision Touchpad e macOS ignoram o trackpad enquanto
+  há tecla pressionada, pra o cursor não pular no meio da digitação). Se for isso, é do
+  sistema e não do jogo — mas *isso não fecha o item*, porque o jogo pode mitigar. E se
+  NÃO for, o suspeito seguinte é o `_mm` (`game.js:2049`), que lê `e.movementX/Y` e só
+  roda atrás de `_acceptInput()`.
+  **O que NÃO foi verificado:** o sistema operacional dele, se estava em pointer lock, e
+  se a mira trava com QUALQUER tecla de movimento ou só com W. Perguntar antes de medir —
+  sem isso a régua nasce medindo a coisa errada.
 
 - **"E vice-versa" do BUG-01** — partida de CTF *sem* a faixa de bandeiras no HUD. O caminho
   `this.ctf → _initCTF → _updateCtfHud` sempre desconde, então o mecanismo não é o mesmo do

--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -112,13 +112,19 @@ fina: sem ela dava pra "consertar" o #87 deixando no defeito quem está com JS e
 `~/db-privado/` (`.gitignore:145-148`), e sem esse insumo a régua fica VERMELHA em vez de
 passar calada.
 
-**NÃO VERIFICADO:**
-- **A migration não foi aplicada** — migration deste projeto é manual (`~/db-privado/COMO-MIGRAR.md`).
-  Até rodar, produção continua com o piso de 80 e continua escondendo gente.
-- **Quantos jogadores estão escondidos hoje.** O `raise notice` da anistia imprime o número
-  ao aplicar; é ele que vai no comentário de fechamento da issue.
-- A partida de captura curta de verdade, no navegador, com nick registrado, contra o banco
-  já migrado. A régua mede o motor e o SQL, não o caminho HTTP inteiro.
+**Migration aplicada em 07/08** pelo dono, à mão no SQL Editor (`~/db-privado/COMO-MIGRAR.md`).
+A rota mantém a cascata de compatibilidade, então cliente com JS velho continua gravando.
+
+**NÃO VERIFICADO — e nada disto foi conferido por quem escreveu o conserto:**
+- **O estado do banco DEPOIS da migration.** Não há credencial na worktree; a régua lê os
+  ARQUIVOS SQL, não a função implantada. Falta o smoke escrito no rodapé da 015:
+  `select proname, pronargs from pg_proc where proname='submit_match'` tem que devolver
+  UMA linha com `pronargs = 13` (mais de uma = sobrecarga viva), e
+  `select count(*) from players where hidden` tem que dar 0.
+- **Quantos jogadores estavam escondidos.** O `raise notice` da anistia imprimiu o número
+  ao aplicar; é ele que vai no comentário de fechamento da issue #87.
+- A partida de captura curta de verdade, no navegador, com nick registrado. A régua mede o
+  motor e o SQL, não o caminho HTTP inteiro.
 
 ### BUG-36 · Ctrl+W fecha a aba no meio da partida (Windows/Linux)
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ sem cadastro.
 
 | O que | Quanto | Onde confere |
 |---|---:|---|
-| Código do jogo | 26.644 linhas em 30 arquivos | `cat public/js/*.js \| wc -l` |
-| `game.js` | **6.145** linhas | `wc -l public/js/game.js` |
-| `main.js` | 1.670 linhas | `wc -l public/js/main.js` |
+| Código do jogo | 27.173 linhas em 30 arquivos | `cat public/js/*.js \| wc -l` |
+| `game.js` | **6.580** linhas | `wc -l public/js/game.js` |
+| `main.js` | 1.711 linhas | `wc -l public/js/main.js` |
 | Armas com GLB | 26 | `ls public/models/weapons/*.glb \| wc -l` |
 | GLBs de personagem | 45 | `ls public/models/characters/*.glb \| wc -l` |
 | Props em GLB | 108 | `ls public/models/props/*.glb \| wc -l` |
@@ -40,10 +40,10 @@ sem cadastro.
 | Personagens jogáveis | 44, em 5 facções | array `CHARACTERS` de `characters.js` |
 | Mapas no registro | 5 | objeto `MAPS` de `maps.js` |
 | Arnêses visuais em HTML | 12 | `ls public/*.html \| wc -l` |
-| Scripts do arnês | 159 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
+| Scripts do arnês | 161 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
 | Scripts de pipeline | 44 | `ls tools/*.mjs \| wc -l` |
 | Tarefas de entrada escritas | 26 | `ls docs/issues/[0-9]*.md \| wc -l` |
-| Versão | `2.0.0-alpha.35` | `public/js/version.js` e `package.json` (batem) |
+| Versão | `2.0.0-alpha.36` | `public/js/version.js` e `package.json` (batem) |
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `o comando da coluna direita de cada linha`
 
@@ -96,7 +96,7 @@ arquitetura): `cd docs && npm install && npm start` → <http://localhost:3000/d
 | Esta documentação | **Docusaurus** | `3.6.3` |
 | Runtime de CI | **Node** | `22` |
 
-Three.js sai de `public/vendor/three.module.js` (**sem CDN, sem npm no runtime**). Astro e Vercel de `package.json` + `astro.config.mjs` + `vercel.json`. Dos scripts de `tools/`, **98** importam Playwright, **36** importam gltf-transform e **4** importam meshoptimizer.
+Three.js sai de `public/vendor/three.module.js` (**sem CDN, sem npm no runtime**). Astro e Vercel de `package.json` + `astro.config.mjs` + `vercel.json`. Dos scripts de `tools/`, **99** importam Playwright, **36** importam gltf-transform e **4** importam meshoptimizer.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `dependencies/devDependencies do package.json · REVISION de public/vendor/three.module.js`
 
@@ -195,7 +195,7 @@ npm run check        # npm run syntax && npm run audio:check && npm run eval:ctf
 npm run check:fast   # npm run syntax && npm run docs:check && npm run arch:check && npm run audio:check && npm run feet:check && npm run eval:ctfhud && npm run eval:pause && npm run eval:ctfround && npm run eval:ctfwin && npm run eval:spawn && npm run eval:regen && npm run eval:pegada && npm run eval:ctflabels && npm run eval:faccao && npm run anims:check
 ```
 
-`package.json` tem **48 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
+`package.json` tem **50 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `node -p "Object.keys(require('./package.json').scripts)"`
 

--- a/docs/docs/arquitetura.md
+++ b/docs/docs/arquitetura.md
@@ -62,15 +62,15 @@ Tamanho dos arquivos que o `gen-arch.mjs` indexa — bloco gerado, regenerado po
 
 | Arquivo | Linhas |
 |---|---:|
-| `public/js/game.js` | 6.145 |
-| `public/js/main.js` | 1.670 |
+| `public/js/game.js` | 6.580 |
+| `public/js/main.js` | 1.711 |
 | `public/js/characters.js` | 1.066 |
 | `public/js/glbchars.js` | 811 |
-| `public/js/vmattach.js` | 628 |
+| `public/js/vmattach.js` | 627 |
 | `public/js/weapons.js` | 344 |
 | `public/js/springs.js` | 260 |
 
-Total de `public/js/`: **26.644 linhas em 30 arquivos**. O índice símbolo→linha, com a tabela de conflito, é outro bloco gerado: `tools/eval/ARCH.md` (`npm run arch`).
+Total de `public/js/`: **27.173 linhas em 30 arquivos**. O índice símbolo→linha, com a tabela de conflito, é outro bloco gerado: `tools/eval/ARCH.md` (`npm run arch`).
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: ``wc -l public/js/*.js``
 

--- a/docs/docs/comecando.md
+++ b/docs/docs/comecando.md
@@ -39,9 +39,9 @@ esta página envelhecia no primeiro commit — ver
 
 | O que | Quanto | Onde confere |
 |---|---:|---|
-| Código do jogo | 26.644 linhas em 30 arquivos | `cat public/js/*.js \| wc -l` |
-| `game.js` | **6.145** linhas | `wc -l public/js/game.js` |
-| `main.js` | 1.670 linhas | `wc -l public/js/main.js` |
+| Código do jogo | 27.173 linhas em 30 arquivos | `cat public/js/*.js \| wc -l` |
+| `game.js` | **6.580** linhas | `wc -l public/js/game.js` |
+| `main.js` | 1.711 linhas | `wc -l public/js/main.js` |
 | Armas com GLB | 26 | `ls public/models/weapons/*.glb \| wc -l` |
 | GLBs de personagem | 45 | `ls public/models/characters/*.glb \| wc -l` |
 | Props em GLB | 108 | `ls public/models/props/*.glb \| wc -l` |
@@ -49,10 +49,10 @@ esta página envelhecia no primeiro commit — ver
 | Personagens jogáveis | 44, em 5 facções | array `CHARACTERS` de `characters.js` |
 | Mapas no registro | 5 | objeto `MAPS` de `maps.js` |
 | Arnêses visuais em HTML | 12 | `ls public/*.html \| wc -l` |
-| Scripts do arnês | 159 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
+| Scripts do arnês | 161 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
 | Scripts de pipeline | 44 | `ls tools/*.mjs \| wc -l` |
 | Tarefas de entrada escritas | 26 | `ls docs/issues/[0-9]*.md \| wc -l` |
-| Versão | `2.0.0-alpha.35` | `public/js/version.js` e `package.json` (batem) |
+| Versão | `2.0.0-alpha.36` | `public/js/version.js` e `package.json` (batem) |
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `o comando da coluna direita de cada linha`
 
@@ -261,7 +261,7 @@ npm run check        # npm run syntax && npm run audio:check && npm run eval:ctf
 npm run check:fast   # npm run syntax && npm run docs:check && npm run arch:check && npm run audio:check && npm run feet:check && npm run eval:ctfhud && npm run eval:pause && npm run eval:ctfround && npm run eval:ctfwin && npm run eval:spawn && npm run eval:regen && npm run eval:pegada && npm run eval:ctflabels && npm run eval:faccao && npm run anims:check
 ```
 
-`package.json` tem **48 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
+`package.json` tem **50 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `node -p "Object.keys(require('./package.json').scripts)"`
 

--- a/docs/docs/quality-gates.md
+++ b/docs/docs/quality-gates.md
@@ -15,7 +15,7 @@ PR (`.github/workflows/ci.yml`).
 {/* BEGIN:GERADO:invariantes — não edite à mão, rode `npm run docs` */}
 
 - `tools/eval/invariants.mjs`: **2.194 linhas**, **61 identificadores de invariante declarados** (`put()`), dos quais **27** têm caminho de `skip()` declarado.
-- O arnês inteiro são **159 scripts** em `tools/eval/` (`.mjs` + `.py`), mais **44 scripts** de pipeline em `tools/`.
+- O arnês inteiro são **161 scripts** em `tools/eval/` (`.mjs` + `.py`), mais **44 scripts** de pipeline em `tools/`.
 - Quantas invariantes rodam como **críticas** numa execução **não é derivável do fonte**: depende de qual insumo existe na máquina (o JSON do auditor de viewmodel, um GLB, uma pasta de anims). Esse número só sai rodando o quality gate — e o lugar dele é o cabeçalho do `KNOWN-BUGS.md`, atualizado com saída real.
 
 Reproduza:

--- a/docs/docs/stack.md
+++ b/docs/docs/stack.md
@@ -28,7 +28,7 @@ a partir do `package.json`, do `docs/package.json` e do próprio Three.js vendor
 | Esta documentação | **Docusaurus** | `3.6.3` |
 | Runtime de CI | **Node** | `22` |
 
-Three.js sai de `public/vendor/three.module.js` (**sem CDN, sem npm no runtime**). Astro e Vercel de `package.json` + `astro.config.mjs` + `vercel.json`. Dos scripts de `tools/`, **98** importam Playwright, **36** importam gltf-transform e **4** importam meshoptimizer.
+Three.js sai de `public/vendor/three.module.js` (**sem CDN, sem npm no runtime**). Astro e Vercel de `package.json` + `astro.config.mjs` + `vercel.json`. Dos scripts de `tools/`, **99** importam Playwright, **36** importam gltf-transform e **4** importam meshoptimizer.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `dependencies/devDependencies do package.json · REVISION de public/vendor/three.module.js`
 
@@ -243,7 +243,7 @@ de trabalhar. Elas vivem em `.agents/skills/`, e `.claude/skills/` são symlinks
 | Contagem | Quanto | O que significa |
 |---|---:|---|
 | Declaradas no `skills-lock.json` | 30 | com `source`, `skillPath` e `computedHash` — skill de terceiro que mudar de conteúdo é detectável |
-| Pastas em `.agents/skills/` no disco | 30 | o que existe **nesta máquina** |
+| Pastas em `.agents/skills/` no disco | 9 | o que existe **nesta máquina** |
 | …dessas, com `SKILL.md` presente | 9 | o resto é pasta vazia: a skill está no lock e o conteúdo não foi baixado |
 | Versionadas (chegam em quem clona) | 9 | `git ls-files .agents/skills` |
 | …dessas, com `SKILL.md` no git | 9 | é o que um clone limpo consegue ler |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coro-solto",
-  "version": "2.0.0-alpha.35",
+  "version": "2.0.0-alpha.36",
   "license": "AGPL-3.0-only",
   "description": "CORO SOLTO: Treta Suprema (ex-CS BRASIL) — FPS de navegador estilo CS 1.6 (site Astro + jogo vanilla em Three.js)",
   "scripts": {
@@ -25,6 +25,10 @@
     "eval:ctflabels": "node tools/eval/ctf-labels-check.mjs",
     "//eval:faccao": "Toda tabela de cor indexada por facção cobre toda facção do elenco. Nasceu do dono jogando em 07/08: 'quando captura bandeira não pinta de vermelho e nem põe o brasão' — o rename Time E (06/08) trocou a letra em BRASAO e no arquivo e esqueceu COR_TIME, então bandeiraTextura('E') devolvia null e o pano saía sem cor e sem brasão. O mesmo rename passou batido em TEAM_RIM (contorno branco) e na faixa do peito (braçadeira azul). Nenhum dos três dá erro no console. `--mutar=sem-e|cor-errada` prova que morde.",
     "eval:faccao": "node tools/eval/faccao-paleta-check.mjs",
+    "//eval:submitguard": "A trava anti-fraude do banco não pode recusar partida que o jogo produz. Issue #87 (maurodesouza): 'stats não enviados: partida rápida demais pra ser verdade' numa partida de CAPTURA legítima no fy_quebrada. A cláusula exigia 80 s por rodada — número que veio do ABATE, onde a rodada é uma janela de 99 s; no CAPTURA a rodada não tem janela nenhuma. Medido: 6 de 50 partidas de captura jogadas até o fim eram recusadas, mais 4 de 50 abandonos, E a cláusula chamava _flag() antes de recusar (3 strikes escondem o jogador do ranking). FORA DO `check` DE PROPÓSITO, pelo mesmo motivo do eval:boot: o piso é LIDO de ~/db-privado (o banco não mora neste repo, .gitignore:145-148) e sem esse insumo a régua não sabe medir — e não saber custa o mesmo que estar errado, então ela fica VERMELHA em vez de passar calada. É passo de pré-deploy. SG1 (física)/SG4 (sem strike)/SG5 (default brando) rodam em segundos; SG2/SG3 sobem o motor e pedem --amostra (~10 min). `--mutante=piso80|comflag|defaultduro` provam que morde.",
+    "eval:submitguard": "node tools/eval/submit-guard-check.mjs",
+    "//eval:ctrlw": "Agachar andando pra frente não pode fechar a aba. Relato do Daniel Diniz (07/08): 'quando fica muito tempo com a tecla Control pressionada a página fecha' — no Windows, não no Mac. Não é o Control: agachar é ControlLeft/Right e andar pra frente é W, então agachar avançando É Ctrl+W (no Mac o atalho é Cmd+W, por isso não reproduzia aqui). preventDefault não alcança atalho reservado; quem resolve é a Keyboard Lock API em tela cheia, com a confirmação de saída do beforeunload como segunda camada pra Firefox/Safari. CW3 cobra o SILÊNCIO no menu — confirmação que aparece sempre vira praga e é arrancada inteira depois, levando o conserto junto. EXIGE BROWSER: fora do `check`, passo de pré-deploy. `--mutante=semlock|semprompt|promptsempre` provam que morde, e a régua morre se o mutante não casar o texto.",
+    "eval:ctrlw": "node tools/eval/ctrlw-check.mjs",
     "//eval:boot": "O JOGO ABRE? Sobe o astro dev, abre a rota `/` num Chrome de verdade e exige zero pageerror MAIS o `onclick` do #btn-jogar ligado (prova de que o main.js avaliou até o fim). Nasceu de 07/08: `_pingPresenca()` rodava no escopo do módulo antes do `const testMode`, o TDZ matava a avaliação de main.js na linha 483 e o botão JOGAR ficava INERTE — em produção, com o site respondendo 200 e o check:fast inteiro verde. EXIGE BROWSER: fica fora do `check` (que roda sem browser) e é o passo obrigatório antes de deploy. `--mutante=tdz` reproduz o defeito interceptando o main.js servido.",
     "eval:boot": "node tools/eval/boot-check.mjs",
     "eval:vm": "node tools/eval/vm-mint-audit.mjs",

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1966,7 +1966,11 @@ export class Game {
     this.keys = {};
     this._kd = e => {
       if (e.code === 'Tab') { e.preventDefault(); this._showScoreboard(true); }
-      // em pointer lock, engole atalhos do navegador (Ctrl+S/D/A/R…) — Ctrl+W o Chrome não deixa prevenir, use C pra agachar
+      /* Em pointer lock, engole os atalhos do navegador que a página PODE cancelar
+         (Ctrl+S/D/A/R…). Os que ela NÃO pode — Ctrl+W à frente de todos — não passam por
+         aqui: são atalhos reservados e o `preventDefault` é ignorado. Este comentário já
+         registrou a derrota ("use C pra agachar"); quem venceu foi `_travaAtalhos()`, com
+         a Keyboard Lock API em tela cheia, mais a confirmação de saída do main.js. */
       if ((e.ctrlKey || e.metaKey) && document.pointerLockElement) e.preventDefault();
       this.keys[e.code] = true;
       if (this.radioOpen) {
@@ -2074,6 +2078,33 @@ export class Game {
 
   _requestLock() {
     try { this.renderer.domElement.requestPointerLock()?.catch?.(() => {}); } catch {}
+    this._travaAtalhos();
+  }
+
+  /* CTRL+W FECHAVA A ABA NO MEIO DO TIROTEIO (Windows/Linux) — relato do Daniel Diniz:
+     *"quando fica muito tempo com a tecla Control pressionada a página fecha"*. Não era o
+     Control sozinho: agachar é ControlLeft/Right (`_updatePlayer`, `wantCrouch`) e andar
+     pra frente é W. **Agachar andando pra frente É Ctrl+W**, que no Windows/Linux fecha a
+     aba. No Mac o atalho é Cmd+W, e por isso não reproduzia aqui. Mesma família: Ctrl+1/2/3
+     troca de aba, e 1/2/3 é a troca de arma.
+
+     O `preventDefault` do `_kd` NÃO resolve — Ctrl+W é atalho reservado do navegador e a
+     página não consegue cancelar (o comentário lá em cima já registrava a derrota). Quem
+     resolve é a Keyboard Lock API, e ela **só funciona em tela cheia** — por isso a tela
+     cheia entra junto, pedida cedo no `startGame` (main.js), enquanto o clique ainda vale
+     como gesto do usuário.
+
+     Escape fica DE FORA da lista de propósito: travado, ele passaria a exigir toque longo
+     pra sair da tela cheia, e Escape é como se abre o menu de pausa.
+
+     Chromium só. Firefox e Safari caem na segunda camada — a confirmação de saída do
+     `beforeunload` no main.js. Régua: `tools/eval/ctrlw-check.mjs`. */
+  _travaAtalhos() {
+    if (this.testMode || !document.fullscreenElement) return;
+    try { navigator.keyboard?.lock?.(['KeyW', 'KeyT', 'KeyN', 'KeyR', 'Digit1', 'Digit2', 'Digit3'])?.catch?.(() => {}); } catch {}
+  }
+  _soltaAtalhos() {
+    try { navigator.keyboard?.unlock?.(); } catch {}
   }
   _acceptInput() {
     if (this.paused || this.state !== 'live' && this.state !== 'countdown') return false;
@@ -2589,6 +2620,11 @@ export class Game {
     if (v) this.keys = {};
     this.el.pause.classList.toggle('hidden', !v);
     if (v && document.pointerLockElement) document.exitPointerLock();
+    /* PAUSADO OS ATALHOS VOLTAM A SER DO NAVEGADOR. A trava de Ctrl+W existe pra proteger
+       quem está no tiroteio; segurar ela com o menu de pausa aberto seria sequestrar o
+       navegador de quem está justamente tentando sair. O `_requestLock` do RETOMAR
+       rearma. */
+    if (v) this._soltaAtalhos();
     // JANELA DE GUARDA (ver PAUSE_ARM_MS): o menu acabou de cair debaixo da mira, então
     // por PAUSE_ARM_MS ele não aceita clique — o tiro em voo cai no fundo e RETOMA.
     if (entrou) this.pauseArmAt = this._now() + PAUSE_ARM_MS;
@@ -6518,6 +6554,7 @@ export class Game {
     document.removeEventListener('contextmenu', this._cc);
     document.removeEventListener('pointerlockchange', this._plc);
     window.removeEventListener('blur', this._blur);
+    this._soltaAtalhos();   // fora da partida os atalhos do navegador voltam a ser do navegador
     this.el.hud.classList.add('hidden');
     this.el.pause.classList.add('hidden');
     // timer da janela de guarda: sem isso ele acorda depois da partida morta e mexe no DOM

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -528,6 +528,15 @@ async function startGame(team, charId, enemyFaction) {
   stopMenuMusic();   // música é só do menu — some (fade) quando a partida começa
   if (game) game.dispose();
   show(null);
+  /* TELA CHEIA PEDIDA AQUI, E O LUGAR É O QUE IMPORTA. Ela é pré-requisito da Keyboard
+     Lock API, que é a única coisa que impede Ctrl+W de fechar a aba no meio da partida
+     (ver `_travaAtalhos` no game.js). `requestFullscreen` exige gesto do usuário, e o
+     gesto é o clique que chamou este `startGame` — mas logo abaixo vem `await sfxReady` e
+     o `Promise.all` dos GLBs, que levam segundos e queimam a ativação transiente. Pedir
+     depois dos awaits falha calado. Aqui em cima o clique ainda vale.
+     Falhar é ACEITÁVEL: sem tela cheia não há trava de atalho, e a confirmação de saída
+     do `beforeunload` cobre o caso. Por isso nada de await e nada de erro na tela. */
+  if (!testMode) { try { document.documentElement.requestFullscreen?.()?.catch?.(() => {}); } catch {} }
   const _sp = document.getElementById('boot-splash'); if (_sp) _sp.remove();   // fluxo ?auto= pula a splash
   // LOADING REAL da partida: overlay opaco cobre TUDO enquanto os GLBs entram e o mundo
   // é construído — nada de cena parcial/"minecraft" aparecendo aos poucos
@@ -593,7 +602,10 @@ async function startGame(team, charId, enemyFaction) {
     }).then((reg) => { if (reg && reg.error) rankingBloqueado = String(reg.error); });
   }
   try { window.va?.('event', { name: 'game_start', data: { team, character: charId, map: currentMap } }); } catch {}
-  if (!testMode) { try { renderer.domElement.requestPointerLock()?.catch?.(() => {}); } catch {} }
+  /* UM FUNIL SÓ pra "assumir o input". Isto era um `requestPointerLock` duplicado do que
+     o `game._requestLock()` já fazia — e a duplicata é que deixava a trava de atalhos sem
+     lugar pra morar no começo da partida (o RETOMAR passava pelo funil, o COMEÇAR não). */
+  if (!testMode) game._requestLock();
 }
 function quitToMenu() {
   // corta a vinheta de round ao sair da partida (pedido do dono): o teto de 25 s do
@@ -606,6 +618,9 @@ function quitToMenu() {
   try { if (game) game.dispose(); } catch (e) { console.error('dispose falhou ao sair pro menu', e); }
   game = null; window.__game = null;
   if (document.pointerLockElement) document.exitPointerLock();
+  // a tela cheia era da PARTIDA (pré-requisito da trava de Ctrl+W); no menu ela não serve
+  // pra nada e prender o jogador nela é rude. O `dispose()` acima já soltou os atalhos.
+  try { if (document.fullscreenElement) document.exitFullscreen?.()?.catch?.(() => {}); } catch {}
   show('main-menu');
 }
 
@@ -1238,24 +1253,45 @@ function traduErroSubmit(msg) {
 }
 
 // stats parciais quando o jogador abandona a partida (sair pro menu / fechar aba)
+/* "Tem partida viva agora?" — uma definição só, usada pelo payload de abandono E pela
+   confirmação de saída. Eram a mesma condição escrita duas vezes, e duas cópias de uma
+   condição é como uma delas fica pra trás. */
+function emPartida() {
+  return !!game && !testMode && ['live', 'roundEnd', 'countdown'].includes(game.state);
+}
 function partialPayload() {
-  if (!game || submitted || testMode) return null;
-  if (!['live', 'roundEnd', 'countdown'].includes(game.state)) return null;
+  if (!emPartida() || submitted) return null;
   const g = game, p = g.player;
   const rounds = g.roundsWon.E + g.roundsWon.B;
   if (!p.kills && !p.deaths && !rounds && g.time < 30) return null;
   const nick = registeredNick || (nickEl.value || '').trim();
   if (!nick) return null;
+  /* `mode` VAI TAMBÉM NO ABANDONO, e é aqui que ele mais importa (issue #87): este
+     payload é o mais CURTO que o jogo produz — vencer a 1ª rodada de captura por
+     dominação e fechar a aba manda `rounds: 1` com `seconds` de poucas dezenas. Sem o
+     modo, o servidor aplicava o piso do ABATE (80 s/rodada) e recusava. */
   return {
     nick, token: getToken(), won: false, kills: p.kills, deaths: p.deaths,
     headshots: p.headshots || 0, bestStreak: g.mk.best || 0, rounds, team: g.playerTeam,
-    seconds: Math.round(g.time), character: currentChar,
+    seconds: Math.round(g.time), character: currentChar, mode: matchMode,
   };
 }
-addEventListener('beforeunload', () => {
+addEventListener('beforeunload', (e) => {
   sendTelemetry();   // aba fechando no meio da partida ainda conta como tempo jogado
   const pl = partialPayload();
   if (pl) navigator.sendBeacon('/api/submit-match', new Blob([JSON.stringify(pl)], { type: 'application/json' }));
+  /* SEGUNDA CAMADA CONTRA O CTRL+W (relato do Daniel Diniz: *"quando fica muito tempo com
+     a tecla Control pressionada a página fecha"* — é agachar + andar pra frente formando
+     Ctrl+W no Windows). A trava de atalho do game.js resolve de verdade, mas é Chromium e
+     exige tela cheia; no Firefox, no Safari e quando a tela cheia não pega, o que sobra é
+     o navegador PERGUNTAR antes de fechar. Perder a partida com um diálogo é chato;
+     perder sem aviso é o defeito.
+
+     `emPartida()` é o gate, e ele é a metade que importa: no menu nada disso arma, então
+     quem quer só fechar a aba fecha a aba. Uma confirmação que aparece sempre vira praga e
+     em duas semanas alguém arranca ela inteira — e leva o conserto junto. Cláusula CW3 da
+     `tools/eval/ctrlw-check.mjs` existe pra cobrar exatamente esse silêncio no menu. */
+  if (emPartida()) { e.preventDefault(); e.returnValue = ''; }
 });
 
 /* ---------------- fila de reenvio (rate limit do servidor) ---------------- */
@@ -1299,7 +1335,7 @@ async function recordMatchStats(s) {
       nick, token: getToken(), won: s.won, kills: s.kills, deaths: s.deaths,
       headshots: s.headshots, bestStreak: s.bestStreak,
       rounds: s.roundsP + s.roundsB, team: s.team, seconds: s.seconds || 0,
-      character: s.character,
+      character: s.character, mode: matchMode,
     });
     if (!res) submitNote('ranking global indisponível');
     else if (res.error) submitNote(traduErroSubmit(res.error));

--- a/public/js/version.js
+++ b/public/js/version.js
@@ -2,7 +2,7 @@
 // ATENÇÃO: o mesmo ?v= vai no import map do index.astro (bump dos dois lados juntos,
 // senão o navegador serve módulos JS velhos do cache — causa raiz de "correções que
 // não chegavam ao usuário" por dias).
-export const VERSION = '2.0.0-alpha.34';
+export const VERSION = '2.0.0-alpha.36';
 
 /* POR QUE 2.0.0-alpha E NÃO 3.3.0 (04/08/2026)
    O número tinha saltado de 1.15.0 para 3.1.0 sem nenhum release no meio: nenhuma das

--- a/src/pages/api/submit-match.ts
+++ b/src/pages/api/submit-match.ts
@@ -25,14 +25,21 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
   try { body = await request.json(); } catch {
     return new Response(JSON.stringify({ error: 'bad_json' }), { status: 400, headers: { 'content-type': 'application/json' } });
   }
-  const { nick, token, won, kills, deaths, headshots, bestStreak, rounds, team, seconds, character } = body ?? {};
+  const { nick, token, won, kills, deaths, headshots, bestStreak, rounds, team, seconds, character, mode } = body ?? {};
   if (typeof nick !== 'string' || typeof token !== 'string')
     return new Response(JSON.stringify({ error: 'missing_fields' }), { status: 400, headers: { 'content-type': 'application/json' } });
 
   const n = nick.slice(0, 14);
+  /* MODO DA PARTIDA (issue #87). A trava de tempo do RPC aplica um piso de segundos por
+     rodada, e o piso do ABATE (80 s, rodada de 99 s) não vale pro CAPTURA, onde a rodada
+     não tem janela de tempo — era isso que recusava partida legítima e ainda marcava o
+     jogador. Só 'rounds' e 'ctf' passam; qualquer outra coisa vira null, e null cai no
+     piso BAIXO do lado do banco (cliente com JS em cache não pode ser punido). */
+  const m = mode === 'rounds' || mode === 'ctf' ? mode : null;
   // cascata de compatibilidade: se a função do banco está desatualizada
-  // (sem p_character/p_seconds/p_rounds/p_team), grava o núcleo dos stats mesmo assim
+  // (sem p_mode/p_character/p_seconds/p_rounds/p_team), grava o núcleo dos stats mesmo assim
   const attempts = [
+    { p_nick: n, p_token: token, p_won: !!won, p_kills: kills | 0, p_deaths: deaths | 0, p_headshots: headshots | 0, p_best_streak: bestStreak | 0, p_rounds: rounds | 0, p_team: team === 'E' || team === 'P' ? 'P' : team === 'B' ? 'B' : null, p_seconds: seconds | 0, p_character: typeof character === 'string' ? character.slice(0, 20) : null, p_ip: ip, p_mode: m },
     { p_nick: n, p_token: token, p_won: !!won, p_kills: kills | 0, p_deaths: deaths | 0, p_headshots: headshots | 0, p_best_streak: bestStreak | 0, p_rounds: rounds | 0, p_team: team === 'E' || team === 'P' ? 'P' : team === 'B' ? 'B' : null, p_seconds: seconds | 0, p_character: typeof character === 'string' ? character.slice(0, 20) : null, p_ip: ip },
     { p_nick: n, p_token: token, p_won: !!won, p_kills: kills | 0, p_deaths: deaths | 0, p_headshots: headshots | 0, p_best_streak: bestStreak | 0, p_rounds: rounds | 0, p_team: team === 'E' || team === 'P' ? 'P' : team === 'B' ? 'B' : null },
     { p_nick: n, p_token: token, p_won: !!won, p_kills: kills | 0, p_deaths: deaths | 0, p_headshots: headshots | 0, p_best_streak: bestStreak | 0 },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -154,7 +154,7 @@
      Gerado por tools/eval/canarinho-icon.mjs a partir do GLB real. -->
 <link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/style.css?v=2.0.0-alpha.34">
+<link rel="stylesheet" href="/style.css?v=2.0.0-alpha.36">
 <!-- Cache-bust por módulo. Entraram nesta lista (07/08) o `graffiti_pass`/`graffiti_layout`
      e, de quebra, o `map_quebrada`/`map_decals`, que estavam faltando desde que nasceram.
      Sem o `?v=`, quem já jogou fica com o módulo em cache e vê o mapa NOVO com o grafite
@@ -163,32 +163,32 @@
 <script type="importmap" is:inline>
 { "imports": {
   "three": "./vendor/three.module.js", "three/addons/": "./vendor/addons/",
-  "./js/main.js": "./js/main.js?v=2.0.0-alpha.34",
-  "./js/game.js": "./js/game.js?v=2.0.0-alpha.34",
-  "./js/glbchars.js": "./js/glbchars.js?v=2.0.0-alpha.34",
-  "./js/weapons.js": "./js/weapons.js?v=2.0.0-alpha.34",
-  "./js/characters.js": "./js/characters.js?v=2.0.0-alpha.34",
-  "./js/audio.js": "./js/audio.js?v=2.0.0-alpha.34",
-  "./js/maps.js": "./js/maps.js?v=2.0.0-alpha.34",
-  "./js/map_brasilia.js": "./js/map_brasilia.js?v=2.0.0-alpha.34",
-  "./js/map_piscina.js": "./js/map_piscina.js?v=2.0.0-alpha.34",
-  "./js/map_havan.js": "./js/map_havan.js?v=2.0.0-alpha.34",
-  "./js/map_ferrovelho.js": "./js/map_ferrovelho.js?v=2.0.0-alpha.34",
-  "./js/map_quebrada.js": "./js/map_quebrada.js?v=2.0.0-alpha.34",
-  "./js/map_decals.js": "./js/map_decals.js?v=2.0.0-alpha.34",
-  "./js/graffiti_pass.js": "./js/graffiti_pass.js?v=2.0.0-alpha.34",
-  "./js/graffiti_layout.js": "./js/graffiti_layout.js?v=2.0.0-alpha.34",
-  "./js/mapprops.js": "./js/mapprops.js?v=2.0.0-alpha.34",
-  "./js/fparms.js": "./js/fparms.js?v=2.0.0-alpha.34",
-  "./js/vmattach.js": "./js/vmattach.js?v=2.0.0-alpha.34",
-  "./js/stylize.js": "./js/stylize.js?v=2.0.0-alpha.34",
-  "./js/bloom.js": "./js/bloom.js?v=2.0.0-alpha.34",
-  "./js/gpuparticles.js": "./js/gpuparticles.js?v=2.0.0-alpha.34",
-  "./js/textures.js": "./js/textures.js?v=2.0.0-alpha.34",
-  "./js/version.js": "./js/version.js?v=2.0.0-alpha.34",
-  "./js/i18n.js": "./js/i18n.js?v=2.0.0-alpha.34",
-  "./js/handik.js": "./js/handik.js?v=2.0.0-alpha.34",
-  "./js/springs.js": "./js/springs.js?v=2.0.0-alpha.34"
+  "./js/main.js": "./js/main.js?v=2.0.0-alpha.36",
+  "./js/game.js": "./js/game.js?v=2.0.0-alpha.36",
+  "./js/glbchars.js": "./js/glbchars.js?v=2.0.0-alpha.36",
+  "./js/weapons.js": "./js/weapons.js?v=2.0.0-alpha.36",
+  "./js/characters.js": "./js/characters.js?v=2.0.0-alpha.36",
+  "./js/audio.js": "./js/audio.js?v=2.0.0-alpha.36",
+  "./js/maps.js": "./js/maps.js?v=2.0.0-alpha.36",
+  "./js/map_brasilia.js": "./js/map_brasilia.js?v=2.0.0-alpha.36",
+  "./js/map_piscina.js": "./js/map_piscina.js?v=2.0.0-alpha.36",
+  "./js/map_havan.js": "./js/map_havan.js?v=2.0.0-alpha.36",
+  "./js/map_ferrovelho.js": "./js/map_ferrovelho.js?v=2.0.0-alpha.36",
+  "./js/map_quebrada.js": "./js/map_quebrada.js?v=2.0.0-alpha.36",
+  "./js/map_decals.js": "./js/map_decals.js?v=2.0.0-alpha.36",
+  "./js/graffiti_pass.js": "./js/graffiti_pass.js?v=2.0.0-alpha.36",
+  "./js/graffiti_layout.js": "./js/graffiti_layout.js?v=2.0.0-alpha.36",
+  "./js/mapprops.js": "./js/mapprops.js?v=2.0.0-alpha.36",
+  "./js/fparms.js": "./js/fparms.js?v=2.0.0-alpha.36",
+  "./js/vmattach.js": "./js/vmattach.js?v=2.0.0-alpha.36",
+  "./js/stylize.js": "./js/stylize.js?v=2.0.0-alpha.36",
+  "./js/bloom.js": "./js/bloom.js?v=2.0.0-alpha.36",
+  "./js/gpuparticles.js": "./js/gpuparticles.js?v=2.0.0-alpha.36",
+  "./js/textures.js": "./js/textures.js?v=2.0.0-alpha.36",
+  "./js/version.js": "./js/version.js?v=2.0.0-alpha.36",
+  "./js/i18n.js": "./js/i18n.js?v=2.0.0-alpha.36",
+  "./js/handik.js": "./js/handik.js?v=2.0.0-alpha.36",
+  "./js/springs.js": "./js/springs.js?v=2.0.0-alpha.36"
 } }
 </script>
 </head>

--- a/tools/eval/ARCH.md
+++ b/tools/eval/ARCH.md
@@ -3,14 +3,14 @@
 <!-- BEGIN:GERADO — não edite à mão, rode `npm run arch` -->
 
 > Gerado por `node tools/gen-arch.mjs`. **Não edite este bloco à mão.**
-> Versão do jogo: 2.0.0-alpha.34 · `npm run arch` para regenerar · `npm run arch:check` no CI.
+> Versão do jogo: 2.0.0-alpha.36 · `npm run arch` para regenerar · `npm run arch:check` no CI.
 
 ## Tamanho dos arquivos indexados
 
 | Arquivo | Linhas | Símbolos |
 |---|---:|---:|
-| `public/js/game.js` | 6544 | 230 |
-| `public/js/main.js` | 1676 | 153 |
+| `public/js/game.js` | 6581 | 232 |
+| `public/js/main.js` | 1712 | 154 |
 | `public/js/glbchars.js` | 812 | 60 |
 | `public/js/characters.js` | 1067 | 41 |
 | `public/js/vmattach.js` | 628 | 4 |
@@ -19,25 +19,25 @@
 
 ## Maiores métodos de `game.js` — onde o conflito mora
 
-Os 15 maiores somam **2990 linhas (46% do arquivo)**. Método grande = PR irrevisável e merge conflitante.
+Os 15 maiores somam **2990 linhas (45% do arquivo)**. Método grande = PR irrevisável e merge conflitante.
 
 | Linhas | Início | Método | |
 |---:|---:|---|---|
-| 800 | 5412 | `_updateBot()` | ⚠️ candidato a extração |
+| 800 | 5448 | `_updateBot()` | ⚠️ candidato a extração |
 | 524 | 682 | `constructor()` | 🔴 append-only |
-| 327 | 4664 | `_updatePlayer()` | ⚠️ candidato a extração |
-| 248 | 2160 | `_resetPositions()` |  |
+| 327 | 4700 | `_updatePlayer()` | ⚠️ candidato a extração |
+| 248 | 2191 | `_resetPositions()` |  |
 | 242 | 1295 | `_buildViewModels()` |  |
-| 146 | 4991 | `_updatePickups()` |  |
-| 133 | 4276 | `_botCtf()` |  |
-| 84 | 4010 | `_initCTF()` |  |
-| 83 | 2902 | `_tryShoot()` |  |
-| 77 | 3233 | `_dmgArc()` |  |
-| 76 | 4415 | `_updateCtfHud()` |  |
-| 66 | 6250 | `_updateRadar()` |  |
-| 64 | 3382 | `_wpnIcon()` |  |
-| 61 | 6448 | `update()` | 🔴 append-only |
-| 59 | 3174 | `_kill()` |  |
+| 146 | 5027 | `_updatePickups()` |  |
+| 133 | 4312 | `_botCtf()` |  |
+| 84 | 4046 | `_initCTF()` |  |
+| 83 | 2938 | `_tryShoot()` |  |
+| 77 | 3269 | `_dmgArc()` |  |
+| 76 | 4451 | `_updateCtfHud()` |  |
+| 66 | 6286 | `_updateRadar()` |  |
+| 64 | 3418 | `_wpnIcon()` |  |
+| 61 | 6484 | `update()` | 🔴 append-only |
+| 59 | 3210 | `_kill()` |  |
 
 ## Tabela de CONFLITO — resolvida para as linhas de hoje
 
@@ -47,20 +47,20 @@ faixas disjuntas simultaneamente com zero conflito de conteúdo.
 
 | Frente | Faixas em `game.js` | Arquivos exclusivos |
 |---|---|---|
-| **ARMAS / VIEWMODEL** | `16–64` `323–323` `357–366` `391–417` `518–535` `562–583` `609–612` `629–648` `1295–1921` `2684–2741` `2756–2837` `2856–3049` `3446–3469` `3517–3577` `3643–3659` | `public/js/vmattach.js` `public/js/springs.js` `public/js/weapons.js` `public/js/fparms.js` `public/js/handik.js` |
-| **BOTS / JOGABILIDADE** | `177–180` `231–231` `257–268` `655–666` `3135–3232` `3954–4009` `4172–4408` `4491–4513` `4664–4990` `5284–5301` `5383–6211` | — |
-| **MAPAS / MUNDO** | `1241–1294` `2160–2407` `4010–4149` `4991–5136` | `public/js/maps.js` `public/js/mapprops.js` `public/js/map_brasilia.js` `public/js/map_havan.js` `public/js/map_piscina.js` `public/js/map_piscinao_ramos.js` `public/js/map_ferrovelho.js` |
-| **GRÁFICOS / FX** | `1922–1964` `2620–2632` `3470–3508` `3588–3642` | `public/js/bloom.js` `public/js/textures.js` `public/js/vao.js` `public/js/stylize.js` `public/js/gpuparticles.js` |
-| **UI / HUD / MENU** | `1206–1240` `2585–2598` `2614–2619` `2633–2639` `3233–3445` `6250–6315` `6346–6447` | `public/js/main.js` `public/style.css` `src/pages/index.astro` |
+| **ARMAS / VIEWMODEL** | `16–64` `323–323` `357–366` `391–417` `518–535` `562–583` `609–612` `629–648` `1295–1921` `2720–2777` `2792–2873` `2892–3085` `3482–3505` `3553–3613` `3679–3695` | `public/js/vmattach.js` `public/js/springs.js` `public/js/weapons.js` `public/js/fparms.js` `public/js/handik.js` |
+| **BOTS / JOGABILIDADE** | `177–180` `231–231` `257–268` `655–666` `3171–3268` `3990–4045` `4208–4444` `4527–4549` `4700–5026` `5320–5337` `5419–6247` | — |
+| **MAPAS / MUNDO** | `1241–1294` `2191–2438` `4046–4185` `5027–5172` | `public/js/maps.js` `public/js/mapprops.js` `public/js/map_brasilia.js` `public/js/map_havan.js` `public/js/map_piscina.js` `public/js/map_piscinao_ramos.js` `public/js/map_ferrovelho.js` |
+| **GRÁFICOS / FX** | `1922–1964` `2656–2668` `3506–3544` `3624–3678` | `public/js/bloom.js` `public/js/textures.js` `public/js/vao.js` `public/js/stylize.js` `public/js/gpuparticles.js` |
+| **UI / HUD / MENU** | `1206–1240` `2616–2634` `2650–2655` `2669–2675` `3269–3481` `6286–6351` `6382–6483` | `public/js/main.js` `public/style.css` `src/pages/index.astro` |
 | **ÁUDIO** | — | `public/js/audio.js` |
 | **PERSONAGENS** | — | `public/js/characters.js` `public/js/glbchars.js` |
 | **SITE / BACKEND** | — | `src/` `supabase/` |
 
-**🔴 Zonas vermelhas (append-only, qualquer frente pode precisar):** `update()` 6448–6508 · `_dom()` 1206–1240 · `constructor()` 682–1205
+**🔴 Zonas vermelhas (append-only, qualquer frente pode precisar):** `update()` 6484–6544 · `_dom()` 1206–1240 · `constructor()` 682–1205
 
 Nenhuma sobreposição entre frentes — todas as faixas são disjuntas. ✓
 
-Cobertura: **3977 de 6544 linhas (61%)** do `game.js` têm dono declarado. O resto é território neutro — declare a frente mesmo assim.
+Cobertura: **3982 de 6581 linhas (61%)** do `game.js` têm dono declarado. O resto é território neutro — declare a frente mesmo assim.
 
 <details><summary><strong>Índice completo de <code>game.js</code> (todos os símbolos)</strong></summary>
 
@@ -124,145 +124,147 @@ Cobertura: **3977 de 6544 linhas (61%)** do `game.js` têm dono declarado. O res
 | 1933 | `_makeFlashTex()` | 22 |
 | 1955 | `_makeFlashCoreTex()` | 10 |
 | 1965 | `_input()` | 2 |
-| 1967 | `_kd` | 33 |
-| 2000 | `_ku` | 4 |
-| 2004 | `_md` | 34 |
-| 2038 | `_mu` | 7 |
-| 2045 | `_mm` | 14 |
-| 2059 | `_cc` | 1 |
-| 2060 | `_blur` | 1 |
-| 2061 | `_plc` | 14 |
-| 2075 | `_requestLock()` | 3 |
-| 2078 | `_acceptInput()` | 8 |
-| 2086 | `_pauseBackdrop()` | 7 |
-| 2093 | `_radioShow()` | 6 |
-| 2099 | `_radioUi()` | 8 |
-| 2107 | `_radioPick()` | 14 |
-| 2121 | `start()` | 4 |
-| 2125 | `_startRound()` | 35 |
-| 2160 | `_resetPositions()` | 248 |
-| 2408 | `_checkCtfAlvo()` | 13 |
-| 2421 | `_checkPace()` | 13 |
-| 2434 | `_endRound()` | 37 |
-| 2471 | `_fimDaPartida()` | 14 |
-| 2485 | `_endMatch()` | 36 |
-| 2521 | `_ensureDolly()` | 41 |
-| 2562 | `_tickDolly()` | 23 |
-| 2585 | `setPaused()` | 14 |
-| 2599 | `_now()` | 3 |
-| 2602 | `pauseArmed()` | 1 |
-| 2603 | `_syncPauseArm()` | 7 |
-| 2610 | `resume()` | 4 |
-| 2614 | `applySettings()` | 6 |
-| 2620 | `_applyQuality()` | 13 |
-| 2633 | `onResize()` | 7 |
-| 2640 | `_switchTeam()` | 44 |
-| 2684 | `_applyVmVisibility()` | 24 |
-| 2708 | `_ensureStaticVm()` | 34 |
-| 2742 | `_rebuildStaticVmClass()` | 14 |
-| 2756 | `_switchWeapon()` | 30 |
-| 2786 | `_deploySfx()` | 7 |
-| 2793 | `_scope()` | 17 |
-| 2810 | `_zoomFov()` | 8 |
-| 2818 | `_reloading()` | 1 |
-| 2819 | `_startReload()` | 19 |
-| 2838 | `_reloadLayers()` | 18 |
-| 2856 | `_installRecoil()` | 33 |
-| 2889 | `_shotRecoil()` | 13 |
-| 2902 | `_tryShoot()` | 83 |
-| 2985 | `_meleeHit()` | 12 |
-| 2997 | `_fireHitscan()` | 53 |
-| 3050 | `_surfaceOf()` | 27 |
-| 3077 | `_fleshImpact()` | 19 |
-| 3096 | `_fxVoice()` | 9 |
-| 3105 | `_impactSfx()` | 14 |
-| 3119 | `_tintFx()` | 16 |
-| 3135 | `_damage()` | 39 |
-| 3174 | `_kill()` | 59 |
-| 3233 | `_dmgArc()` | 77 |
-| 3310 | `_mkBanner()` | 9 |
-| 3319 | `_hitmarker()` | 15 |
-| 3334 | `_dmgNumber()` | 20 |
-| 3354 | `_feed()` | 19 |
-| 3373 | `_skullIcon()` | 9 |
-| 3382 | `_wpnIcon()` | 64 |
-| 3446 | `_tracer()` | 24 |
-| 3470 | `_puff()` | 39 |
-| 3509 | `_holeDecalMat()` | 8 |
-| 3517 | `_flash()` | 52 |
-| 3569 | `_muzzleWorld()` | 9 |
-| 3578 | `_updateDoors()` | 10 |
-| 3588 | `_updateFx()` | 55 |
-| 3643 | `_ejectCasing()` | 17 |
-| 3660 | `_makeCtfFlagTex()` | 23 |
-| 3683 | `_paintFlagSymbol()` | 9 |
-| 3692 | `_flagTexFor()` | 26 |
-| 3718 | `_legadoSimbolo()` | 8 |
-| 3726 | `_loadCtfSymbols()` | 22 |
-| 3748 | `_makeCtfZoneTex()` | 31 |
-| 3779 | `_makeSmokeTex()` | 8 |
-| 3787 | `_updateSmokeHud()` | 6 |
-| 3793 | `_spawnGrenade()` | 11 |
-| 3804 | `_throwSmoke()` | 8 |
-| 3812 | `_throwFrag()` | 10 |
-| 3822 | `_explodeFrag()` | 38 |
-| 3860 | `_corDaFumaca()` | 15 |
-| 3875 | `_popSmoke()` | 19 |
-| 3894 | `_updateGrenades()` | 27 |
-| 3921 | `_teamColor()` | 18 |
-| 3939 | `_teamInk()` | 8 |
-| 3947 | `_factionOf()` | 1 |
-| 3948 | `_voiceKey()` | 1 |
-| 3949 | `_teamName()` | 1 |
-| 3950 | `_teamTag()` | 1 |
-| 3951 | `_mirror()` | 3 |
-| 3954 | `_botSeparation()` | 56 |
-| 4010 | `_initCTF()` | 84 |
-| 4094 | `_updateCTF()` | 56 |
-| 4150 | `_ctfWin()` | 22 |
-| 4172 | `_freeYaw()` | 25 |
-| 4197 | `_pullString()` | 23 |
-| 4220 | `_walkReach()` | 18 |
-| 4238 | `_wpComp()` | 16 |
-| 4254 | `_findPathLocal()` | 22 |
-| 4276 | `_botCtf()` | 133 |
-| 4409 | `_hideCtfHud()` | 6 |
-| 4415 | `_updateCtfHud()` | 76 |
-| 4491 | `_collide()` | 23 |
-| 4514 | `_collideRot()` | 26 |
-| 4540 | `_freeSpot()` | 30 |
-| 4570 | `_retaAndavel()` | 20 |
-| 4590 | `_walkDepth()` | 16 |
-| 4606 | `_noteHit()` | 15 |
-| 4621 | `_deathFeedback()` | 43 |
-| 4664 | `_updatePlayer()` | 327 |
-| 4991 | `_updatePickups()` | 146 |
-| 5137 | `_wpnMode()` | 3 |
-| 5140 | `_botWeapon()` | 10 |
-| 5150 | `_pickupAllowed()` | 7 |
-| 5157 | `_grabPickup()` | 34 |
-| 5191 | `_assentarNoChao()` | 11 |
-| 5202 | `_dropWeapon()` | 38 |
-| 5240 | `_spawnY()` | 3 |
-| 5243 | `_pickSpawn()` | 23 |
-| 5266 | `_respawnPlayer()` | 18 |
-| 5284 | `_losClear()` | 18 |
-| 5302 | `_botCall()` | 37 |
-| 5339 | `_teamMarkTex()` | 23 |
-| 5362 | `_makeTeamMark()` | 14 |
-| 5376 | `_updateTeamMark()` | 7 |
-| 5383 | `_botEye()` | 1 |
-| 5384 | `_enemyOf()` | 8 |
-| 5392 | `_duelToken()` | 20 |
-| 5412 | `_updateBot()` | 800 |
-| 6212 | `_radarFoot()` | 38 |
-| 6250 | `_updateRadar()` | 66 |
-| 6316 | `_banner()` | 26 |
-| 6342 | `_resultadoDaRodada()` | 4 |
-| 6346 | `_showScoreboard()` | 44 |
-| 6390 | `_updateHud()` | 58 |
-| 6448 | `update()` | 61 |
-| 6509 | `dispose()` | 35 |
+| 1967 | `_kd` | 37 |
+| 2004 | `_ku` | 4 |
+| 2008 | `_md` | 34 |
+| 2042 | `_mu` | 7 |
+| 2049 | `_mm` | 14 |
+| 2063 | `_cc` | 1 |
+| 2064 | `_blur` | 1 |
+| 2065 | `_plc` | 14 |
+| 2079 | `_requestLock()` | 23 |
+| 2102 | `_travaAtalhos()` | 4 |
+| 2106 | `_soltaAtalhos()` | 3 |
+| 2109 | `_acceptInput()` | 8 |
+| 2117 | `_pauseBackdrop()` | 7 |
+| 2124 | `_radioShow()` | 6 |
+| 2130 | `_radioUi()` | 8 |
+| 2138 | `_radioPick()` | 14 |
+| 2152 | `start()` | 4 |
+| 2156 | `_startRound()` | 35 |
+| 2191 | `_resetPositions()` | 248 |
+| 2439 | `_checkCtfAlvo()` | 13 |
+| 2452 | `_checkPace()` | 13 |
+| 2465 | `_endRound()` | 37 |
+| 2502 | `_fimDaPartida()` | 14 |
+| 2516 | `_endMatch()` | 36 |
+| 2552 | `_ensureDolly()` | 41 |
+| 2593 | `_tickDolly()` | 23 |
+| 2616 | `setPaused()` | 19 |
+| 2635 | `_now()` | 3 |
+| 2638 | `pauseArmed()` | 1 |
+| 2639 | `_syncPauseArm()` | 7 |
+| 2646 | `resume()` | 4 |
+| 2650 | `applySettings()` | 6 |
+| 2656 | `_applyQuality()` | 13 |
+| 2669 | `onResize()` | 7 |
+| 2676 | `_switchTeam()` | 44 |
+| 2720 | `_applyVmVisibility()` | 24 |
+| 2744 | `_ensureStaticVm()` | 34 |
+| 2778 | `_rebuildStaticVmClass()` | 14 |
+| 2792 | `_switchWeapon()` | 30 |
+| 2822 | `_deploySfx()` | 7 |
+| 2829 | `_scope()` | 17 |
+| 2846 | `_zoomFov()` | 8 |
+| 2854 | `_reloading()` | 1 |
+| 2855 | `_startReload()` | 19 |
+| 2874 | `_reloadLayers()` | 18 |
+| 2892 | `_installRecoil()` | 33 |
+| 2925 | `_shotRecoil()` | 13 |
+| 2938 | `_tryShoot()` | 83 |
+| 3021 | `_meleeHit()` | 12 |
+| 3033 | `_fireHitscan()` | 53 |
+| 3086 | `_surfaceOf()` | 27 |
+| 3113 | `_fleshImpact()` | 19 |
+| 3132 | `_fxVoice()` | 9 |
+| 3141 | `_impactSfx()` | 14 |
+| 3155 | `_tintFx()` | 16 |
+| 3171 | `_damage()` | 39 |
+| 3210 | `_kill()` | 59 |
+| 3269 | `_dmgArc()` | 77 |
+| 3346 | `_mkBanner()` | 9 |
+| 3355 | `_hitmarker()` | 15 |
+| 3370 | `_dmgNumber()` | 20 |
+| 3390 | `_feed()` | 19 |
+| 3409 | `_skullIcon()` | 9 |
+| 3418 | `_wpnIcon()` | 64 |
+| 3482 | `_tracer()` | 24 |
+| 3506 | `_puff()` | 39 |
+| 3545 | `_holeDecalMat()` | 8 |
+| 3553 | `_flash()` | 52 |
+| 3605 | `_muzzleWorld()` | 9 |
+| 3614 | `_updateDoors()` | 10 |
+| 3624 | `_updateFx()` | 55 |
+| 3679 | `_ejectCasing()` | 17 |
+| 3696 | `_makeCtfFlagTex()` | 23 |
+| 3719 | `_paintFlagSymbol()` | 9 |
+| 3728 | `_flagTexFor()` | 26 |
+| 3754 | `_legadoSimbolo()` | 8 |
+| 3762 | `_loadCtfSymbols()` | 22 |
+| 3784 | `_makeCtfZoneTex()` | 31 |
+| 3815 | `_makeSmokeTex()` | 8 |
+| 3823 | `_updateSmokeHud()` | 6 |
+| 3829 | `_spawnGrenade()` | 11 |
+| 3840 | `_throwSmoke()` | 8 |
+| 3848 | `_throwFrag()` | 10 |
+| 3858 | `_explodeFrag()` | 38 |
+| 3896 | `_corDaFumaca()` | 15 |
+| 3911 | `_popSmoke()` | 19 |
+| 3930 | `_updateGrenades()` | 27 |
+| 3957 | `_teamColor()` | 18 |
+| 3975 | `_teamInk()` | 8 |
+| 3983 | `_factionOf()` | 1 |
+| 3984 | `_voiceKey()` | 1 |
+| 3985 | `_teamName()` | 1 |
+| 3986 | `_teamTag()` | 1 |
+| 3987 | `_mirror()` | 3 |
+| 3990 | `_botSeparation()` | 56 |
+| 4046 | `_initCTF()` | 84 |
+| 4130 | `_updateCTF()` | 56 |
+| 4186 | `_ctfWin()` | 22 |
+| 4208 | `_freeYaw()` | 25 |
+| 4233 | `_pullString()` | 23 |
+| 4256 | `_walkReach()` | 18 |
+| 4274 | `_wpComp()` | 16 |
+| 4290 | `_findPathLocal()` | 22 |
+| 4312 | `_botCtf()` | 133 |
+| 4445 | `_hideCtfHud()` | 6 |
+| 4451 | `_updateCtfHud()` | 76 |
+| 4527 | `_collide()` | 23 |
+| 4550 | `_collideRot()` | 26 |
+| 4576 | `_freeSpot()` | 30 |
+| 4606 | `_retaAndavel()` | 20 |
+| 4626 | `_walkDepth()` | 16 |
+| 4642 | `_noteHit()` | 15 |
+| 4657 | `_deathFeedback()` | 43 |
+| 4700 | `_updatePlayer()` | 327 |
+| 5027 | `_updatePickups()` | 146 |
+| 5173 | `_wpnMode()` | 3 |
+| 5176 | `_botWeapon()` | 10 |
+| 5186 | `_pickupAllowed()` | 7 |
+| 5193 | `_grabPickup()` | 34 |
+| 5227 | `_assentarNoChao()` | 11 |
+| 5238 | `_dropWeapon()` | 38 |
+| 5276 | `_spawnY()` | 3 |
+| 5279 | `_pickSpawn()` | 23 |
+| 5302 | `_respawnPlayer()` | 18 |
+| 5320 | `_losClear()` | 18 |
+| 5338 | `_botCall()` | 37 |
+| 5375 | `_teamMarkTex()` | 23 |
+| 5398 | `_makeTeamMark()` | 14 |
+| 5412 | `_updateTeamMark()` | 7 |
+| 5419 | `_botEye()` | 1 |
+| 5420 | `_enemyOf()` | 8 |
+| 5428 | `_duelToken()` | 20 |
+| 5448 | `_updateBot()` | 800 |
+| 6248 | `_radarFoot()` | 38 |
+| 6286 | `_updateRadar()` | 66 |
+| 6352 | `_banner()` | 26 |
+| 6378 | `_resultadoDaRodada()` | 4 |
+| 6382 | `_showScoreboard()` | 44 |
+| 6426 | `_updateHud()` | 58 |
+| 6484 | `update()` | 61 |
+| 6545 | `dispose()` | 36 |
 
 </details>
 

--- a/tools/eval/ctrlw-check.mjs
+++ b/tools/eval/ctrlw-check.mjs
@@ -1,0 +1,343 @@
+/* CTRLW-CHECK — agachar andando pra frente não pode fechar a aba.
+   ═══════════════════════════════════════════════════════════════════════════════════
+   O DEFEITO QUE COMPROU ESTA RÉGUA (relato do Daniel Diniz, 07/08, no LinkedIn)
+
+     *"quando fica muito tempo com a tecla Control pressionada a página fecha"*
+     *"Testei no Windows... Não acontece no Mac 🤔... testei em outros Browser e tem o
+       mesmo problema. É alguma treta do Windows mesmo"*
+
+   E não é treta do Windows: é o jogo. Agachar é `ControlLeft`/`ControlRight`
+   (`game.js`, `wantCrouch`) e andar pra frente é `W`. **Agachar andando pra frente É
+   Ctrl+W**, que no Windows e no Linux fecha a aba. No Mac o atalho é Cmd+W — por isso o
+   dono, que joga no Mac, nunca viu. Mesma família: Ctrl+1/2/3 troca de aba do navegador,
+   e 1/2/3 é a troca de arma.
+
+   O `preventDefault` que já existia no `_kd` NÃO alcança: Ctrl+W é atalho RESERVADO e a
+   página não consegue cancelar. O comentário do código registrava a derrota há tempos
+   ("Ctrl+W o Chrome não deixa prevenir, use C pra agachar") — dizer ao jogador pra não
+   usar a tecla padrão de FPS não é conserto, é aviso.
+
+   O QUE MEDE, E POR QUE SÃO TRÊS CLÁUSULAS
+
+     CW1 · a trava ARMA ao entrar na partida: `requestFullscreen` é pedido e
+           `navigator.keyboard.lock()` é chamado com uma lista que inclui `KeyW` e os
+           dígitos de troca de arma. (Keyboard Lock é a única API que captura Ctrl+W, e
+           ela só funciona em tela cheia — por isso a tela cheia é parte do conserto e
+           não enfeite.)
+     CW2 · com partida VIVA, o `beforeunload` pede confirmação. É a segunda camada, a que
+           cobre Firefox, Safari e todo caso em que a tela cheia não pegou.
+     CW3 · NO MENU o `beforeunload` fica CALADO. Esta é a cláusula que protege o conserto
+           de si mesmo: confirmação que aparece sempre vira praga, e praga alguém arranca
+           inteira em duas semanas — levando o conserto junto.
+
+   O QUE O ARNÊS FORNECE, E ISSO PRECISA ESTAR ÀS CLARAS
+     Chrome headless não concede tela cheia de verdade e pode não expor `navigator.keyboard`.
+     O arnês então SIMULA O AMBIENTE: `requestFullscreen` resolve e `document.fullscreenElement`
+     passa a responder, e `navigator.keyboard.lock` existe e grava a chamada. O que está
+     sob teste é o CÓDIGO DO JOGO (`_travaAtalhos`, `startGame`, o `beforeunload`) — não a
+     capacidade do navegador headless. A confirmação de que o Windows para de fechar a aba
+     é MANUAL e não é feita aqui: está escrita no KNOWN-BUGS.md como não verificada.
+
+   AS MUTAÇÕES QUE A DEIXAM VERMELHA (em memória, o disco não é tocado)
+     --mutante=semlock       tira a chamada de `_travaAtalhos()` do `_requestLock` -> CW1
+     --mutante=semprompt     tira o `preventDefault` do `beforeunload`             -> CW2
+     --mutante=promptsempre  arma a confirmação SEM olhar se tem partida           -> CW3
+
+   USO
+     node tools/eval/ctrlw-check.mjs
+     node tools/eval/ctrlw-check.mjs --mutante=semlock
+     BASE=https://www.csbrasil.online node tools/eval/ctrlw-check.mjs
+   ═══════════════════════════════════════════════════════════════════════════════════ */
+import { spawn, spawnSync, execSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const args = process.argv.slice(2);
+const val = (k, d) => { const v = (args.find((a) => a.startsWith(`--${k}=`)) || '').split('=')[1]; return v === undefined ? d : v; };
+const MUTANTE = val('mutante', '');
+const PORTA = Number(val('porta', 4322));
+const PACIENCIA = Number(val('paciencia', 420000));   // por passo do menu — ver o comentário no laço
+const EXTERNO = !!process.env.BASE;
+const BASE = process.env.BASE || `http://localhost:${PORTA}`;
+
+let subiuAqui = false;
+async function noAr() {
+  const fim = Date.now() + 90_000;
+  while (Date.now() < fim) {
+    try { const r = await fetch(BASE + '/robots.txt'); if (r.status) return true; } catch { /* ainda não */ }
+    await new Promise((r) => setTimeout(r, 700));
+  }
+  return false;
+}
+async function sobeServidor() {
+  if (EXTERNO) return true;
+  try { if ((await fetch(BASE + '/robots.txt')).status) return true; } catch { /* não estava no ar */ }
+  spawn('npx', ['astro', 'dev', '--port', String(PORTA)], { stdio: 'ignore', detached: false }).on('error', () => {});
+  subiuAqui = true;
+  return noAr();
+}
+function derrubaServidor() { if (subiuAqui) spawnSync('npx', ['astro', 'dev', 'stop'], { stdio: 'ignore' }); }
+
+const falhas = [];
+
+/* ═══ CW4 · A TRAVA CHAMA A API COM AS TECLAS CERTAS (node puro, sem navegador) ═══
+   Esta cláusula existe porque o caminho de navegador é caro e frágil nesta máquina (o `/`
+   em dev leva minutos pra compilar, o preload do elenco derruba o renderer headless), e
+   sem ela a pergunta mais direta — *`_travaAtalhos` chama mesmo `keyboard.lock`, e com
+   quais teclas?* — ficava sem resposta enquanto CW1 não rodasse. Aqui a classe `Game` real
+   sobe em node pelo `harness.mjs`, com `document.fullscreenElement` e `navigator.keyboard`
+   plantados, e o método de produção é chamado direto. Não prova o fluxo do `startGame`
+   (isso é a CW1); prova o contrato da trava.
+     --mutante=semtravar  troca `_travaAtalhos` por um no-op no objeto bootado -> CW4 */
+{
+  const { bootGame, MAPS, initTextures } = await import('./harness.mjs');
+  const g = bootGame(Object.keys(MAPS)[0], { textures: initTextures(), ctf: false, seed: 4242 });
+  g.testMode = false;                                   // bootGame liga testMode; a trava sai cedo com ele
+  const pedidas = [];
+  const alvo = { nada: 1 };
+  Object.defineProperty(globalThis.document, 'fullscreenElement', { get: () => alvo, configurable: true });
+  /* `globalThis.navigator` é somente-leitura no Node 22 — atribuir direto lança. Tem que
+     ser defineProperty, e o `keyboard` vai junto no objeto novo. */
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { ...(globalThis.navigator || {}), keyboard: { lock: (ks) => { pedidas.push(...(ks || [])); return Promise.resolve(); }, unlock() {} } },
+  });
+  if (MUTANTE === 'semtravar') g._travaAtalhos = () => {};
+  g._travaAtalhos();
+  const precisa = ['KeyW', 'Digit1', 'Digit2', 'Digit3'];
+  const faltam = precisa.filter((k) => !pedidas.includes(k));
+  const cw4 = pedidas.length > 0 && faltam.length === 0;
+  if (!cw4) falhas.push(`CW4 · \`_travaAtalhos\` não pediu a trava das teclas certas (pediu ${JSON.stringify(pedidas)}, faltam ${JSON.stringify(faltam)}) — Ctrl+W e Ctrl+1/2/3 continuam com o navegador`);
+  console.log('CW4 · o método de produção chama keyboard.lock com KeyW e os dígitos (node puro)');
+  console.log(`   teclas pedidas: ${JSON.stringify(pedidas)}`);
+  console.log(`   ${cw4 ? 'PASSA' : 'FALHA'}\n`);
+}
+
+let browser;
+try {
+  if (!(await sobeServidor())) {
+    console.error(`✗ CTRLW0  o site não subiu em ${BASE} (90 s de espera)`);
+    process.exit(1);
+  }
+  const gRoot = execSync('npm root -g').toString().trim();
+  const _pw = await import(pathToFileURL(`${gRoot}/playwright/index.js`).href);
+  const chromium = _pw.chromium || _pw.default?.chromium;
+  browser = await chromium.launch({
+    executablePath: process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    /* AS TRÊS FLAGS DE THROTTLING NÃO SÃO ENFEITE. Sem elas o Chrome trata a página
+       headless como plano de fundo e praticamente para o `requestAnimationFrame` — e o
+       `startGame` do main.js espera DOIS rAF antes de `hideLoading()` e do
+       `_requestLock()`. Resultado medido: o jogo chegava a `countdown`, o overlay de
+       loading nunca sumia, a trava nunca era chamada, e a régua acusava o conserto de não
+       armar algo que o `startGame` ainda nem tinha alcançado. Defeito de INSTRUMENTO, e
+       do tipo que acusa código inocente. */
+    args: ['--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--headless=new', '--mute-audio',
+      '--disable-background-timer-throttling', '--disable-renderer-backgrounding', '--disable-backgrounding-occluded-windows'],
+  });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+
+  /* ── O ARNÊS: tela cheia e Keyboard Lock que o headless não tem ───────────────── */
+  await page.addInitScript(() => {
+    window.__ctrlw = { fullscreen: 0, locks: [], unlocks: 0 };
+    let fsEl = null;
+    Object.defineProperty(document, 'fullscreenElement', { get: () => fsEl, configurable: true });
+    Element.prototype.requestFullscreen = function () { window.__ctrlw.fullscreen++; fsEl = this; return Promise.resolve(); };
+    document.exitFullscreen = function () { fsEl = null; return Promise.resolve(); };
+    Object.defineProperty(navigator, 'keyboard', {
+      configurable: true,
+      value: {
+        lock: (ks) => { window.__ctrlw.locks.push(ks || []); return Promise.resolve(); },
+        unlock: () => { window.__ctrlw.unlocks++; },
+      },
+    });
+  });
+
+  /* ── AS MUTAÇÕES, em memória (o arquivo em disco não é tocado) ──────────────────
+     `aplicou` NÃO É ZELO. Mutação que não casa o texto e segue em frente devolve VERDE, e
+     esse verde é lido como "o guarda funciona" — foi assim que um mutante de licença
+     plantou `**MIT License**` com um replace que não casava e o check passou. Aqui, se o
+     texto procurado não estiver no arquivo servido (alguém reformatou a linha, por
+     exemplo), a régua morre na hora dizendo o quê não casou. */
+  const aplicou = { ok: false, alvo: '' };
+  const troca = (glob, de, para) => {
+    aplicou.alvo = de;
+    return page.route(glob, async (rota) => {
+      const r = await rota.fetch();
+      const corpo = await r.text();
+      if (corpo.includes(de)) aplicou.ok = true;
+      await rota.fulfill({ status: 200, contentType: 'application/javascript', body: corpo.replace(de, para) });
+    });
+  };
+  if (MUTANTE === 'semlock') await troca('**/js/game.js*', 'this._travaAtalhos();', '/* mutante */');
+  if (MUTANTE === 'semprompt') await troca('**/js/main.js*', 'if (emPartida()) { e.preventDefault(); e.returnValue = \'\'; }', '/* mutante */');
+  if (MUTANTE === 'promptsempre') await troca('**/js/main.js*', 'if (emPartida()) { e.preventDefault();', 'if (true) { e.preventDefault();');
+
+  const erros = [];
+  page.on('pageerror', (e) => erros.push(e.message));
+  await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 120000 });
+  await page.waitForTimeout(3500);
+
+  console.log(`RÉGUA DO CTRL+W${MUTANTE ? `   [MUTAÇÃO: ${MUTANTE}]` : ''}   alvo ${BASE}\n`);
+  /* IMPRIME A MENSAGEM, não a contagem. "4 pageerror" mandou investigar às cegas uma vez;
+     o texto do erro diz na hora se é o jogo, o arnês ou asset que falta nesta máquina. */
+  if (erros.length) { console.log(`   AVISO · ${erros.length} pageerror no boot:`); for (const e of erros) console.log(`     ${e}`); console.log(''); }
+
+  if (MUTANTE && !aplicou.ok) {
+    console.error(`✗ CTRLW0  MUTANTE NÃO APLICOU — o texto procurado não está no arquivo servido:\n   ${aplicou.alvo}`);
+    console.error('   A régua NÃO foi validada. Verde daqui seria mentira: ajuste o trecho procurado.');
+    await browser.close(); browser = null;
+    derrubaServidor();
+    process.exit(1);
+  }
+
+  /* ── CW3 · NO MENU, SILÊNCIO ──────────────────────────────────────────────────
+     Medida ANTES de começar a partida, que é o estado de menu mais limpo que existe.
+     `dispatchEvent` de um beforeunload cancelável e a pergunta é: alguém cancelou? */
+  const sonda = () => page.evaluate(() => {
+    const ev = new Event('beforeunload', { cancelable: true });
+    window.dispatchEvent(ev);
+    return ev.defaultPrevented;
+  });
+  const noMenu = await sonda();
+  const cw3 = noMenu === false;
+  if (!cw3) falhas.push('CW3 · o beforeunload pede confirmação NO MENU — quem quer só fechar a aba é impedido, e uma confirmação que aparece sempre é arrancada inteira depois');
+  console.log('CW3 · no menu o beforeunload fica calado');
+  console.log(`   confirmação no menu: ${noMenu}   ${cw3 ? 'PASSA' : 'FALHA'}\n`);
+
+  /* ── começa uma partida DE VERDADE ────────────────────────────────────────────
+     Nada de `?debug=1&auto=1` aqui, e o motivo é o defeito: em `testMode` tanto a tela
+     cheia quanto a trava de atalhos quanto a confirmação de saída são desligadas DE
+     PROPÓSITO (as ferramentas de captura dependem disso). Medir pelo caminho de debug
+     mediria justamente os caminhos que não existem lá. */
+  /* O MENU TEM CINCO PASSOS, e descobrir isso custou uma corrida: parar no `btn-jogar`
+     deixava a régua parada em `team-select` por 180 s reportando "não começou". Cada passo
+     espera a tela seguinte APARECER antes de clicar — `waitForTimeout` fixo aqui é a
+     receita da medição intermitente (foi assim que 17 de 26 miniaturas nunca chegaram a
+     ser pedidas na régua das armas). */
+  const passos = [
+    ['nick + modo captura', () => {
+      const n = document.getElementById('nick-input');
+      if (n) { n.value = 'REGUA'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+      document.querySelector('[data-act="ctf"]')?.click();
+    }, () => !!document.getElementById('menu-setup')?.classList.contains('open')],
+    ['JOGAR', () => document.getElementById('btn-jogar')?.click(),
+      () => !document.getElementById('team-select')?.classList.contains('hidden')],
+    ['minha facção', () => document.getElementById('btn-team-e')?.click(),
+      () => document.querySelectorAll('#char-list .char-row').length > 0],
+    ['personagem', () => document.querySelector('#char-list .char-row')?.click(),
+      () => !!document.querySelector('#char-list .char-row.sel')],
+    ['confirma personagem', () => document.getElementById('char-confirm')?.click(),
+      () => !document.getElementById('team-select')?.classList.contains('hidden')],
+    ['facção inimiga', () => document.getElementById('btn-team-b')?.click(), () => true],
+  ];
+  let parouEm = null, motivoDoPasso = '';
+  for (const [nome, acao, pronto] of passos) {
+    await page.evaluate(acao);
+    /* PACIÊNCIA LONGA POR PASSO, e ela foi medida, não chutada. O passo "minha facção"
+       dispara `preloadCharacterAssets` do elenco inteiro antes de montar o `#char-list`, e
+       no headless com swiftshader isso passa de 180 s nesta máquina. Com 60 s e com 180 s
+       a régua dizia "travou no menu"; o diagnóstico impresso no fim mostrou
+       `charRows: 8` — as fileiras existiam, só chegaram depois. Timeout curto não é
+       rigor, é relatório que manda caçar defeito onde só faltava esperar.
+       `--paciencia=<ms>` para máquina mais lenta ainda. */
+    /* `polling: 250` NÃO É DETALHE — é a causa raiz de três corridas vermelhas. O padrão do
+       `waitForFunction` é pollar em `requestAnimationFrame`, e o rAF fica estrangulado
+       exatamente durante o preload pesado que estamos esperando: o predicado morria de
+       fome enquanto o `evaluate` do diagnóstico, logo depois, enxergava `charRows: 8`. A
+       régua acusava "travou no menu" com o menu montado na frente dela. */
+    /* NADA DE `.catch(() => false)` CEGO AQUI. Ele transformou uma exceção do próprio
+       Playwright em "não ficou pronto", e a régua passou três corridas dizendo "travou no
+       menu" enquanto o diagnóstico logo abaixo imprimia `charRows: 8`. Instrumento que
+       engole o próprio erro manda caçar defeito no lugar errado. */
+    const ok = await page.waitForFunction(pronto, { timeout: PACIENCIA, polling: 250 })
+      .then(() => true).catch((e) => { motivoDoPasso = e.message.split('\n')[0]; return false; });
+    if (!ok) { parouEm = nome; break; }
+  }
+
+  /* ESPERA O OVERLAY DE LOADING SUMIR, não só o `state` mudar — e a diferença custou uma
+     corrida com CW1 vermelha e o conserto certo. `game.start()` já põe o estado em
+     `countdown` lá na linha 577 do main.js; o `_requestLock()` (que é quem arma a trava)
+     só roda ~20 linhas depois, atrás de um `await` de dois `requestAnimationFrame` e do
+     `hideLoading()`. Medir no `state` media o meio do `startGame` e acusava o jogo de não
+     armar algo que ele ainda nem tinha chegado a tentar. O overlay sumindo é o sinal de
+     que o `startGame` terminou. */
+  const viva = !parouEm && await page.waitForFunction(
+    () => !!window.__game
+      && ['live', 'countdown', 'roundEnd'].includes(window.__game.state)
+      && !!document.getElementById('load-overlay')?.classList.contains('hidden'),
+    { timeout: 180000, polling: 250 },
+  ).then(() => true).catch(() => false);
+
+  if (!viva) {
+    /* Diagnóstico junto: sem ele "não começou" manda investigar às cegas. Onde o fluxo
+       parou (tela visível, se o Game existe, qual o estado) e os erros que apareceram
+       DEPOIS do clique separam "meu conserto quebrou o começo da partida" de "esta
+       máquina não tem os assets que o preload pede". */
+    /* Conta rAF em 500 ms: `overlayDeLoadingPreso + rafs 0` é assinatura de throttling do
+       arnês, não de defeito do jogo. Distinguir os dois é o que impede a régua de mandar
+       alguém caçar bug no `startGame`. */
+    const diag = await page.evaluate(async () => ({
+      temGame: !!window.__game,
+      estado: window.__game?.state ?? null,
+      rafs: await new Promise((r) => { let n = 0; const t = (() => { n++; requestAnimationFrame(t); }); requestAnimationFrame(t); setTimeout(() => r(n), 500); }),
+      loading: !document.getElementById('load-overlay')?.classList.contains('hidden'),
+      charList: !!document.getElementById('char-list'),
+      charRows: document.querySelectorAll('#char-list .char-row').length,
+      charFilhos: document.getElementById('char-list')?.children.length ?? -1,
+      classesDoPrimeiro: document.getElementById('char-list')?.children[0]?.className ?? null,
+      visiveis: [...document.querySelectorAll('.screen,[id$="-panel"],#main-menu,#loading')]
+        .filter((el) => !el.classList.contains('hidden')).map((el) => el.id).filter(Boolean),
+    })).catch(() => null);
+    falhas.push(parouEm
+      ? `CW0 · o fluxo do menu travou no passo "${parouEm}" — a régua não mediu CW1/CW2 (isto NÃO é aprovação)`
+      : 'CW0 · a partida não começou em 180 s — a régua não conseguiu medir CW1/CW2 (isto NÃO é aprovação)');
+    console.log('CW1/CW2 · NÃO MEDIDAS: a partida não subiu no headless');
+    console.log(`   passo que travou: ${parouEm || '(o menu completou; o Game é que não ficou vivo)'}`);
+    if (motivoDoPasso) console.log(`   motivo do Playwright: ${motivoDoPasso}`);
+    console.log(`   diagnóstico: ${JSON.stringify(diag)}`);
+    console.log(`   erros até aqui: ${erros.length ? erros.join(' | ') : 'nenhum'}\n`);
+  } else {
+    /* As três condições que o `_travaAtalhos` consulta vêm juntas. Sem elas, "lock: 0×" é
+       um beco: pode ser testMode, pode ser tela cheia que não pegou, pode ser o método
+       não existir. Cada uma tem conserto diferente. */
+    const est = await page.evaluate(() => ({
+      ...window.__ctrlw,
+      estado: window.__game.state,
+      testMode: !!window.__game.testMode,
+      temFullscreen: !!document.fullscreenElement,
+      temMetodo: typeof window.__game._travaAtalhos === 'function',
+      temApi: typeof navigator.keyboard?.lock === 'function',
+    }));
+
+    /* ── CW1 · A TRAVA ARMOU ─────────────────────────────────────────────────── */
+    const listas = est.locks.flat();
+    const temW = listas.includes('KeyW');
+    const temDigitos = ['Digit1', 'Digit2', 'Digit3'].every((k) => listas.includes(k));
+    const cw1 = est.fullscreen > 0 && est.locks.length > 0 && temW && temDigitos;
+    if (!cw1) falhas.push(`CW1 · a trava de atalhos não armou (tela cheia pedida ${est.fullscreen}×, keyboard.lock ${est.locks.length}×, KeyW ${temW}, dígitos ${temDigitos}) — Ctrl+W continua fechando a aba`);
+    console.log('CW1 · ao entrar na partida, tela cheia + keyboard.lock com KeyW e os dígitos');
+    console.log(`   requestFullscreen: ${est.fullscreen}×   keyboard.lock: ${est.locks.length}×   teclas: ${JSON.stringify(listas)}`);
+    console.log(`   condições do _travaAtalhos: testMode=${est.testMode} fullscreenElement=${est.temFullscreen} método=${est.temMetodo} API=${est.temApi}`);
+    console.log(`   ${cw1 ? 'PASSA' : 'FALHA'}\n`);
+
+    /* ── CW2 · CONFIRMAÇÃO COM PARTIDA VIVA ──────────────────────────────────── */
+    const naPartida = await sonda();
+    const cw2 = naPartida === true;
+    if (!cw2) falhas.push('CW2 · com partida viva o beforeunload NÃO pede confirmação — no Firefox/Safari, e sempre que a tela cheia não pegar, a aba fecha seca no meio do tiroteio');
+    console.log('CW2 · com partida viva o beforeunload pede confirmação');
+    console.log(`   estado do jogo: ${est.estado}   confirmação: ${naPartida}   ${cw2 ? 'PASSA' : 'FALHA'}\n`);
+  }
+
+  const passou = falhas.length === 0;
+  console.log(passou
+    ? '✓ CTRLW  agachar andando pra frente não fecha mais a aba — e o menu continua livre'
+    : `✗ CTRLW  ${falhas.length} reprovação(ões):`);
+  for (const f of falhas) console.log(`   ${f}`);
+  await browser.close(); browser = null;
+  derrubaServidor();
+  process.exit(passou ? 0 : 1);
+} catch (e) {
+  console.error('✗ CTRLW0  a régua não conseguiu medir:', e.message);
+  if (browser) await browser.close().catch(() => {});
+  derrubaServidor();
+  process.exit(1);
+}

--- a/tools/eval/submit-guard-check.mjs
+++ b/tools/eval/submit-guard-check.mjs
@@ -1,0 +1,362 @@
+/* SUBMIT-GUARD-CHECK — a trava anti-fraude não pode recusar partida que o jogo produz.
+   ═══════════════════════════════════════════════════════════════════════════════════
+   O DEFEITO QUE COMPROU ESTA RÉGUA (issue #87, reportada pelo maurodesouza)
+
+   Palavras dele: *"Durante uma partida no modo Captura de Bandeira, recebi a mensagem
+   `stats não enviados: partida rápida demais pra ser verdade`. A partida foi totalmente
+   legítima. Eu estava jogando no mapa Quebrada (8x8) e fiquei de AWP cobrindo a viela."*
+
+   A guarda é uma linha de SQL:
+
+     if p_rounds > 0 and p_seconds > 0 and p_seconds < p_rounds * 80 then
+       perform public._flag(p_nick);                       -- <<< e ISTO é o pior
+       raise exception 'partida rápida demais pra ser verdade';
+
+   Ela assume que **toda rodada dura pelo menos 80 s**. Essa premissa nasceu do modo
+   ABATE, onde a rodada É uma janela de tempo (`ROUND_TIME = 99`, `game.js:77`). No modo
+   CAPTURA a rodada NÃO TEM JANELA DE TEMPO NENHUMA: ela fecha por alvo de bandeiras ou
+   por dominação (`_ctfWin`, `game.js:4150`), e `CTF_ROUNDS_TO_WIN` é 2 (`game.js:114`).
+   Uma partida de captura decidida rápido é o modo funcionando, e a regra chama de fraude.
+
+   ── A PARTE QUE A ISSUE NÃO VIU, E É A GRAVE ────────────────────────────────────
+   Antes do `raise`, a cláusula chama `_flag(p_nick)`, que faz `flagged_count + 1` e, em
+   `flagged_count >= 3`, `hidden = true`. **Três partidas rápidas legítimas escondem o
+   jogador do ranking.** Regra com falso-positivo comprovado não pode alimentar contador
+   de shadowban — é disso que trata a cláusula SG4.
+
+   O QUE ESTA RÉGUA MEDE
+
+     SG1 · FÍSICA (rápida, sem simulação — é a que mora no portão)
+           O piso da regra tem que ser MENOR que o tempo mínimo FÍSICO de uma rodada de
+           captura. O mínimo físico é um limite inferior honesto: caminho ótimo em LINHA
+           RETA do spawn passando por todas as bandeiras (força bruta sobre as
+           permutações — nada de heurística, que superestimaria), a PLAYER_SPEED, mais o
+           tempo de permanência no anel com esquadrão cheio (CAP_NEUTRAL/2 por bandeira,
+           `game.js:4099-4112`). Ignora parede, obstáculo, combate e desvio — tudo que a
+           realidade cobra a mais. Nenhum humano bate esse número.
+
+     SG2 · AMOSTRA (só com --amostra: sobe o motor e joga partidas inteiras)
+           5 mapas × N sementes de CAPTURA até `state === 'matchEnd'`, e o predicado SQL
+           literal aplicado no payload que `_endMatch` REALMENTE envia (`game.js:2508`).
+
+     SG3 · ABANDONO (só com --amostra)
+           `partialPayload()` (`main.js:1294`) dispara no `beforeunload` e manda
+           `rounds` + `seconds` de partida interrompida — é a fonte mais curta que existe.
+           Vencer a 1ª rodada por dominação e fechar a aba é trivial e tem que passar.
+
+     SG4 · SEM STRIKE (rápida — leitura do SQL)
+           A cláusula de tempo não chama `_flag` / `fn_f9c`.
+
+     SG5 · DEFAULT BRANDO (rápida — leitura do SQL)
+           O ramo DEFAULT do piso é o BAIXO. Cliente com JS em cache manda payload sem
+           `mode` por dias (é o mesmo laço do `?v=`), e um default duro devolve o #87 pra
+           ele enquanto a régua fica verde pelo cliente novo.
+
+     O SQL NÃO MORA NESTE REPOSITÓRIO (`.gitignore:145-148`, decisão do dono de 06/08:
+     *"não quero revelar nossa db tão fácil"* — fonte da verdade em `~/db-privado/`).
+     SG4 e SG5 saem PULADAS quando o insumo não está na máquina, e DIZEM que saíram.
+
+   MEDIDO ANTES DO CONSERTO (07/08, `--amostra --sementes=4242,7,99,1234,555,8080,31337,2026,64,777`)
+
+     recusadas pela regra vigente (80 s/rodada) : 6 de 50 partidas de captura (12 %)
+     menor s/rodada de partida inteira          : 48,0 s   (awp_map, semente 64)
+     MENOR RODADA INDIVIDUAL                    : 31,1 s   (fy_pool_day, semente 99)
+     mapas atingidos                            : awp_map 3/10, fy_ferrovelho 2/10,
+                                                  fy_quebrada 1/10
+
+   E o simulador é o caso LENTO: o jogador dele é passivo. O Mauro estava de AWP limpando
+   a viela — jogo humano bom produz rodada mais curta que qualquer linha desta tabela.
+
+   O PALPITE ÓBVIO, MEDIDO E MORTO (lei 4 da bug-hunt)
+     *"é só baixar 80 para 40"* — rode `--piso=40 --amostra` e olhe: ainda recusa. O
+     número não vem de palpite, vem do SG1.
+
+   ATENÇÃO AO INSTRUMENTO (armadilha #7 da skill bug-hunt)
+     As simulações compartilham o cursor do `Math.random` entre mapas por causa do cache
+     preguiçoso de textura. Célula a célula NÃO é comparável entre execuções; só vale a
+     SEQUÊNCIA INTEIRA, com a mesma lista de mapas e a mesma lista de sementes.
+
+   AS MUTAÇÕES QUE A DEIXAM VERMELHA (todas executadas)
+     --mutante=piso80       devolve o piso único de 80 s -> SG1 nos 5 mapas
+                            (e SG2/SG3 com --amostra)
+     --mutante=comflag      devolve a chamada de _flag na cláusula de tempo -> SG4 nos 3
+     --mutante=defaultduro  inverte o `case` para `when p_mode='ctf' then 6 else 80`.
+                            Mesma conta pro cliente NOVO — e o cliente velho volta ao #87.
+                            -> SG5 nos 3. É a mutação mais fina das três: sem ela, dava
+                            pra "consertar" o #87 deixando metade dos jogadores no defeito.
+
+   USO
+     node tools/eval/submit-guard-check.mjs                    # SG1/SG4/SG5, segundos
+     node tools/eval/submit-guard-check.mjs --amostra          # + SG2/SG3 (lento: ~10 min)
+     node tools/eval/submit-guard-check.mjs --mutante=piso80
+     node tools/eval/submit-guard-check.mjs --piso=40 --amostra
+   ═══════════════════════════════════════════════════════════════════════════════════ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Game, MAPS, initTextures, renderer, sfx, PCHAR, seedRandom } from './harness.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RAIZ = path.resolve(HERE, '../..');
+
+const args = process.argv.slice(2);
+const val = (k, d) => { const v = (args.find((a) => a.startsWith(`--${k}=`)) || '').split('=')[1]; return v === undefined ? d : v; };
+const MUT = val('mutante', '');
+const AMOSTRA = args.includes('--amostra');
+const SEMENTES = val('sementes', '4242,7,99,1234,555,8080,31337,2026,64,777').split(',').map(Number);
+
+const falhas = [];
+
+/* ─── O PISO SOB TESTE SAI DO SQL, NÃO DE UMA CÓPIA AQUI ─────────────────────────
+   A primeira versão desta régua declarava `PISO_ABATE = 80` e `PISO_CAPTURA = 6` em JS,
+   "espelhando" o SQL. Isso é o defeito do limiar duplicado que esta base já pagou: a
+   passada de grafite aceitava 20 % de buraco e a auditoria reprovava acima de 13 %, peça
+   nascia aprovada de um lado e reprovada do outro, e dois consertos seguidos não moveram
+   o número (451 → 445 → 445). Alinhar os limiares levou de 688 para 272.
+
+   Aqui o modo de falha seria pior e mais silencioso: alguém mexe no piso do SQL, a régua
+   continua validando o número ANTIGO, e ela fica VERDE atestando um banco que recusa
+   jogador. Então o piso é LIDO da fonte que roda em produção.
+
+   Consequência aceita, e é a resposta à pergunta 4 da skill: sem o SQL na máquina esta
+   régua NÃO SABE MEDIR, e não saber custa o mesmo que estar errado — ela fica VERMELHA.
+   Por isso ela mora fora do `check` (que roda em CI sem o banco), junto do `eval:boot` e
+   do `eval:ctrlw`, como passo de pré-deploy. */
+const DB = process.env.DB_PRIVADO || path.join(process.env.HOME || '', 'db-privado');
+const FONTE = 'supabase/migrations/015_submit_guard_modo.sql';
+const semComentario = (t) => t.split('\n').map((l) => l.replace(/--.*$/, '')).join('\n');
+
+function lePisoDoSql() {
+  const p = path.join(DB, FONTE);
+  if (!fs.existsSync(p)) return null;
+  const m = semComentario(fs.readFileSync(p, 'utf8'))
+    .match(/case\s+when\s+p_mode\s*=\s*'([a-z]+)'\s*then\s*(\d+)\s*else\s*(\d+)\s*end/i);
+  return m ? { quando: m[1], explicito: Number(m[2]), padrao: Number(m[3]) } : null;
+}
+const SQL = lePisoDoSql();
+if (!SQL) {
+  console.log('RÉGUA DA TRAVA DE SUBMISSÃO\n');
+  console.log(`✗ SUBMIT-GUARD  NÃO SEI MEDIR — e não saber custa o mesmo que estar errado.`);
+  console.log(`   O piso vem do SQL, e ${path.join(DB, FONTE)} não está aqui (ou o \`case\` mudou de forma).`);
+  console.log('   O banco mora FORA deste repositório por decisão do dono (.gitignore:145-148,');
+  console.log('   06/08: "não quero revelar nossa db tão fácil"). Fonte da verdade: ~/db-privado/.');
+  console.log('   Conserto: rode na máquina do dono, ou aponte com DB_PRIVADO=/caminho/do/db-privado.');
+  process.exit(1);
+}
+/* `--piso=N` troca só o ramo DEFAULT (é o experimento de refutação do palpite óbvio:
+   `--piso=40 --amostra`). `--mutante=piso80` devolve o mundo único de antes do #87. */
+const PISO_OVERRIDE = args.some((a) => a.startsWith('--piso=')) ? Number(val('piso', 0)) : null;
+function pisoDe(modo) {
+  if (MUT === 'piso80') return 80;
+  if (modo === SQL.quando) return SQL.explicito;
+  return PISO_OVERRIDE ?? SQL.padrao;
+}
+const recusa = (rounds, seconds, modo) =>
+  rounds > 0 && seconds > 0 && seconds < rounds * pisoDe(modo);
+console.log(`RÉGUA DA TRAVA DE SUBMISSÃO${MUT ? `   [MUTAÇÃO: ${MUT}]` : ''}`);
+console.log(`piso LIDO de ${FONTE}: abate ${pisoDe('rounds')} s/rodada · captura ${pisoDe('ctf')} s/rodada`);
+if (PISO_OVERRIDE !== null) console.log(`(--piso=${PISO_OVERRIDE} sobrepõe o ramo default — experimento, não o estado real)`);
+console.log('');
+
+/* ═══ SG1 · FÍSICA ═══════════════════════════════════════════════════════════════
+   Limite inferior do tempo de uma rodada de captura. Tudo que a régua ignora (parede,
+   desvio, combate, morrer no caminho) só faz o número real SUBIR — por isso ele serve
+   como piso: se a regra recusa abaixo dele, ela recusa o impossível, e só. */
+const CAP_NEUTRAL = 2.2;      // game.js:4099
+const CREW_MAX = 2;           // game.js:4111 — esquadrão cheio dobra a velocidade de captura
+const PLAYER_SPEED = 5.35;    // game.js:268
+
+const textures = initTextures();
+const IDS = Object.keys(MAPS);
+console.log('SG1 · o piso da captura é menor que o tempo FÍSICO mínimo de rodada');
+console.log('   mapa                bandeiras  caminho(m)  corrida(s)  anel(s)  MÍNIMO(s)  piso  veredito');
+let minFisicoGlobal = Infinity;
+for (const id of IDS) {
+  seedRandom(4242);
+  const g = new Game({
+    renderer, textures, sfx, settings: { bots: 4, quality: 'low', difficulty: 'normal', sens: 1 },
+    playerCharId: PCHAR, playerTeam: 'E', playerFaction: 'E', enemyFaction: 'B',
+    nickname: 'SIM', mapId: id, ctf: true, testMode: true, onQuit() {}, onMatchEnd() {},
+  });
+  g._ensureDolly = () => {};
+  g.start ? g.start() : g._startRound();
+
+  const pts = (g.ctfPts || []).map((p) => ({ x: p.x, z: p.z }));
+  const sp = (g.world.spawns.E || [])[0] || { x: 0, z: 0 };
+  const d = (a, b) => Math.hypot(a.x - b.x, a.z - b.z);
+
+  /* Caminho ÓTIMO por força bruta (≤ 4 bandeiras = ≤ 24 permutações). Heurística do
+     vizinho mais próximo daria um caminho MAIOR que o ótimo, e um caminho maior daria um
+     mínimo maior — ou seja, um piso mais frouxo. Aqui não dá pra economizar. */
+  const perms = (a) => (a.length <= 1 ? [a] : a.flatMap((x, i) => perms([...a.slice(0, i), ...a.slice(i + 1)]).map((r) => [x, ...r])));
+  let melhor = Infinity;
+  for (const ordem of perms(pts)) {
+    let soma = d(sp, ordem[0]);
+    for (let i = 1; i < ordem.length; i++) soma += d(ordem[i - 1], ordem[i]);
+    melhor = Math.min(melhor, soma);
+  }
+  const corrida = melhor / PLAYER_SPEED;
+  const anel = pts.length * (CAP_NEUTRAL / CREW_MAX);
+  const minimo = corrida + anel;
+  minFisicoGlobal = Math.min(minFisicoGlobal, minimo);
+
+  const piso = pisoDe('ctf');
+  const ok = piso < minimo;
+  if (!ok) falhas.push(`SG1 ${id}: piso de ${piso} s/rodada é MAIOR que o mínimo físico de ${minimo.toFixed(1)} s — a regra recusa rodada que o mapa permite`);
+  console.log(`   ${id.padEnd(18)} ${String(pts.length).padStart(9)} ${melhor.toFixed(1).padStart(11)} ${corrida.toFixed(1).padStart(11)} ${anel.toFixed(1).padStart(8)} ${minimo.toFixed(1).padStart(10)} ${String(piso).padStart(5)}  ${ok ? 'ok' : 'RECUSA O POSSÍVEL'}`);
+}
+console.log(`   mínimo físico entre os mapas: ${minFisicoGlobal.toFixed(1)} s/rodada\n`);
+
+/* ═══ SG4 · A CLÁUSULA DE TEMPO NÃO DÁ STRIKE ════════════════════════════════════
+   Lê os DOIS arquivos que carregam o corpo da função: a migration viva e o espelho
+   ofuscado (que é cópia byte-a-byte com nomes trocados — se ele ficar pra trás, aplicar
+   a ofuscação um dia REINTRODUZ o defeito). */
+console.log('SG4 · a cláusula de tempo recusa sem marcar o jogador (sem _flag / fn_f9c)');
+/* TRÊS arquivos, e o terceiro é o que salva o conserto de morrer sozinho: o
+   `opcional/012` é cópia byte-a-byte do `submit_match` com os nomes trocados. Se ele
+   ficar para trás, aplicar a ofuscação um dia REINTRODUZ o #87 — e ninguém ligaria uma
+   coisa na outra seis meses depois. */
+const ALVOS = [
+  { arq: 'supabase/schema.sql', flag: '_flag' },
+  { arq: FONTE, flag: '_flag' },
+  { arq: 'supabase/opcional/012_ofuscacao_schema.sql', flag: 'fn_f9c' },
+];
+let sg4Mediu = 0;
+for (const { arq, flag } of ALVOS) {
+  const p = path.join(DB, arq);
+  if (!fs.existsSync(p)) { falhas.push(`SG4 ${arq}: arquivo não existe em ${DB} — a cláusula não tem onde ser lida`); console.log(`   ${arq.padEnd(48)} AUSENTE`); continue; }
+  /* COMENTÁRIO FORA ANTES DE PROCURAR — e isto é conserto de INSTRUMENTO, não zelo.
+     Na primeira corrida o SG4 reprovou o próprio 015: o cabeçalho dele cita o código
+     ANTIGO (`p_seconds < p_rounds * 80` e `_flag(p_nick)`) para explicar o defeito, e a
+     régua leu a explicação como se fosse a cláusula viva. Régua que não distingue código
+     de comentário mede prosa. (Limite conhecido: tira `--` em qualquer posição; nenhum
+     literal destes arquivos contém `--`, e se algum passar a conter, isto aqui é o
+     primeiro lugar a olhar.) */
+  const txt = semComentario(fs.readFileSync(p, 'utf8'));
+  /* Recorta o bloco da cláusula de tempo: do `if` que fala de p_seconds até o `end if`.
+     Ler o arquivo inteiro daria falso positivo — as OUTRAS cláusulas mantêm o strike de
+     propósito, e é certo que mantenham. */
+  const i = txt.search(/if\s+p_rounds\s*>\s*0[\s\S]{0,200}?p_seconds/);
+  if (i < 0) { falhas.push(`SG4 ${arq}: não achei a cláusula de tempo — ela foi renomeada ou sumiu`); console.log(`   ${arq.padEnd(48)} CLÁUSULA NÃO ENCONTRADA`); continue; }
+  const fim = txt.indexOf('end if;', i);
+  let bloco = txt.slice(i, fim < 0 ? i + 400 : fim);
+  if (MUT === 'comflag') bloco += `\n    perform public.${flag}(p_nick);`;   // devolve o strike
+  const temFlag = new RegExp(`\\b${flag}\\s*\\(`).test(bloco);
+  if (temFlag) falhas.push(`SG4 ${arq}: a cláusula de tempo ainda chama ${flag}() — regra com falso-positivo alimentando shadowban`);
+  sg4Mediu++;
+  console.log(`   ${arq.padEnd(48)} ${temFlag ? `CHAMA ${flag}()` : 'sem strike'}`);
+}
+console.log(`   arquivos medidos: ${sg4Mediu}/${ALVOS.length}\n`);
+
+/* ═══ SG5 · MODO DESCONHECIDO CAI NO PISO BAIXO ══════════════════════════════════
+   Quem tem JS em cache continua mandando payload SEM `mode` por dias — é o mesmo laço
+   do `?v=` (lei 8 da bug-hunt: "40 commits não chegavam ao navegador"). Se o ramo
+   DEFAULT do `case` for o piso alto, esse jogador continua sendo recusado exatamente
+   como no #87, e a régua ficaria verde porque o cliente NOVO passa. Então a cláusula não
+   pergunta "o piso está certo?", pergunta "qual ramo é o default?".
+
+   A forma tem que ser  `case when p_mode = 'rounds' then 80 else <baixo> end`
+   e NÃO                `case when p_mode = 'ctf' then 6 else 80 end`
+   As duas dão o mesmo número para cliente novo. Só a primeira protege o cliente velho. */
+console.log('SG5 · no SQL, o ramo DEFAULT do piso (modo desconhecido) é o piso BAIXO');
+for (const { arq } of ALVOS) {
+  const p = path.join(DB, arq);
+  if (!fs.existsSync(p)) continue;
+  const txt = semComentario(fs.readFileSync(p, 'utf8'));
+  let m = txt.match(/case\s+when\s+p_mode\s*=\s*'([a-z]+)'\s*then\s*(\d+)\s*else\s*(\d+)\s*end/i);
+  /* devolve o mundo em que o default é o alto: mesma conta pro cliente novo, cliente
+     velho de volta ao #87 */
+  if (m && MUT === 'defaultduro') m = [m[0], 'ctf', m[3], m[2]];
+  if (!m) { falhas.push(`SG5 ${arq}: não achei o \`case\` do piso por modo — foi reescrito de outra forma`); console.log(`   ${arq.padEnd(48)} CASE NÃO ENCONTRADO`); continue; }
+  const [, quando, alto, def] = m;
+  const ok = quando === 'rounds' && Number(def) < Number(alto);
+  if (!ok) falhas.push(`SG5 ${arq}: o default do piso é ${def} s (ramo explícito: ${quando}=${alto}) — cliente com JS em cache manda \`mode\` nulo e volta a ser recusado`);
+  console.log(`   ${arq.padEnd(48)} when ${quando}=${alto} · default ${def}  ${ok ? 'ok' : 'DEFAULT DURO'}`);
+}
+console.log('');
+
+/* ═══ SG2 / SG3 · A AMOSTRA ══════════════════════════════════════════════════════
+   Cara (~10 min). Fica atrás de --amostra para o portão continuar sendo segundos; o
+   número dela vive na entrada do KNOWN-BUGS.md com o comando que reproduz. */
+function relogioVirtual() {
+  /* `_endRound` → `_startRound` e as vinhetas passam por setTimeout. Sem relógio virtual
+     a partida nunca troca de rodada no headless e a medição mede o nada. Mesmo padrão do
+     `ui-check.mjs`. */
+  const fila = []; let t = 0;
+  const st0 = globalThis.setTimeout, ct0 = globalThis.clearTimeout;
+  globalThis.setTimeout = (fn, ms = 0) => { const h = { t: t + ms / 1000, fn }; fila.push(h); return h; };
+  globalThis.clearTimeout = (h) => { const i = fila.indexOf(h); if (i >= 0) fila.splice(i, 1); };
+  return {
+    avanca(dt) { t += dt; for (let i = fila.length - 1; i >= 0; i--) if (fila[i].t <= t) { const h = fila.splice(i, 1)[0]; try { h.fn(); } catch {} } },
+    solta() { globalThis.setTimeout = st0; globalThis.clearTimeout = ct0; },
+  };
+}
+
+if (AMOSTRA) {
+  const DT = 1 / 60, TETO = 700;
+  const linhas = [];
+  for (const id of IDS) {
+    for (const seed of SEMENTES) {
+      const relogio = relogioVirtual();
+      seedRandom(seed);
+      const g = new Game({
+        renderer, textures, sfx, settings: { bots: 4, quality: 'low', difficulty: 'normal', sens: 1 },
+        playerCharId: PCHAR, playerTeam: 'E', playerFaction: 'E', enemyFaction: 'B',
+        nickname: 'SIM', mapId: id, ctf: true, testMode: true, onQuit() {}, onMatchEnd() {},
+      });
+      g._ensureDolly = () => {};
+      /* O PAYLOAD DE PRODUÇÃO, não uma reimplementação: pendura o mesmo `onMatchEnd` que o
+         `main.js` pendura e usa o objeto que `game.js:2508` monta. Se o campo mudar de nome
+         lá, esta régua para de medir e o portão avisa — que é o comportamento certo. */
+      let payload = null;
+      g.onMatchEnd = (s) => { payload = s; };
+      g.start ? g.start() : g._startRound();
+      /* SG3: o instante do PRIMEIRO fecho de rodada é o payload de abandono mais curto que
+         o jogo consegue produzir — vencer a rodada e fechar a aba. */
+      let abandono = null;
+      const w0 = g._ctfWin.bind(g); g._ctfWin = (t) => { const r = w0(t); if (!abandono) abandono = { rounds: g.roundsWon.E + g.roundsWon.B, seconds: Math.round(g.time) }; return r; };
+      const e0 = g._endRound.bind(g); g._endRound = () => { const r = e0(); if (!abandono) abandono = { rounds: g.roundsWon.E + g.roundsWon.B, seconds: Math.round(g.time) }; return r; };
+
+      for (let i = 0; i < Math.round(TETO / DT); i++) {
+        g.update(DT); relogio.avanca(DT);
+        if (g.state === 'matchEnd') break;
+      }
+      relogio.solta();
+      const rounds = payload ? payload.roundsP + payload.roundsB : g.roundsWon.E + g.roundsWon.B;
+      const seconds = payload ? payload.seconds : null;
+      linhas.push({ id, seed, rounds, seconds, abandono });
+    }
+  }
+
+  const modo = 'ctf';
+  console.log(`SG2 · nenhuma partida de captura jogada até o fim é recusada  (modo enviado: ${modo})`);
+  console.log('   mapa                semente  rounds  seconds  s/round  veredito');
+  const recusadas = [];
+  for (const l of linhas) {
+    if (l.seconds === null) { console.log(`   ${l.id.padEnd(18)} ${String(l.seed).padStart(7)}       —        —        —  não fechou no teto`); continue; }
+    const r = recusa(l.rounds, l.seconds, modo);
+    if (r) recusadas.push(l);
+    console.log(`   ${l.id.padEnd(18)} ${String(l.seed).padStart(7)} ${String(l.rounds).padStart(7)} ${String(l.seconds).padStart(8)} ${(l.seconds / l.rounds).toFixed(1).padStart(8)}  ${r ? 'RECUSADA' : 'ok'}`);
+  }
+  const fechadas = linhas.filter((l) => l.seconds !== null);
+  if (recusadas.length) falhas.push(`SG2: ${recusadas.length} de ${fechadas.length} partidas de captura LEGÍTIMAS foram recusadas`);
+  console.log(`   recusadas: ${recusadas.length}/${fechadas.length}\n`);
+
+  console.log('SG3 · o payload de ABANDONO (vencer a rodada e fechar a aba) não é recusado');
+  const abandonos = linhas.map((l) => l.abandono).filter(Boolean);
+  const abRec = abandonos.filter((a) => recusa(a.rounds, a.seconds, modo));
+  const menor = abandonos.reduce((m, a) => (a.seconds / a.rounds < m.seconds / m.rounds ? a : m), abandonos[0] || { rounds: 1, seconds: 1e9 });
+  console.log(`   ${abandonos.length} abandonos possíveis · o mais curto: rounds ${menor.rounds}, seconds ${menor.seconds} (${(menor.seconds / menor.rounds).toFixed(1)} s/rodada)`);
+  if (abRec.length) falhas.push(`SG3: ${abRec.length} de ${abandonos.length} abandonos legítimos foram recusados`);
+  console.log(`   recusados: ${abRec.length}/${abandonos.length}\n`);
+} else {
+  console.log('SG2/SG3 · PULADAS (rodam com --amostra, ~10 min). Os números da última corrida\n            estão no KNOWN-BUGS.md, com o comando que reproduz.\n');
+}
+
+if (falhas.length) {
+  console.log(`✗ SUBMIT-GUARD  ${falhas.length} reprovação(ões):`);
+  for (const f of falhas) console.log(`   ${f}`);
+  process.exit(1);
+}
+console.log('✓ SUBMIT-GUARD  a trava recusa só o impossível, e recusa sem marcar ninguém');
+process.exit(0);


### PR DESCRIPTION
Fecha #87.

Os dois consertos compartilham `main.js`, `package.json` e `KNOWN-BUGS.md`, por isso vêm juntos.

---

## issue #87 — "partida rápida demais pra ser verdade" numa partida legítima

Relato do @maurodesouza: partida de CAPTURA no `fy_quebrada`, de AWP cobrindo a viela, recusada com *"stats não enviados"*.

A cláusula exigia **80 s por rodada**. O objetivo escrito no comentário estava certo — *"speed hack não produz partida instantânea"* — mas o NÚMERO veio do modo ABATE, onde a rodada **é** uma janela de 99 s (`game.js:77`). No CAPTURA a rodada não tem janela nenhuma: fecha por bandeiras ou por dominação (`game.js:4150`), e 2 rodadas fecham a partida. O modo herdou uma premissa que nunca foi dele.

**A parte que a issue não viu, e é a grave:** antes do `raise`, a cláusula chamava `_flag(p_nick)`, que faz `flagged_count + 1` e, em 3, `hidden = true`. A view `leaderboard` filtra por `not p.hidden`. **Três partidas rápidas legítimas escondiam o jogador do ranking, em silêncio.**

### Medido — antes × depois

`node tools/eval/submit-guard-check.mjs --amostra` (5 mapas × 10 sementes de CAPTURA jogadas até `matchEnd` no motor real)

| | piso 80 (antes) | piso por modo (depois) |
|---|---|---|
| partidas legítimas recusadas (SG2) | **6 de 50** | 0 de 50 |
| abandonos legítimos recusados (SG3) | 4 de 50 | 0 de 50 |
| mapas onde o piso recusa o fisicamente possível (SG1) | **5 de 5** | 0 de 5 |
| a cláusula dá strike (SG4) | sim | não |

E o simulador é o caso **lento** — o jogador dele é passivo. O relator estava de AWP.

### O palpite óbvio, medido e morto

*"É só baixar 80 para 40."* Rodado: **passaria na amostra** (0/50 em SG2) e mesmo assim reprova a física nos 5 mapas e recusa 4 de 50 abandonos. É por isso que a régua tem cláusula de FÍSICA além da de amostra — sozinha, a amostra teria aprovado o número errado.

### De onde vem o número novo

Tempo físico mínimo de uma rodada de captura: caminho ótimo em linha reta do spawn por todas as bandeiras (força bruta sobre as permutações), a `PLAYER_SPEED`, mais permanência no anel com esquadrão cheio. Ignora parede, desvio e combate — tudo que a realidade cobra a mais.

`awp_map` 20,1 s · `fy_pool_day` **12,3 s** · `fy_havan` 35,6 s · `fy_ferrovelho` 24,6 s · `fy_quebrada` 24,9 s

Piso do CAPTURA = **6 s/rodada**, metade do mais apertado. O do ABATE continua 80 (lá a rodada não desce de ~99 s).

### Banco

O SQL mora fora do repositório (`.gitignore:145-148`, decisão de 06/08). A migration `015_submit_guard_modo.sql` acrescenta `p_mode`, tira o `_flag` da cláusula de tempo e traz a **anistia** de quem já foi marcado — não existe coluna de auditoria dizendo qual regra gerou cada strike, então punição não atribuível vinda de regra defeituosa se desfaz inteira. `schema.sql` e o espelho `opcional/012` atualizados juntos: o espelho é cópia byte-a-byte, e ficar pra trás reintroduziria o defeito ao aplicar a ofuscação.

A rota mantém a cascata de compatibilidade: se o banco ainda não tiver `p_mode`, ela cai sozinha na chamada de 12 params sem quebrar ninguém.

---

## Ctrl+W fecha a aba no meio da partida (Windows/Linux)

Relato do Daniel Diniz: *"quando fica muito tempo com a tecla Control pressionada a página fecha"* — no Windows, não no Mac.

Não é o Control: agachar é `ControlLeft`/`ControlRight` e andar pra frente é `W`, então **agachar avançando É Ctrl+W**. No Mac o atalho é Cmd+W, por isso não reproduzia lá. Mesma família: Ctrl+1/2/3 troca de aba e 1/2/3 troca de arma. `preventDefault` não alcança atalho reservado — o comentário do `game.js` já registrava a derrota (*"use C pra agachar"*).

Duas camadas:

1. `_travaAtalhos()` com a **Keyboard Lock API** — única que captura Ctrl+W, e só funciona em tela cheia, por isso a tela cheia entra junto e é pedida cedo no `startGame`, enquanto o clique ainda vale como gesto do usuário (depois do `await sfxReady` e do `Promise.all` dos GLBs a ativação transiente já queimou).
2. O `beforeunload` pede confirmação **enquanto a partida está viva** — cobre Firefox, Safari e o caso da tela cheia não pegar.

Solta a trava no `dispose()` e no `setPaused(true)`: segurar o navegador de quem está tentando sair seria hostil.

**De quebra:** o `requestPointerLock` estava duplicado (`main.js` e `_requestLock`), e era a duplicata que deixava a trava sem lugar no COMEÇO da partida — o RETOMAR passava pelo funil, o COMEÇAR não. Agora é um funil só.

---

## Réguas novas

`tools/eval/submit-guard-check.mjs` (`npm run eval:submitguard`) e `tools/eval/ctrlw-check.mjs` (`npm run eval:ctrlw`). As duas ficam **fora do `check`**, pelo mesmo motivo do `eval:boot`: uma lê o SQL de `~/db-privado` e a outra exige navegador. Passo de pré-deploy.

O piso da primeira é **lido do SQL**, não copiado para o JS — limiar duplicado é o defeito que esta base já pagou no grafite (20 % de um lado, 13 % do outro, dois consertos sem mover o número). Sem o insumo ela fica **vermelha**, não passa calada.

| mutação | cláusula | resultado |
|---|---|---|
| `piso80` | SG1 | vermelha nos 5 mapas ✓ |
| `comflag` | SG4 | vermelha nos 3 arquivos ✓ |
| `defaultduro` | SG5 | vermelha nos 3 ✓ |
| `semtravar` | CW4 | teclas pedidas `[]`, FALHA ✓ |
| `promptsempre` | CW3 | FALHA ✓ |

A `defaultduro` é a mais fina: sem ela dava pra "consertar" o #87 deixando no defeito exatamente quem está com JS em cache.

## O que NÃO foi verificado

- **Windows + Chrome com Ctrl+W de verdade** — é o item que fecha aquele defeito. A régua mede a chamada da API, não o navegador hospedeiro. Pedir ao relator.
- **CW1 e CW2** não fecharam na máquina de desenvolvimento: o `/` em dev leva minutos pra compilar e o preload do elenco derruba o renderer headless. A régua reprova por isso e **diz que reprovou** — não conta como aprovação. CW4 e CW3 estão verdes com mutação provada.
- Firefox e Safari: espera-se o diálogo de confirmação, não o fechamento seco. Não testado.
- `audio:check` e `feet:check` vermelhos, **nenhum dos dois causado por este PR**: o primeiro é o pacote de áudio ausente na worktree, o segundo é `foot-offsets.json` já defasado na `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
