### PR TITLE
fix: sanitize public API errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ algo está errado e o quality gate está verde, o defeito é do quality gate.
 
 | Zona | O que é | Tamanho medido | Regra |
 |---|---|---|---|
-| `public/` | o **jogo** | 31 arquivos `.js`, 27.053 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
+| `public/` | o **jogo** | 31 arquivos `.js`, 27.058 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
 | `src/` | o **site** | 17 páginas `.astro`, 17 rotas `/api` · Astro `^7.1.1` | framework é bem-vindo; `service_role` só no servidor |
 | `tools/` | o **arnês** | 169 scripts em `tools/eval/`, 46 em `tools/` | node puro: sobe o jogo real sem browser |
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ sem cadastro.
 
 | O que | Quanto | Onde confere |
 |---|---:|---|
-| Código do jogo | 27.053 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
+| Código do jogo | 27.058 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
 | `game.js` | **6.203** linhas | `wc -l public/js/game.js` |
-| `main.js` | 1.876 linhas | `wc -l public/js/main.js` |
+| `main.js` | 1.881 linhas | `wc -l public/js/main.js` |
 | Armas com GLB | 26 | `ls public/models/weapons/*.glb \| wc -l` |
 | GLBs de personagem | 45 | `ls public/models/characters/*.glb \| wc -l` |
 | Props em GLB | 108 | `ls public/models/props/*.glb \| wc -l` |

--- a/docs/docs/arquitetura.md
+++ b/docs/docs/arquitetura.md
@@ -63,14 +63,14 @@ Tamanho dos arquivos que o `gen-arch.mjs` indexa — bloco gerado, regenerado po
 | Arquivo | Linhas |
 |---|---:|
 | `public/js/game.js` | 6.203 |
-| `public/js/main.js` | 1.876 |
+| `public/js/main.js` | 1.881 |
 | `public/js/characters.js` | 1.066 |
 | `public/js/glbchars.js` | 837 |
 | `public/js/vmattach.js` | 628 |
 | `public/js/weapons.js` | 344 |
 | `public/js/springs.js` | 260 |
 
-Total de `public/js/`: **27.053 linhas em 31 arquivos**. O índice símbolo→linha, com a tabela de conflito, é outro bloco gerado: `tools/eval/ARCH.md` (`npm run arch`).
+Total de `public/js/`: **27.058 linhas em 31 arquivos**. O índice símbolo→linha, com a tabela de conflito, é outro bloco gerado: `tools/eval/ARCH.md` (`npm run arch`).
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: ``wc -l public/js/*.js``
 

--- a/docs/docs/comecando.md
+++ b/docs/docs/comecando.md
@@ -39,9 +39,9 @@ esta página envelhecia no primeiro commit — ver
 
 | O que | Quanto | Onde confere |
 |---|---:|---|
-| Código do jogo | 27.053 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
+| Código do jogo | 27.058 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
 | `game.js` | **6.203** linhas | `wc -l public/js/game.js` |
-| `main.js` | 1.876 linhas | `wc -l public/js/main.js` |
+| `main.js` | 1.881 linhas | `wc -l public/js/main.js` |
 | Armas com GLB | 26 | `ls public/models/weapons/*.glb \| wc -l` |
 | GLBs de personagem | 45 | `ls public/models/characters/*.glb \| wc -l` |
 | Props em GLB | 108 | `ls public/models/props/*.glb \| wc -l` |

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1461,7 +1461,7 @@ addEventListener('beforeunload', (e) => {
 const PENDING_KEY = 'awpbr_pending_submit';
 async function submitGlobal(pl) {
   const res = await api('/api/submit-match', pl);
-  if (res?.error && /aguarde/i.test(res.error)) {
+  if (res?.error === 'submit_cooldown') {
     localStorage.setItem(PENDING_KEY, JSON.stringify(pl));
     setTimeout(retryPending, 95_000);   // reenvia sozinho quando a janela abrir
   }
@@ -1472,7 +1472,7 @@ async function retryPending() {
   if (!raw) return;
   const res = await api('/api/submit-match', JSON.parse(raw));
   if (res && !res.error) localStorage.removeItem(PENDING_KEY);
-  else if (res?.error && /aguarde/i.test(res.error)) setTimeout(retryPending, 95_000);
+  else if (res?.error === 'submit_cooldown') setTimeout(retryPending, 95_000);
 }
 
 /* ---------------- local stats (espelhados pro ranking global) ----------------

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1391,7 +1391,7 @@ async function api(path, body) {
       ? { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) }
       : undefined);
     const j = await r.json().catch(() => ({}));
-    return r.ok ? j : { error: j.error || `http_${r.status}` };
+    return r.ok ? j : { error: j.error || `http_${r.status}`, message: j.message };
   } catch { return null; }
 }
 function submitNote(msg) {
@@ -1503,7 +1503,7 @@ async function recordMatchStats(s) {
       character: s.character, mode: matchMode,
     });
     if (!res) submitNote('ranking global indisponível');
-    else if (res.error) submitNote(traduErroSubmit(res.error));
+    else if (res.error) submitNote(res.message || traduErroSubmit(res.error));
   }
   renderPlayerPlate();   // XP/nível do card do menu sobem junto com os stats
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1459,9 +1459,14 @@ addEventListener('beforeunload', (e) => {
 
 /* ---------------- fila de reenvio (rate limit do servidor) ---------------- */
 const PENDING_KEY = 'awpbr_pending_submit';
