### PR TITLE
fix(release): tag anotada no bump — alpha.38 nasceu leve e o Release ficou órfão

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,16 @@ jobs:
             fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace(/VERSION = '[^']*'/, \"VERSION = '$V'\"));
           "
           node tools/gen-docs.mjs
+          # gen-arch também: o ARCH.md embute a versão do jogo no cabeçalho gerado, e sem
+          # regenerá-lo aqui o arch:check reprova o PR SEGUINTE (caso real 08/08: o bump
+          # do alpha.38 deixou o ARCH.md em alpha.37 e o PR #94 nasceu vermelho). Os dois
+          # geradores são node puro, não precisam de npm ci.
+          node tools/gen-arch.mjs
           if git ls-remote --exit-code --tags origin "$NEW" > /dev/null 2>&1; then
             echo "::error::tag $NEW já existe no remoto — bump manual necessário."
             exit 1
           fi
-          git add package.json package-lock.json public/js/version.js README.md docs/
+          git add package.json package-lock.json public/js/version.js README.md docs/ tools/eval/ARCH.md
           git commit -m "chore(release): $NEW"
           # Tag ANOTADA + push explícito do ref. `--follow-tags` só sobe tag anotada, e
           # `git tag` sem `-a` cria tag LEVE: o alpha.38 (08/08) nasceu leve, ficou só no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,14 @@ jobs:
           fi
           git add package.json package-lock.json public/js/version.js README.md docs/
           git commit -m "chore(release): $NEW"
-          git tag "$NEW"
-          git push origin main --follow-tags
+          # Tag ANOTADA + push explícito do ref. `--follow-tags` só sobe tag anotada, e
+          # `git tag` sem `-a` cria tag LEVE: o alpha.38 (08/08) nasceu leve, ficou só no
+          # runner, e o `gh release create` abortou com "tag exists locally but has not
+          # been pushed" (reproduzido em repo bare local: tag leve + --follow-tags = nada
+          # no remoto). O ls-remote final é a régua que prova que a tag subiu de verdade.
+          git tag -a "$NEW" -m "$NEW"
+          git push origin main "refs/tags/$NEW"
+          git ls-remote --exit-code origin "refs/tags/$NEW" > /dev/null
 
       - name: GitHub Release
         if: steps.guard.outputs.skip != 'true'

--- a/tools/eval/ARCH.md
+++ b/tools/eval/ARCH.md
@@ -3,7 +3,7 @@
 <!-- BEGIN:GERADO — não edite à mão, rode `npm run arch` -->
 
 > Gerado por `node tools/gen-arch.mjs`. **Não edite este bloco à mão.**
-> Versão do jogo: 2.0.0-alpha.37 · `npm run arch` para regenerar · `npm run arch:check` no CI.
+> Versão do jogo: 2.0.0-alpha.38 · `npm run arch` para regenerar · `npm run arch:check` no CI.
 
 ## Tamanho dos arquivos indexados
 


### PR DESCRIPTION
## O que aconteceu (08/08)

O primeiro run do `release.yml` falhou no passo **GitHub Release**:

```
tag v2.0.0-alpha.38 exists locally but has not been pushed to rubenmarcus/csbrasil
```

## Causa raiz (reproduzida antes do conserto)

`git tag "$NEW"` cria tag **leve**, e `git push --follow-tags` só acompanha tag **anotada**. Testado em repo bare local: tag leve + `--follow-tags` → nada no remoto; tag anotada → sobe. Resultado: o commit `chore(release): v2.0.0-alpha.38` subiu para a main, a tag morreu com o runner, e o `gh release create` abortou.

## O conserto

- `git tag -a "$NEW" -m "$NEW"` (release tag deve ser anotada de qualquer forma)
- push explícito do ref: `git push origin main "refs/tags/$NEW"` — sem depender de convenção do `--follow-tags`
- **régua pós-push**: `git ls-remote --exit-code origin "refs/tags/$NEW"` falha alto no passo de bump se a tag não subir, em vez de deixar o órfão para o passo seguinte

## Recuperação do alpha.38

O commit `76b3040 chore(release): v2.0.0-alpha.38` está na main sem tag nem Release. Depois do merge deste PR, recuperação manual (uma vez):

```bash
git tag -a v2.0.0-alpha.38 -m v2.0.0-alpha.38 76b3040
git push origin refs/tags/v2.0.0-alpha.38
gh release create v2.0.0-alpha.38 --target 76b3040 --title "CORO SOLTO v2.0.0-alpha.38" --generate-notes
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes release tags annotated, pushes the tag explicitly, verifies its remote presence, and regenerates the version-bearing architecture document during release bumps. The remaining non-blocking concern is that the branch and tag are still pushed non-atomically.
- Creates annotated release tags and explicitly pushes their refs.
- Verifies that the release tag exists remotely before creating the GitHub Release.
- Regenerates and stages `tools/eval/ARCH.md` alongside other version artifacts.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking recommendation to make the branch-and-tag push atomic so remote ref rejection cannot leave partial release state.

The annotated tag, explicit push, remote verification, and regenerated architecture document address the reported release failure; only the push transaction’s partial-update behavior remains.

**Files Needing Attention:** .github/workflows/release.yml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Fixes lightweight-tag publication and regenerates architecture metadata, but the multi-ref push can still leave partial remote state because it lacks `--atomic`. |
| tools/eval/ARCH.md | Correctly updates the generated architecture header from alpha.37 to alpha.38. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Release workflow
    participant G as Git remote
    participant R as GitHub Release
    W->>G: Check whether tag exists
    G-->>W: Tag absent
    W->>W: Commit bump and create annotated tag
    W->>G: Push main and tag (non-atomic)
    alt Both refs accepted
        G-->>W: Success
        W->>G: Verify tag
        W->>R: Create release
    else One ref rejected
        G-->>W: Partial update and failure
        Note over W,R: Workflow stops before release creation
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frelease.yml%3A90%0A**Push%20de%20refs%20n%C3%A3o%20at%C3%B4mico**%0A%0AA%20verifica%C3%A7%C3%A3o%20da%20tag%20e%20este%20push%20s%C3%A3o%20opera%C3%A7%C3%B5es%20separadas%3B%20se%20outro%20ator%20criar%20a%20mesma%20tag%20nesse%20intervalo%2C%20o%20remoto%20pode%20aceitar%20%60main%60%20e%20rejeitar%20a%20tag%2C%20interrompendo%20o%20workflow%20ap%C3%B3s%20publicar%20o%20commit%20de%20release%2C%20mas%20antes%20de%20criar%20o%20GitHub%20Release.%20Use%20um%20push%20at%C3%B4mico%20para%20que%20a%20rejei%C3%A7%C3%A3o%20de%20qualquer%20ref%20reverta%20toda%20a%20opera%C3%A7%C3%A3o.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20git%20push%20--atomic%20origin%20main%20%22refs%2Ftags%2F%24NEW%22%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rubenmarcus%2Fcsbrasil&pr=94&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/release.yml:90
**Push de refs não atômico**

A verificação da tag e este push são operações separadas; se outro ator criar a mesma tag nesse intervalo, o remoto pode aceitar `main` e rejeitar a tag, interrompendo o workflow após publicar o commit de release, mas antes de criar o GitHub Release. Use um push atômico para que a rejeição de qualquer ref reverta toda a operação.

```suggestion
          git push --atomic origin main "refs/tags/$NEW"
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): gen-arch no bump — ARCH.md..."](https://github.com/rubenmarcus/csbrasil/commit/a69d08b7eb82b1c5fd003cb51d8ea2a148afe007) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51372850)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->