### PR TITLE
fix(ci): protege previews e reduz comentários narrativos

### DIFF
--- a/.claude/skills/bug-hunt/SKILL.md
+++ b/.claude/skills/bug-hunt/SKILL.md
@@ -243,8 +243,9 @@ não é motivo para forçar um conserto. São três casos, e cada um tem saída 
 **3 · Refute o palpite óbvio.** Meça-o e escreva o resultado negativo na entrada. É o passo que
 mais economiza tempo e o mais pulado.
 
-**4 · Conserte na causa, não no sintoma.** Comentário em português no código com a causa raiz e
-o número medido — é o padrão desta base e é o que sobrevive ao próximo handoff.
+**4 · Conserte na causa, não no sintoma.** O antes/depois e a causa raiz ficam na entrada do
+`KNOWN-BUGS.md`. No código, prefira nomes claros; se uma invariante não couber neles, use no
+máximo duas linhas e aponte para a entrada, sem copiar a investigação.
 
 **5 · Mute a régua.** Reintroduza o defeito e exija vermelho na cláusula certa. Sem isso o passo
 2 não vale.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
@@ -24,6 +24,8 @@ jobs:
         run: python3 -m py_compile scripts/ci/*.py
       - name: Bash scripts syntax
         run: bash -n scripts/*.sh
+      - name: Fronteira de confiança dos workflows
+        run: python3 scripts/ci/workflow_security_check.py --selftest
       - name: Syntax check do jogo (public/js)
         run: npm run syntax
 
@@ -31,6 +33,8 @@ jobs:
       # mão ele desatualiza no primeiro commit, e uma tabela de conflito com
       # linha errada é pior que não ter tabela: dois agentes acham que estão em
       # regiões diferentes e não estão.
+      - name: Documentação gerada está em dia
+        run: npm run docs:check
       - name: ARCH.md gerado está em dia
         run: npm run arch:check
       - name: Manifesto de wallpapers está em dia
@@ -38,19 +42,11 @@ jobs:
       - name: Texto público sem travessão
         run: npm run travessao:check
 
-      # ── PORTÃO DE QUALIDADE ───────────────────────────────────────────────
-      # Os quatro arneses abaixo rodam em NODE PURO (sem Chrome/SwiftShader) e
-      # terminam em segundos; todos saem com código 1 em falha crítica, então o
-      # `run` já reprova o job sozinho — não precisa de `if`/parser de saída.
-      # DEPENDÊNCIA DE ARTEFATO: invariants.mjs regera vm_kick_sim.json sozinho
-      # (0,08 s) e LÊ tools/eval/vm_mint_audit.json, que precisa estar VERSIONADO —
-      # sem ele VM1..VM6/VM9/VM10 viram PULADAS, que é portão verde por ausência de
-      # dado. `git ls-files tools/eval/vm_mint_audit.json` tem que devolver o arquivo.
-      # A invariante AUD1 cobre o outro lado: o JSON versionado ter ficado velho.
-      - name: Invariantes (portão — falha crítica reprova o PR)
-        run: node tools/eval/invariants.mjs
+      # O auditor de VM escreve o JSON consumido pelas invariantes; a ordem é contrato.
       - name: Enquadramento do viewmodel por arma (26 armas, GLB real)
         run: node tools/eval/vm-mint-audit.mjs
+      - name: Invariantes (portão — falha crítica reprova o PR)
+        run: node tools/eval/invariants.mjs
       - name: Coice do viewmodel (near plane + pitch em rajada)
         run: node tools/eval/vm-kick-sim.mjs
       - name: Navegação dos bots (60 s × 5 mapas, sementes fixas)
@@ -70,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.13'
       - name: Check Signed-off-by
@@ -90,7 +86,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Extrair notas do CHANGELOG
         run: |
           TAG="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/crash-fix.yml
+++ b/.github/workflows/crash-fix.yml
@@ -40,8 +40,8 @@ jobs:
       # no env DO JOB: `if` de step não enxerga o env do próprio step
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: 22 }
 
       - name: classifica o crash

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: 22 }
-      - run: npm i -g vercel@latest
+      - run: npm i -g vercel@58.9.0
       - name: build e deploy de produção
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -14,7 +14,7 @@ jobs:
   versao-bumpada:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: package.json e version.js têm que concordar
         run: |
           HEAD=$(node -pe 'require("./package.json").version')

--- a/.github/workflows/preview-bot.yml
+++ b/.github/workflows/preview-bot.yml
@@ -1,19 +1,10 @@
-# cs-brasil-ai-bot — PREVIEW SEGURO PARA PR DE FORK (pedido do dono, 06/08).
-#
-# POR QUE EXISTE: a Vercel não builda PR de fork (certo — build de estranho com segredo é
-# furo). Este bot AVALIA o diff SEM fazer checkout do código do fork (só a API de diff) e,
-# se o PR for de baixo risco, aplica o label `preview-autorizado` + comenta o veredito.
-# O deploy do preview roda num segundo job, GATED pelo label e pelo environment
-# `preview-forks` (proteja com required reviewer se quiser mão humana no meio).
-#
-# SEGURANÇA (não relaxar): o job de avaliação usa pull_request_target e NUNCA pode dar
-# checkout no código do PR nem rodar nada dele. A heurística é ALLOWLIST: qualquer toque
-# em workflow/scripts/deps/api reprova. O hook de IA (avaliar o conteúdo com um modelo)
-# entra depois no mesmo lugar — a decisão continua sendo só um label.
+# Código de fork só recebe segredos depois de um mantenedor aprovar o SHA atual.
+# Todo push revoga o label; a próxima revisão precisa aplicá-lo novamente.
 name: preview-bot
+
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   pull-requests: write
@@ -21,65 +12,79 @@ permissions:
 
 jobs:
   avaliar:
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.event.action != 'labeled'
     runs-on: ubuntu-latest
-    outputs:
-      preview_autorizado: ${{ steps.decide.outputs.preview_autorizado }}
     steps:
-      - name: avalia o diff pela API (sem checkout do fork)
-        id: decide
+      - name: revoga aprovação quando o SHA muda
+        if: github.event.action == 'synchronize'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR" --repo "$REPO" --remove-label "preview-autorizado" 2>/dev/null || true
+
+      - name: classifica o diff sem executar código do fork
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          echo "preview_autorizado=false" >> "$GITHUB_OUTPUT"
           gh api "repos/$REPO/pulls/$PR/files" --paginate \
             --jq '.[] | .filename + " +" + (.additions|tostring) + " -" + (.deletions|tostring)' > /tmp/arquivos.txt
-          cat /tmp/arquivos.txt
           TOTAL=$(gh api "repos/$REPO/pulls/$PR" --jq '.additions + .deletions')
           PERIGO=$(grep -cE '^\.github/|^scripts/|^package(-lock)?\.json|^vercel\.json|^src/pages/api/|^supabase/|^\.env' /tmp/arquivos.txt || true)
-          echo "linhas=$TOTAL arquivos_sensiveis=$PERIGO"
           if [ "$PERIGO" -gt 0 ] || [ "$TOTAL" -gt 3000 ]; then
-            gh pr comment "$PR" --repo "$REPO" --body "🤖 **cs-brasil-ai-bot**: este PR toca área sensível (workflows/deps/api/deploy) ou é grande demais ($TOTAL linhas) — preview automático NEGADO. Um mantenedor pode liberar aplicando o label \`preview-autorizado\` manualmente."
-            exit 0
+            TEXTO="área sensível ou diff grande; revisão manual obrigatória"
+          else
+            TEXTO="candidato a preview; um mantenedor deve revisar o SHA e aplicar o label"
           fi
-          gh pr edit "$PR" --repo "$REPO" --add-label "preview-autorizado"
-          echo "preview_autorizado=true" >> "$GITHUB_OUTPUT"
-          gh pr comment "$PR" --repo "$REPO" --body "🤖 **cs-brasil-ai-bot**: diff de baixo risco ($TOTAL linhas, sem arquivo sensível) — label \`preview-autorizado\` aplicado; o preview sobe no job seguinte. Regras: CONTRIBUTING.md."
+          gh pr comment "$PR" --repo "$REPO" --body "🤖 **cs-brasil-ai-bot**: $TEXTO \`preview-autorizado\`."
 
   preview:
-    needs: avaliar
-    if: needs.avaliar.outputs.preview_autorizado == 'true'
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'preview-autorizado'
     runs-on: ubuntu-latest
     environment: preview-forks
     steps:
-      - name: confirma que o label ainda existe
-        id: gate
+      - name: confirma mantenedor, label e SHA aprovado
         env:
           GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          EVENT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          TEM=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" --jq '[.[].name] | index("preview-autorizado") != null')
-          echo "preview_autorizado_atual=$TEM" >> "$GITHUB_OUTPUT"
-          [ "$TEM" = "true" ] || { echo "label removido — preview cancelado"; exit 0; }
-      - uses: actions/checkout@v4
-        if: steps.gate.outputs.preview_autorizado_atual == 'true'
+          PERMISSION=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq .permission 2>/dev/null || echo none)
+          case "$PERMISSION" in admin|maintain|write) ;; *) echo "ator sem permissão de mantenedor"; exit 1 ;; esac
+          API_SHA=$(gh api "repos/$REPO/pulls/$PR" --jq .head.sha)
+          [ "$API_SHA" = "$EVENT_SHA" ]
+          gh api "repos/$REPO/issues/$PR/labels" --jq 'any(.[]; .name == "preview-autorizado")' | grep -qx true
+
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          ref: ${{ github.event.pull_request.head.sha }}   # código do FORK: roda SÓ aqui, com environment gated
-      - uses: actions/setup-node@v4
-        if: steps.gate.outputs.preview_autorizado_atual == 'true'
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: 22 }
-      - run: npm i -g vercel@latest
-        if: steps.gate.outputs.preview_autorizado_atual == 'true'
-      - name: preview na Vercel
-        if: steps.gate.outputs.preview_autorizado_atual == 'true'
+      - run: npm i -g vercel@58.9.0
+      - name: publica preview
+        id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
           vercel build --token "$VERCEL_TOKEN"
           URL=$(vercel deploy --prebuilt --token "$VERCEL_TOKEN")
-          gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "🤖 **cs-brasil-ai-bot**: preview no ar → $URL"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+      - name: comenta URL
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "🤖 **cs-brasil-ai-bot**: preview no ar → ${{ steps.deploy.outputs.url }}"

--- a/.github/workflows/prod-watch.yml
+++ b/.github/workflows/prod-watch.yml
@@ -41,8 +41,8 @@ jobs:
     env:
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: 22 }
 
       # Purge pós-deploy ANTES do probe: medir o edge velho acusaria o deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
   bump-tag-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 0 }
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: 22 }
 
       # Defesa contra o dia em que alguém trocar GITHUB_TOKEN por PAT (aí o push do bot

--- a/.github/workflows/smoke-web.yml
+++ b/.github/workflows/smoke-web.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
@@ -43,7 +43,7 @@ jobs:
         run: npx playwright test --config=playwright.smoke.config.mjs tests/smoke/web-smoke.spec.js --reporter=list --trace=on --output=test-results
       - name: Upload smoke artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: smoke-web-artifacts
           path: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,8 +28,8 @@ jobs:
     if: needs.staging-config.outputs.available == 'true'
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
@@ -44,7 +44,7 @@ jobs:
         run: npx playwright test --config=playwright.smoke.config.mjs tests/smoke/web-smoke.spec.js --reporter=list --trace=on --output=test-results
       - name: Upload staging smoke artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: staging-smoke-artifacts
           path: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,13 @@ O porquê completo de cada regra da fronteira está em
 
 ## As leis da casa
 
-Não são estilo. Cada uma custou dias, e cada uma está documentada no código com o caso real
-que a gerou — os casos completos estão em
+Não são estilo. Cada uma custou dias; os casos completos estão em
 [`docs/docs/quality-gates.md`](docs/docs/quality-gates.md).
+
+**Comentários no código têm orçamento quase zero.** Não narre o que a linha faz nem cole o
+histórico da investigação. Só comente uma invariante, compatibilidade ou risco que os nomes não
+consigam expressar, em no máximo duas linhas, apontando para a issue ou doc quando precisar de
+contexto. Evidência, antes/depois e cronologia ficam em `KNOWN-BUGS.md` ou `docs/`.
 
 **1 · Régua antes do conserto.** Escreva a medição, prove que ela **reprova** o estado atual,
 só então conserte. Intenção que não vira invariante é otimizada para fora: uma rodada levou o

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,9 @@ critério de aceite.
 2. **Produção publica no MERGE** (auto-deploy da Vercel na `main`, decisão do dono em
    08/08); o Release/tag/bump saem juntos, automáticos, via `release.yml`. O caminho
    manual por tag (`deploy-prod.yml` via dispatch) continua de pé como fallback.
-3. **PR de fork ganha preview via bot**: o `cs-brasil-ai-bot` (`preview-bot.yml`) avalia
-   o diff sem executar seu código; PR pequeno e fora de área sensível (workflows, deps,
-   `src/pages/api/`, deploy) recebe `preview-autorizado` e o preview sobe sozinho.
-   Tocou área sensível? Um mantenedor aplica o label na mão depois de revisar.
+3. **Preview de fork exige revisão humana**: o `cs-brasil-ai-bot` (`preview-bot.yml`)
+   classifica o diff sem executá-lo. Um mantenedor revisa o SHA atual e aplica
+   `preview-autorizado`; qualquer push revoga a aprovação.
 4. **Quality gates locais antes de abrir**: `npm run check:fast` (segundos) e, se mexeu em
    jogo, `npm run check`. Vermelho novo no quality gate = PR volta.
 5. **Nada de travessão `—` no texto do site (`src/`)**. Use hífen com espaços (` - `). O
@@ -148,8 +147,11 @@ E teste à mão: o jogo abre, o console fica limpo, uma partida completa roda
 ## Regras de código
 
 - **Português** em nome, comentário, commit e doc.
-- Comentário explica **por quê**, não o quê. O padrão do repo é comentário que
-  conta a causa raiz e o número medido — siga ele.
+- **Código não é relatório.** Comentário novo só explica uma invariante, compatibilidade ou
+  risco que os nomes não expressem, em no máximo duas linhas. Histórico, causa raiz, números e
+  reprodução ficam na issue, em `KNOWN-BUGS.md` ou em `docs/`; o comentário apenas aponta.
+- Não narre o óbvio, não deixe diário de investigação e não use comentários para compensar nome
+  ruim. Ao tocar num trecho, remova comentários redundantes daquele mesmo trecho.
 - `arquivo:linha` em qualquer afirmação sobre código.
 - PRs pequenos e focados: uma feature ou um fix por PR.
 - **Sistema interconectado** (arma + mão + animação + ADS + mira + HUD) se mexe

--- a/docs/docs/licenca.md
+++ b/docs/docs/licenca.md
@@ -41,7 +41,7 @@ não enumerada à mão:
 |---|---|---|
 | licença canônica | `LICENSE` | linhas 1, 10, 42, 63 (+7)  |
 | badge + seção de licenças | `README.md` | linhas 3, 381, 387, 388 (+1)  |
-| termo que o contribuidor aceita | `CONTRIBUTING.md` | linhas 181, 184, 187  |
+| termo que o contribuidor aceita | `CONTRIBUTING.md` | linhas 183, 186, 189  |
 | rodapé do site | `src/layouts/Layout.astro` | linha 598  |
 | JSON-LD do jogo | `src/pages/index.astro` | linha 290  |
 | página `/sobre` | `src/pages/sobre.astro` | linhas 121, 124, 133  |
@@ -50,7 +50,7 @@ não enumerada à mão:
 
 **26 ocorrências** de `AGPL-3.0` em **7** das 8 superfícies declaradas. Trocar a licença é mudar **todas elas no mesmo commit**: metade trocada é pior que nenhuma, porque cada arquivo passa a responder uma coisa diferente para quem pergunta.
 
-**Outros nomes de licença citados nessas superfícies:** `MIT` em `README.md` (linhas 387, 388, 389, 393), `MIT` em `CONTRIBUTING.md` (linhas 184, 185, 186), `MIT` em `src/pages/sobre.astro` (linha 123), `MIT` em `public/llms.txt` (linha 47), `MIT` em `docs/docusaurus.config.js` (linha 152). Citar não é declarar — essas linhas são histórico da migração ou crédito a dependência de terceiro. A regra continua a mesma: **só o `LICENSE` declara**, e hoje ele diz `AGPL-3.0`.
+**Outros nomes de licença citados nessas superfícies:** `MIT` em `README.md` (linhas 387, 388, 389, 393), `MIT` em `CONTRIBUTING.md` (linhas 186, 187, 188), `MIT` em `src/pages/sobre.astro` (linha 123), `MIT` em `public/llms.txt` (linha 47), `MIT` em `docs/docusaurus.config.js` (linha 152). Citar não é declarar — essas linhas são histórico da migração ou crédito a dependência de terceiro. A regra continua a mesma: **só o `LICENSE` declara**, e hoje ele diz `AGPL-3.0`.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `grep -n dos nomes de licença conhecidos, nas superfícies declaradas em tools/gen-docs.mjs`
 

--- a/scripts/ci/workflow_security_check.py
+++ b/scripts/ci/workflow_security_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import argparse
+import re
+from pathlib import Path
+
+
+WORKFLOW = Path('.github/workflows/preview-bot.yml')
+
+
+def preview_failures(source: str) -> list[str]:
+    errors = []
+    required = {
+        'types: [opened, synchronize, reopened, labeled]': 'evento labeled ausente',
+        "github.event.action == 'labeled'": 'preview não exige evento labeled',
+        "github.event.label.name == 'preview-autorizado'": 'preview não exige o label correto',
+        'repos/$REPO/collaborators/$ACTOR/permission': 'permissão do ator não é consultada',
+        'admin|maintain|write': 'papéis autorizados não estão limitados',
+        'API_SHA': 'SHA atual do PR não é conferido',
+        'EVENT_SHA': 'SHA aprovado pelo evento não é conferido',
+        'ref: ${{ github.event.pull_request.head.sha }}': 'checkout não está preso ao SHA aprovado',
+        'persist-credentials: false': 'checkout persiste credencial no código do fork',
+        'allow-unsafe-pr-checkout: true': 'checkout de fork seguirá quebrado no pull_request_target',
+        '--remove-label "preview-autorizado"': 'push novo não revoga aprovação anterior',
+        'environment: preview-forks': 'environment de preview ausente',
+    }
+    for marker, message in required.items():
+        if marker not in source:
+            errors.append(message)
+    if '--add-label "preview-autorizado"' in source:
+        errors.append('workflow autoaprova código de fork')
+    if 'preview_autorizado=true' in source:
+        errors.append('workflow decide autorização sem mantenedor')
+    return errors
+
+
+def supply_failures(workflows: dict[Path, str]) -> list[str]:
+    errors = []
+    for path, source in workflows.items():
+        for action, ref in re.findall(r'uses:\s*([^\s@]+)@([^\s#]+)', source):
+            if not re.fullmatch(r'[0-9a-f]{40}', ref):
+                errors.append(f'{path}: {action}@{ref} não está preso a SHA')
+        for ref in re.findall(r'npm i -g vercel@([^\s]+)', source):
+            if not re.fullmatch(r'\d+\.\d+\.\d+', ref):
+                errors.append(f'{path}: vercel@{ref} não está preso a versão')
+    return errors
+
+
+def selftest(source: str) -> list[str]:
+    mutations = {
+        'auto-label': source + '\n# --add-label "preview-autorizado"\n',
+        'sem-ator': source.replace('repos/$REPO/collaborators/$ACTOR/permission', 'repos/$REPO'),
+        'sem-evento': source.replace("github.event.action == 'labeled'", "github.event.action == 'opened'"),
+        'credencial-persistida': source.replace('persist-credentials: false', 'persist-credentials: true'),
+        'sha-solto': source.replace('ref: ${{ github.event.pull_request.head.sha }}', 'ref: main'),
+        'label-reutilizado': source.replace('--remove-label "preview-autorizado"', '--remove-label "outro"'),
+        'action-mutável': re.sub(r'actions/checkout@[0-9a-f]{40}', 'actions/checkout@v4', source),
+        'cli-mutável': re.sub(r'vercel@\d+\.\d+\.\d+', 'vercel@latest', source),
+    }
+    missed = [
+        name for name, mutated in mutations.items()
+        if not (preview_failures(mutated) + supply_failures({WORKFLOW: mutated}))
+    ]
+    return missed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--selftest', action='store_true')
+    args = parser.parse_args()
+    source = WORKFLOW.read_text(encoding='utf-8')
+    workflows = {path: path.read_text(encoding='utf-8') for path in Path('.github/workflows').glob('*.yml')}
+    errors = preview_failures(source) + supply_failures(workflows)
+    if errors:
+        for error in errors:
+            print(f'WFS FAIL: {error}')
+        return 1
+    print('WFS PASS: preview de fork exige aprovação manual presa ao SHA')
+    if args.selftest:
+        missed = selftest(source)
+        if missed:
+            print(f'WFS MUTATION FAIL: {", ".join(missed)}')
+            return 1
+        print('WFS MUTATION PASS: 8/8 mutações ficaram vermelhas')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/ci/workflow_security_check.py
+++ b/scripts/ci/workflow_security_check.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import re
+import tempfile
 from pathlib import Path
 
 
@@ -45,6 +46,14 @@ def supply_failures(workflows: dict[Path, str]) -> list[str]:
     return errors
 
 
+def read_workflows(root: Path = Path('.github/workflows')) -> dict[Path, str]:
+    return {
+        path: path.read_text(encoding='utf-8')
+        for pattern in ('*.yml', '*.yaml')
+        for path in root.glob(pattern)
+    }
+
+
 def selftest(source: str) -> list[str]:
     mutations = {
         'auto-label': source + '\n# --add-label "preview-autorizado"\n',
@@ -60,6 +69,11 @@ def selftest(source: str) -> list[str]:
         name for name, mutated in mutations.items()
         if not (preview_failures(mutated) + supply_failures({WORKFLOW: mutated}))
     ]
+    with tempfile.TemporaryDirectory() as tmp:
+        mutant = Path(tmp) / 'mutable-action.yaml'
+        mutant.write_text('steps:\\n  - uses: actions/checkout@v4\\n', encoding='utf-8')
+        if not supply_failures(read_workflows(Path(tmp))):
+            missed.append('extensao-yaml')
     return missed
 
 
@@ -68,7 +82,7 @@ def main() -> int:
     parser.add_argument('--selftest', action='store_true')
     args = parser.parse_args()
     source = WORKFLOW.read_text(encoding='utf-8')
-    workflows = {path: path.read_text(encoding='utf-8') for path in Path('.github/workflows').glob('*.yml')}
+    workflows = read_workflows()
     errors = preview_failures(source) + supply_failures(workflows)
     if errors:
         for error in errors:
@@ -80,7 +94,7 @@ def main() -> int:
         if missed:
             print(f'WFS MUTATION FAIL: {", ".join(missed)}')
             return 1
-        print('WFS MUTATION PASS: 8/8 mutações ficaram vermelhas')
+        print('WFS MUTATION PASS: 9/9 mutações ficaram vermelhas')
     return 0
 
 


### PR DESCRIPTION
## Resumo
- exige autorização manual presa ao SHA antes de expor segredos a preview de fork
- revoga a autorização quando o PR muda e fixa actions/CLI por versão imutável
- corrige a ordem vm-mint-audit -> invariantes e adiciona docs:check
- estabelece orçamento quase zero para comentários narrativos no código
- adiciona régua de segurança com 8 mutações que precisam falhar

## Validação
- python3 scripts/ci/workflow_security_check.py --selftest
- npm run check:deploy
- npm run docs:check
- npm run arch:check
- npm run build (Node 22.19.0)
- YAML parse e git diff --check

Mudança de workflow: requer revisão humana antes do merge.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR hardens fork previews by requiring maintainer authorization tied to the current commit and adds CI checks for workflow supply-chain constraints. It also pins Actions and Vercel CLI versions, corrects quality-gate ordering, and reduces narrative code comments.
- Requires a privileged actor to apply the preview authorization label.
- Verifies the event SHA against the PR’s current head before checking out fork code.
- Scans both `.yml` and `.yaml` workflow files for mutable action references.
- Adds mutation coverage for workflow discovery and preview authorization invariants.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/workflow_security_check.py | Adds preview-policy and immutable-reference checks, including explicit discovery and mutation coverage for both `.yml` and `.yaml` workflows. |
| .github/workflows/preview-bot.yml | Replaces automatic fork-preview approval with maintainer labeling, current-head verification, and an exact-SHA checkout before secret-backed deployment. |
| .github/workflows/ci.yml | Pins reusable actions, runs the workflow security checker, adds generated-document validation, and restores the required VM-audit ordering. |
| .github/workflows/deploy-prod.yml | Pins checkout, Node setup, and the globally installed Vercel CLI. |
| .github/workflows/release.yml | Pins checkout and Node setup while retaining the existing release flow. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Fork PR opened or updated] --> B[Classify changed files]
  B --> C[Maintainer reviews current SHA]
  C --> D[Apply preview-autorizado label]
  D --> E{Actor has write-level permission?}
  E -- No --> F[Reject preview]
  E -- Yes --> G{Event SHA equals current PR head?}
  G -- No --> F
  G -- Yes --> H[Checkout exact fork SHA without persisted credentials]
  H --> I[Build and deploy preview]
  I --> J[Post preview URL]
  A -->|New synchronize event| K[Remove prior authorization label]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): valida workflows .yaml"](https://github.com/rubenmarcus/csbrasil/commit/2402032b67f14d63ed86cd1cae70a8141cd55d4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51600539)</sub>

<!-- /greptile_comment -->