+function isSubmitCooldown(res) {
+  const error = typeof res?.error === 'string' ? res.error : '';
+  const message = typeof res?.message === 'string' ? res.message : '';
+  return error === 'submit_cooldown' || /aguarde/i.test(error) || /aguarde/i.test(message);
+}
 async function submitGlobal(pl) {
   const res = await api('/api/submit-match', pl);
-  if (res?.error === 'submit_cooldown') {
+  if (isSubmitCooldown(res)) {
     localStorage.setItem(PENDING_KEY, JSON.stringify(pl));
     setTimeout(retryPending, 95_000);   // reenvia sozinho quando a janela abrir
   }
@@ -1472,7 +1477,7 @@ async function retryPending() {
   if (!raw) return;
   const res = await api('/api/submit-match', JSON.parse(raw));
   if (res && !res.error) localStorage.removeItem(PENDING_KEY);
-  else if (res?.error === 'submit_cooldown') setTimeout(retryPending, 95_000);
+  else if (isSubmitCooldown(res)) setTimeout(retryPending, 95_000);
 }
 
 /* ---------------- local stats (espelhados pro ranking global) ----------------

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,20 @@
+type ErrorPayload = {
+  error: string;
+  message?: string;
+};
+
+export function jsonError(status: number, error: string, message?: string) {
+  const body: ErrorPayload = { error };
+  if (message) body.message = message;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+export function logInternalError(scope: string, error: unknown, extra?: Record<string, unknown>) {
+  console.error(`[${scope}]`, {
+    error,
+    ...extra,
+  });
+}

--- a/src/pages/api/leaderboard.ts
+++ b/src/pages/api/leaderboard.ts
@@ -3,6 +3,7 @@ import type { APIRoute } from 'astro';
 import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
 import { RANKING_ON } from '../../lib/site';
 import { rateLimit } from '../../lib/ratelimit';
+import { jsonError, logInternalError } from '../../lib/api-error';
 
 export const prerender = false;
 
@@ -23,8 +24,10 @@ export const GET: APIRoute = async ({ request }) => {
   if (!(await rateLimit(supabaseAdmin, 'leaderboard', ip, 30, 60)))
     return new Response(JSON.stringify({ error: 'rate_limited' }), { status: 429, headers: { 'content-type': 'application/json' } });
   const { data, error } = await supabaseAdmin.from('leaderboard').select('*');
-  if (error)
-    return new Response(JSON.stringify({ error: error.message }), { status: 500, headers: { 'content-type': 'application/json' } });
+  if (error) {
+    logInternalError('api/leaderboard', error);
+    return jsonError(500, 'leaderboard_unavailable', 'ranking global indisponível no momento');
+  }
   return new Response(JSON.stringify({ players: data }), {
     headers: { 'content-type': 'application/json', 'cache-control': 'public, max-age=30' },
   });

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -5,6 +5,7 @@ import { buildSocialUrl } from '../../lib/social';
 import { isAllowedAvatarUrl } from '../../lib/safe-url';
 import { rateLimit } from '../../lib/ratelimit';
 import { isValidNick, NICK_HINT } from '../../lib/nick';
+import { jsonError, logInternalError } from '../../lib/api-error';
 
 export const prerender = false;
 
@@ -43,8 +44,10 @@ export const POST: APIRoute = async ({ request }) => {
     p_nick: nickLimpo, p_token: token,
     p_social: typeof social === 'string' ? social.slice(0, 60) : null,
   });
-  if (error)
-    return new Response(JSON.stringify({ error: error.message }), { status: 409, headers: { 'content-type': 'application/json' } });
+  if (error) {
+    logInternalError('api/register', error, { nick: nick.trim().slice(0, 14) });
+    return jsonError(409, 'register_conflict', 'não foi possível registrar este nick');
+  }
 
   // multi-redes: [{net, handle}] → [{net, url}] + social_link = primeira
   if (Array.isArray(socials) && socials.length) {

--- a/src/pages/api/submit-match.ts
+++ b/src/pages/api/submit-match.ts
@@ -4,6 +4,7 @@ import type { APIRoute } from 'astro';
 import { supabaseAdmin, NOT_CONFIGURED } from '../../lib/supabase';
 import { geoFrom } from '../../lib/geo';
 import { rateLimit } from '../../lib/ratelimit';
+import { jsonError, logInternalError } from '../../lib/api-error';
 
 export const prerender = false;
 
@@ -12,6 +13,22 @@ export const prerender = false;
 // (ver o cabeçalho de src/lib/ratelimit.ts). Agora conta no Postgres, então é
 // o mesmo limite pra todas as instâncias. O limite por NICK (1/90 s) e o teto
 // diário continuam dentro do RPC submit_match, onde sempre foram duráveis.
+
+function submitErrorPayload(message: string) {
+  if (/token inválido/i.test(message))
+    return { error: 'invalid_token', message: 'token do jogador inválido' };
+  if (/aguarde 90s/i.test(message))
+    return { error: 'submit_cooldown', message: 'aguarde antes de enviar outra partida' };
+  if (/limite diário/i.test(message))
+    return { error: 'daily_limit_reached', message: 'limite diário de partidas atingido' };
+  if (/stats implaus/i.test(message))
+    return { error: 'implausible_stats', message: 'stats rejeitadas pela validação automática' };
+  if (/fisicamente possível/i.test(message))
+    return { error: 'impossible_kills', message: 'kills além do permitido pela validação automática' };
+  if (/partida rápida demais/i.test(message))
+    return { error: 'match_too_fast', message: 'partida terminou rápido demais para validação automática' };
+  return { error: 'submit_rejected', message: 'não foi possível validar esta partida' };
+}
 
 export const POST: APIRoute = async ({ request, clientAddress }) => {
   if (!supabaseAdmin)
@@ -51,8 +68,11 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     error = r.error;
     if (!/could not find the function|schema cache/i.test(r.error.message)) break; // erro real (token, rate limit…)
   }
-  if (error)
-    return new Response(JSON.stringify({ error: error.message }), { status: 403, headers: { 'content-type': 'application/json' } });
+  if (error) {
+    logInternalError('api/submit-match', error, { nick: n });
+    const safe = submitErrorPayload(error.message || '');
+    return jsonError(403, safe.error, safe.message);
+  }
 
   // geo: presença + histórico agregado por cidade (nunca IP bruto)
   const g = geoFrom(request);

--- a/src/pages/api/submit-match.ts
+++ b/src/pages/api/submit-match.ts
@@ -17,7 +17,7 @@ export const prerender = false;
 function submitErrorPayload(message: string) {
   if (/token inválido/i.test(message))
     return { error: 'invalid_token', message: 'token do jogador inválido' };
-  if (/aguarde 90s/i.test(message))
+  if (/aguarde antes de submeter outra partida|muitas partidas seguidas/i.test(message))
     return { error: 'submit_cooldown', message: 'aguarde antes de enviar outra partida' };
   if (/limite diário/i.test(message))
     return { error: 'daily_limit_reached', message: 'limite diário de partidas atingido' };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -911,6 +911,6 @@ const IMPORTMAP = JSON.stringify({
   }
 </script>
 
-<script type="module" src="/js/main.js" is:inline></script>
+<script type="module" src={`/js/main.js?v=${V}`} is:inline></script>
 </body>
 </html>

--- a/tools/eval/ARCH.md
+++ b/tools/eval/ARCH.md
@@ -10,7 +10,7 @@
 | Arquivo | Linhas | Símbolos |
 |---|---:|---:|
 | `public/js/game.js` | 6204 | 220 |
-| `public/js/main.js` | 1877 | 164 |
+| `public/js/main.js` | 1882 | 165 |
 | `public/js/glbchars.js` | 838 | 60 |
 | `public/js/characters.js` | 1067 | 41 |
 | `public/js/vmattach.js` | 629 | 4 |


### PR DESCRIPTION
## Summary
- sanitize leaderboard, register and submit-match so they stop returning raw backend messages
- log internal Supabase failures on the server and return fixed public error codes plus safe messages
- keep the match-end UI readable by preferring the safe API message on the client

## Validation
- npm run build (Node 22.19.0 via nvm)

## Issue
- Closes #69
- https://github.com/rubenmarcus/csbrasil/issues/69

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces raw backend errors with stable public error codes and safe messages, while adding client-side handling for sanitized cooldown responses.
- Adds shared API error-response and server-logging helpers.
- Sanitizes leaderboard, registration, and match-submission failures.
- Updates match retry and user-message handling.
- Adds a version query to the main game module, but does not advance its cache version.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the unchanged asset-version key can leave clients running the old cooldown classifier and dropping completed matches.

The server and current client code fix cooldown sanitization, but main.js changed without the required version bump, so cached clients can still miss the retry behavior that the fix depends on.

**Files Needing Attention:** src/pages/index.astro, public/js/version.js
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/pages/api/submit-match.ts | Maps known RPC failures to safe public codes, including both cooldown messages from the prior report. |
| public/js/main.js | Correctly recognizes submit_cooldown in normal and queued submissions, but deployment correctness depends on clients receiving this changed module. |
| src/pages/index.astro | Adds cache-busting to the main.js entry URL while reusing the existing version key, leaving the prior stale-client failure outstanding. |
| src/lib/api-error.ts | Centralizes fixed JSON error responses and internal server-side error logging. |
| src/pages/api/register.ts | Replaces raw registration RPC errors with a fixed conflict code and safe message. |
| src/pages/api/leaderboard.ts | Replaces raw leaderboard backend errors with a stable unavailable response. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fpages%2Findex.astro%3A914%0A**Reused%20cache%20key%20drops%20retries**%0A%0AWhen%20a%20browser%20or%20edge%20cache%20already%20contains%20%60main.js%60%20under%20the%20current%20package-version%20key%2C%20this%20URL%20can%20load%20the%20old%20cooldown%20classifier%2C%20causing%20sanitized%20%60submit_cooldown%60%20responses%20to%20be%20dropped%20instead%20of%20queueing%20the%20completed%20match%20for%20retry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rubenmarcus%2Fcsbrasil&pr=97&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/pages/index.astro:914
**Reused cache key drops retries**

When a browser or edge cache already contains `main.js` under the current package-version key, this URL can load the old cooldown classifier, causing sanitized `submit_cooldown` responses to be dropped instead of queueing the completed match for retry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["chore(docs): regenera índices após rebas..."](https://github.com/rubenmarcus/csbrasil/commit/5afebe1816f2da32caf89aef65c7073fd3849de7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51396378)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->