### PR TITLE
fix: compact portrait mobile HUD

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1779,3 +1779,38 @@ html[data-ui="legacy"] .cs-vignette{
 .dd-ico{width:44px;height:17px;object-fit:contain;vertical-align:middle;margin-right:8px}
 .dd-ico-all{display:inline-flex;flex-direction:column;gap:1px;margin-right:8px}
 .dd-ico-all .dd-ico{width:38px;height:13px;margin:0}
+
+
+@media (max-width:640px) and (orientation:portrait){
+  #hud-actions{top:8px;right:8px;gap:6px}
+  #hud-actions button{width:30px;height:30px;font-size:14px}
+  #radar{top:8px;left:8px;width:104px;height:104px}
+  #radio-log{top:118px;left:8px;font-size:11px}
+  #radio-menu{top:142px;left:8px;min-width:180px;padding:8px 12px}
+  #hud-top{top:8px;left:124px;right:8px;transform:none;justify-content:space-between;gap:8px}
+  .team-score{font-size:13px;letter-spacing:1px;padding:4px 8px}
+  #hud-mid{flex:1;min-width:0}
+  #round-time{font-size:24px}
+  #rounds-row{font-size:10px;letter-spacing:1px;white-space:nowrap}
+  #killfeed{top:56px;right:8px;max-width:44vw;font-size:11px}
+  .kf-row{max-width:100%;padding:3px 8px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  #round-banner{top:22%;left:12px;right:12px}
+  #banner-title{font-size:34px;letter-spacing:3px;line-height:1.05}
+  #banner-sub{font-size:13px;letter-spacing:1px;line-height:1.25;max-width:100%}
+  #lock-hint{top:34%;left:12px;right:12px}
+  .lh-title{font-size:22px;letter-spacing:2px;line-height:1.15}
+  .lh-sub{font-size:12px;line-height:1.3;max-width:320px;margin:8px auto 0}
+  #pickup-hint{top:54%;max-width:calc(100vw - 24px);padding:7px 12px;font-size:12px;letter-spacing:1px;text-align:center}
+  #hud-bottom-left{left:12px;bottom:14px}
+  #hp-cross{font-size:18px}
+  #hp-num{font-size:30px}
+  #hp-bar{width:150px}
+  #hud-bottom-right{right:12px;bottom:14px;max-width:45vw}
+  #weapon-name{font-size:10px;letter-spacing:1px;line-height:1.2}
+  #ammo{font-size:30px}
+  .ammo-sep{margin:0 6px;font-size:20px}
+  #ammo-reserve{font-size:20px}
+  #scoreboard{width:min(94vw,560px);min-width:0;padding:16px 12px;max-height:76vh;overflow:auto}
+  #scoreboard table{font-size:12px}
+  #scoreboard th,#scoreboard td{padding-left:6px;padding-right:6px}
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1793,7 +1793,7 @@ html[data-ui="legacy"] .cs-vignette{
   #round-time{font-size:24px}
   #rounds-row{font-size:10px;letter-spacing:1px;white-space:nowrap}
   #killfeed{top:56px;right:8px;max-width:44vw;font-size:11px}
-  .kf-row{max-width:100%;padding:3px 8px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .kf-row{max-width:100%;padding:3px 8px;overflow-wrap:anywhere}
   #round-banner{top:22%;left:12px;right:12px}
   #banner-title{font-size:34px;letter-spacing:3px;line-height:1.05}
   #banner-sub{font-size:13px;letter-spacing:1px;line-height:1.25;max-width:100%}


### PR DESCRIPTION
## Summary
- add a portrait-only mobile HUD layout block in `public/style.css`
- shrink and reposition radar, top score strip and killfeed to avoid overlap on narrow screens
- tighten objective, hint and scoreboard typography so in-game text stays legible in portrait

## Validation
- npm run build (Node 22.19.0 via nvm)

## Issue
- Closes #72
- https://github.com/rubenmarcus/csbrasil/issues/72

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a portrait-only mobile layout that compacts and repositions HUD elements on narrow screens.
- Caps the portrait killfeed and allows long entry text to wrap.
- Repositions the radar, score strip, hints, banners, and bottom HUD.
- Reduces scoreboard and HUD typography for portrait viewports.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/style.css | Adds portrait-specific HUD sizing and positioning; the row-level killfeed constraint and break opportunities address the previously reported overflow. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(hud): wrap portrait killfeed rows"](https://github.com/rubenmarcus/csbrasil/commit/b2b35adbffb803cd88373d58d0d791f05ee7cff2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51397265)</sub>

<!-- /greptile_comment -->