### PR TITLE
fix(ci): gate fork preview on explicit label

### DIFF
--- a/.github/workflows/preview-bot.yml
+++ b/.github/workflows/preview-bot.yml
@@ -45,16 +45,10 @@ jobs:
 
   preview:
     needs: avaliar
-    if: contains(github.event.pull_request.labels.*.name, 'preview-autorizado') || success()
+    if: contains(github.event.pull_request.labels.*.name, 'preview-autorizado')
     runs-on: ubuntu-latest
     environment: preview-forks
     steps:
-      - name: só continua com o label
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TEM=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" --jq '[.[].name] | index("preview-autorizado") != null')
-          [ "$TEM" = "true" ] || { echo "sem label — nada a fazer"; exit 0; }
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}   # código do FORK: roda SÓ aqui, com environment gated

--- a/.github/workflows/preview-bot.yml
+++ b/.github/workflows/preview-bot.yml
@@ -23,13 +23,17 @@ jobs:
   avaliar:
     if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    outputs:
+      preview_autorizado: ${{ steps.decide.outputs.preview_autorizado }}
     steps:
       - name: avalia o diff pela API (sem checkout do fork)
+        id: decide
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          echo "preview_autorizado=false" >> "$GITHUB_OUTPUT"
           gh api "repos/$REPO/pulls/$PR/files" --paginate \
             --jq '.[] | .filename + " +" + (.additions|tostring) + " -" + (.deletions|tostring)' > /tmp/arquivos.txt
           cat /tmp/arquivos.txt
@@ -41,21 +45,34 @@ jobs:
             exit 0
           fi
           gh pr edit "$PR" --repo "$REPO" --add-label "preview-autorizado"
+          echo "preview_autorizado=true" >> "$GITHUB_OUTPUT"
           gh pr comment "$PR" --repo "$REPO" --body "🤖 **cs-brasil-ai-bot**: diff de baixo risco ($TOTAL linhas, sem arquivo sensível) — label \`preview-autorizado\` aplicado; o preview sobe no job seguinte. Regras: CONTRIBUTING.md."
 
   preview:
     needs: avaliar
-    if: contains(github.event.pull_request.labels.*.name, 'preview-autorizado')
+    if: needs.avaliar.outputs.preview_autorizado == 'true'
     runs-on: ubuntu-latest
     environment: preview-forks
     steps:
+      - name: confirma que o label ainda existe
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TEM=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" --jq '[.[].name] | index("preview-autorizado") != null')
+          echo "preview_autorizado_atual=$TEM" >> "$GITHUB_OUTPUT"
+          [ "$TEM" = "true" ] || { echo "label removido — preview cancelado"; exit 0; }
       - uses: actions/checkout@v4
+        if: steps.gate.outputs.preview_autorizado_atual == 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha }}   # código do FORK: roda SÓ aqui, com environment gated
       - uses: actions/setup-node@v4
+        if: steps.gate.outputs.preview_autorizado_atual == 'true'
         with: { node-version: 22 }
       - run: npm i -g vercel@latest
+        if: steps.gate.outputs.preview_autorizado_atual == 'true'
       - name: preview na Vercel
+        if: steps.gate.outputs.preview_autorizado_atual == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
Corrige o preview-bot para PRs de fork: o job de preview não roda mais sem o label `preview-autorizado`. Isso evita vermelho espúrio em PRs como #118 e #119, onde o código passa localmente mas o preview automático não deveria sequer disparar.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The workflow now carries the evaluator’s authorization decision into the preview job and verifies the label’s current state before executing the fork preview.
- Exposes `preview_autorizado` as an output of the evaluation job.
- Schedules preview only when the current evaluation authorizes it.
- Skips checkout, setup, and deployment if authorization is subsequently revoked.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/preview-bot.yml | Propagates the fresh evaluation result and adds a live label check, resolving both stale-label authorization behaviors reported previously. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E as avaliar job
    participant G as GitHub labels API
    participant P as preview job
    participant V as Vercel
    E->>E: Evaluate fork diff
    alt Diff authorized
        E->>G: Add preview-autorizado
        E-->>P: "preview_autorizado=true"
        P->>G: Read current labels
        alt Label remains present
            P->>P: Checkout fork SHA
            P->>V: Build and deploy preview
        else Label was removed
            P-->>P: Skip preview steps
        end
    else Diff rejected
        E-->>P: "preview_autorizado=false"
        P-->>P: Job skipped
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): recheck preview label before fo..."](https://github.com/rubenmarcus/csbrasil/commit/8ded5d89b0ed2fbda4a93aa0badc6e77d3ec04fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51542620)</sub>

<!-- /greptile_comment -->