### PR TITLE
fix(client): gera UUID em navegadores antigos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: python3 scripts/ci/workflow_security_check.py --selftest
       - name: Syntax check do jogo (public/js)
         run: npm run syntax
+      - name: UUID compatível com navegadores antigos
+        run: npm run eval:uuid
 
       # O ARCH.md (índice por linha + tabela de conflito) é GERADO. Escrito à
       # mão ele desatualiza no primeiro commit, e uma tabela de conflito com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ algo está errado e o quality gate está verde, o defeito é do quality gate.
 
 | Zona | O que é | Tamanho medido | Regra |
 |---|---|---|---|
-| `public/` | o **jogo** | 31 arquivos `.js`, 27.058 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
+| `public/` | o **jogo** | 31 arquivos `.js`, 27.069 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
 | `src/` | o **site** | 17 páginas `.astro`, 17 rotas `/api` · Astro `^7.1.1` | framework é bem-vindo; `service_role` só no servidor |
 | `tools/` | o **arnês** | 170 scripts em `tools/eval/`, 46 em `tools/` | node puro: sobe o jogo real sem browser |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ algo está errado e o quality gate está verde, o defeito é do quality gate.
 |---|---|---|---|
 | `public/` | o **jogo** | 31 arquivos `.js`, 27.058 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
 | `src/` | o **site** | 17 páginas `.astro`, 17 rotas `/api` · Astro `^7.1.1` | framework é bem-vindo; `service_role` só no servidor |
-| `tools/` | o **arnês** | 169 scripts em `tools/eval/`, 46 em `tools/` | node puro: sobe o jogo real sem browser |
+| `tools/` | o **arnês** | 170 scripts em `tools/eval/`, 46 em `tools/` | node puro: sobe o jogo real sem browser |
 
 **Não existe `public/index.html`.** O HTML do jogo é `src/pages/index.astro`, servido na rota `/`. Servir `public/` estaticamente entrega os arnêses visuais, **não o jogo** — é a pegadinha que custa a primeira hora de todo mundo.
 
@@ -144,7 +144,7 @@ npm run check        # npm run syntax && npm run audio:check && npm run eval:ctf
 npm run check:fast   # node tools/eval/runner.mjs syntax eval:release docs:check arch:check audio:check feet:check eval:ctfhud eval:pause eval:ctfround eval:ctfwin eval:spawn eval:regen eval:pegada eval:ctflabels anims:check anims:merge:check walls:check media:check travessao:check
 ```
 
-`package.json` tem **60 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
+`package.json` tem **61 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `node -p "Object.keys(require('./package.json').scripts)"`
 

--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -1607,7 +1607,8 @@ publicação em potencial, e o `.gitignore` não protege de um deploy local.
   O cliente chamava o método diretamente ao criar `cs_anon` e `awpbr_token`; quando
   `crypto` existia sem `randomUUID`, `getAnonId()` lançava antes do primeiro ping.
   `npm run eval:uuid` reproduz esse ambiente e exige UUID v4 nos caminhos nativo,
-  `getRandomValues` e sem Web Crypto. Medição: **0/3 → 3/3**; a mutação
+  `getRandomValues` e sem Web Crypto (este último reprova em vez de gerar token
+  previsível com `Math.random`). Medição: **0/3 → 3/3**; a mutação
   `--mutante=chamada-direta` devolve o erro.
 
 - **~~BUG-40 · Release atribui ao bot uma contribuição externa e usa o nome antigo~~ ·

--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -1603,6 +1603,13 @@ publicação em potencial, e o `.gitignore` não protege de um deploy local.
 
 ## Relatados, ainda não reproduzidos
 
+- **BUG-41 · `crypto.randomUUID` derruba presença em navegador incompatível (#143).**
+  O cliente chamava o método diretamente ao criar `cs_anon` e `awpbr_token`; quando
+  `crypto` existia sem `randomUUID`, `getAnonId()` lançava antes do primeiro ping.
+  `npm run eval:uuid` reproduz esse ambiente e exige UUID v4 nos caminhos nativo,
+  `getRandomValues` e sem Web Crypto. Medição: **0/3 → 3/3**; a mutação
+  `--mutante=chamada-direta` devolve o erro.
+
 - **~~BUG-40 · Release atribui ao bot uma contribuição externa e usa o nome antigo~~ ·
   RESOLVIDO 09/08.** Palavras do dono: *"o nosso bot deu squash merge e tirou a
   contribuicao do emerson garrido. isso é errado"* · *"queriamos todos RELEASES

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sem cadastro.
 | Personagens jogáveis | 44, em 5 facções | array `CHARACTERS` de `characters.js` |
 | Mapas no registro | 5 | objeto `MAPS` de `maps.js` |
 | Arnêses visuais em HTML | 12 | `ls public/*.html \| wc -l` |
-| Scripts do arnês | 169 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
+| Scripts do arnês | 170 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
 | Scripts de pipeline | 46 | `ls tools/*.mjs \| wc -l` |
 | Tarefas de entrada escritas | 26 | `ls docs/issues/[0-9]*.md \| wc -l` |
 | Versão | `2.0.0-alpha.50` | `public/js/version.js` e `package.json` (batem) |
@@ -195,7 +195,7 @@ npm run check        # npm run syntax && npm run audio:check && npm run eval:ctf
 npm run check:fast   # node tools/eval/runner.mjs syntax eval:release docs:check arch:check audio:check feet:check eval:ctfhud eval:pause eval:ctfround eval:ctfwin eval:spawn eval:regen eval:pegada eval:ctflabels anims:check anims:merge:check walls:check media:check travessao:check
 ```
 
-`package.json` tem **60 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
+`package.json` tem **61 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `node -p "Object.keys(require('./package.json').scripts)"`
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ sem cadastro.
 | Scripts do arnês | 170 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
 | Scripts de pipeline | 46 | `ls tools/*.mjs \| wc -l` |
 | Tarefas de entrada escritas | 26 | `ls docs/issues/[0-9]*.md \| wc -l` |
-| Versão | `2.0.0-alpha.50` | `public/js/version.js` e `package.json` (batem) |
+| Versão | `2.0.0-alpha.51` | `public/js/version.js` e `package.json` (batem) |
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `o comando da coluna direita de cada linha`
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ sem cadastro.
 
 | O que | Quanto | Onde confere |
 |---|---:|---|
-| Código do jogo | 27.058 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
+| Código do jogo | 27.069 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
 | `game.js` | **6.203** linhas | `wc -l public/js/game.js` |
-| `main.js` | 1.881 linhas | `wc -l public/js/main.js` |
+| `main.js` | 1.892 linhas | `wc -l public/js/main.js` |
 | Armas com GLB | 26 | `ls public/models/weapons/*.glb \| wc -l` |
 | GLBs de personagem | 45 | `ls public/models/characters/*.glb \| wc -l` |
 | Props em GLB | 108 | `ls public/models/props/*.glb \| wc -l` |

--- a/docs/docs/arquitetura.md
+++ b/docs/docs/arquitetura.md
@@ -63,14 +63,14 @@ Tamanho dos arquivos que o `gen-arch.mjs` indexa — bloco gerado, regenerado po
 | Arquivo | Linhas |
 |---|---:|
 | `public/js/game.js` | 6.203 |
-| `public/js/main.js` | 1.881 |
+| `public/js/main.js` | 1.892 |
 | `public/js/characters.js` | 1.066 |
 | `public/js/glbchars.js` | 837 |
 | `public/js/vmattach.js` | 628 |
 | `public/js/weapons.js` | 344 |
 | `public/js/springs.js` | 260 |
 
-Total de `public/js/`: **27.058 linhas em 31 arquivos**. O índice símbolo→linha, com a tabela de conflito, é outro bloco gerado: `tools/eval/ARCH.md` (`npm run arch`).
+Total de `public/js/`: **27.069 linhas em 31 arquivos**. O índice símbolo→linha, com a tabela de conflito, é outro bloco gerado: `tools/eval/ARCH.md` (`npm run arch`).
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: ``wc -l public/js/*.js``
 

--- a/docs/docs/comecando.md
+++ b/docs/docs/comecando.md
@@ -49,7 +49,7 @@ esta página envelhecia no primeiro commit — ver
 | Personagens jogáveis | 44, em 5 facções | array `CHARACTERS` de `characters.js` |
 | Mapas no registro | 5 | objeto `MAPS` de `maps.js` |
 | Arnêses visuais em HTML | 12 | `ls public/*.html \| wc -l` |
-| Scripts do arnês | 169 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
+| Scripts do arnês | 170 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
 | Scripts de pipeline | 46 | `ls tools/*.mjs \| wc -l` |
 | Tarefas de entrada escritas | 26 | `ls docs/issues/[0-9]*.md \| wc -l` |
 | Versão | `2.0.0-alpha.50` | `public/js/version.js` e `package.json` (batem) |
@@ -261,7 +261,7 @@ npm run check        # npm run syntax && npm run audio:check && npm run eval:ctf
 npm run check:fast   # node tools/eval/runner.mjs syntax eval:release docs:check arch:check audio:check feet:check eval:ctfhud eval:pause eval:ctfround eval:ctfwin eval:spawn eval:regen eval:pegada eval:ctflabels anims:check anims:merge:check walls:check media:check travessao:check
 ```
 
-`package.json` tem **60 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
+`package.json` tem **61 scripts**. Vários trazem uma chave `//nome` logo acima com o motivo de existirem — é onde mora o porquê.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `node -p "Object.keys(require('./package.json').scripts)"`
 

--- a/docs/docs/comecando.md
+++ b/docs/docs/comecando.md
@@ -39,9 +39,9 @@ esta página envelhecia no primeiro commit — ver
 
 | O que | Quanto | Onde confere |
 |---|---:|---|
-| Código do jogo | 27.058 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
+| Código do jogo | 27.069 linhas em 31 arquivos | `cat public/js/*.js \| wc -l` |
 | `game.js` | **6.203** linhas | `wc -l public/js/game.js` |
-| `main.js` | 1.881 linhas | `wc -l public/js/main.js` |
+| `main.js` | 1.892 linhas | `wc -l public/js/main.js` |
 | Armas com GLB | 26 | `ls public/models/weapons/*.glb \| wc -l` |
 | GLBs de personagem | 45 | `ls public/models/characters/*.glb \| wc -l` |
 | Props em GLB | 108 | `ls public/models/props/*.glb \| wc -l` |

--- a/docs/docs/comecando.md
+++ b/docs/docs/comecando.md
@@ -52,7 +52,7 @@ esta página envelhecia no primeiro commit — ver
 | Scripts do arnês | 170 | `ls tools/eval/*.mjs tools/eval/*.py \| wc -l` |
 | Scripts de pipeline | 46 | `ls tools/*.mjs \| wc -l` |
 | Tarefas de entrada escritas | 26 | `ls docs/issues/[0-9]*.md \| wc -l` |
-| Versão | `2.0.0-alpha.50` | `public/js/version.js` e `package.json` (batem) |
+| Versão | `2.0.0-alpha.51` | `public/js/version.js` e `package.json` (batem) |
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `o comando da coluna direita de cada linha`
 

--- a/docs/docs/quality-gates.md
+++ b/docs/docs/quality-gates.md
@@ -15,7 +15,7 @@ PR (`.github/workflows/ci.yml`).
 {/* BEGIN:GERADO:invariantes — não edite à mão, rode `npm run docs` */}
 
 - `tools/eval/invariants.mjs`: **2.194 linhas**, **61 identificadores de invariante declarados** (`put()`), dos quais **27** têm caminho de `skip()` declarado.
-- O arnês inteiro são **169 scripts** em `tools/eval/` (`.mjs` + `.py`), mais **46 scripts** de pipeline em `tools/`.
+- O arnês inteiro são **170 scripts** em `tools/eval/` (`.mjs` + `.py`), mais **46 scripts** de pipeline em `tools/`.
 - Quantas invariantes rodam como **críticas** numa execução **não é derivável do fonte**: depende de qual insumo existe na máquina (o JSON do auditor de viewmodel, um GLB, uma pasta de anims). Esse número só sai rodando o quality gate — e o lugar dele é o cabeçalho do `KNOWN-BUGS.md`, atualizado com saída real.
 
 Reproduza:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coro-solto",
-  "version": "2.0.0-alpha.50",
+  "version": "2.0.0-alpha.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coro-solto",
-      "version": "2.0.0-alpha.50",
+      "version": "2.0.0-alpha.51",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@astrojs/vercel": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coro-solto",
-  "version": "2.0.0-alpha.50",
+  "version": "2.0.0-alpha.51",
   "license": "AGPL-3.0-only",
   "description": "CORO SOLTO: Treta Suprema (ex-CS BRASIL) — FPS de navegador estilo CS 1.6 (site Astro + jogo vanilla em Three.js)",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prod:coherence": "node tools/eval/prod-coherence.mjs",
     "//eval:release": "Todo caminho de GitHub Release usa o nome CSBR e as notas nativas do GitHub, que ligam PRs e contribuidores às contas. Nasceu do alpha.47 (BUG-40): o fallback `git log --oneline` mostrou o commit do #119 sem creditar @EmersonGarrido, e o título ainda dizia CORO SOLTO. `--mutante=nome-antigo|semcreditos` prova as duas cláusulas.",
     "eval:release": "node tools/eval/release-check.mjs",
+    "eval:uuid": "node tools/eval/uuid-compat-check.mjs",
     "//eval:pegada": "Colisor de prop na ALTURA DO CORPO (Brasília): recomputa a pegada dos GLBs (tent/stall/drinkstand/bus) e acusa deriva da tabela PEGADA_CORPO / PEGADA_BUS. Nasceu da reprovação de 05/08 ('box do ônibus e barracas') com o obb-check VERDE — ele compara contra a caixa declarada e não vê caixa mais gorda que a malha.",
     "eval:pegada": "node tools/eval/pegada-check.mjs",
     "//eval:ctflabels": "Bandeira com nome do PRÓPRIO mapa, declarada pelo mapa (defeito de 06/08: 'CONGRESSO' jogando na piscina — o fallback do game.js vazava os nomes de Brasília). --mutante=vaza prova que morde.",

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -436,9 +436,20 @@ let submitted = true;   // stats da partida atual já enviados?
    sendBeacon porque isto costuma sair junto com o fim da partida ou com a aba
    fechando — `fetch` normal é cancelado no unload, sendBeacon não. */
 const ANON_KEY = 'cs_anon';
+function clientUuid() {
+  const c = globalThis.crypto;
+  if (typeof c?.randomUUID === 'function') return c.randomUUID();
+  const bytes = new Uint8Array(16);
+  if (typeof c?.getRandomValues === 'function') c.getRandomValues(bytes);
+  else for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map(value => value.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
 function getAnonId() {
   let a = localStorage.getItem(ANON_KEY);
-  if (!a) { a = crypto.randomUUID(); localStorage.setItem(ANON_KEY, a); }
+  if (!a) { a = clientUuid(); localStorage.setItem(ANON_KEY, a); }
   return a;
 }
 let telemetrySent = true;
@@ -1382,7 +1393,7 @@ renderSocials();
 const TOKEN_KEY = 'awpbr_token';
 function getToken() {
   let t = localStorage.getItem(TOKEN_KEY);
-  if (!t) { t = crypto.randomUUID(); localStorage.setItem(TOKEN_KEY, t); }
+  if (!t) { t = clientUuid(); localStorage.setItem(TOKEN_KEY, t); }
   return t;
 }
 async function api(path, body) {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -439,9 +439,9 @@ const ANON_KEY = 'cs_anon';
 function clientUuid() {
   const c = globalThis.crypto;
   if (typeof c?.randomUUID === 'function') return c.randomUUID();
+  if (typeof c?.getRandomValues !== 'function') throw new Error('Web Crypto indisponível');
   const bytes = new Uint8Array(16);
-  if (typeof c?.getRandomValues === 'function') c.getRandomValues(bytes);
-  else for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  c.getRandomValues(bytes);
   bytes[6] = (bytes[6] & 0x0f) | 0x40;
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   const hex = [...bytes].map(value => value.toString(16).padStart(2, '0')).join('');

--- a/public/js/version.js
+++ b/public/js/version.js
@@ -2,7 +2,7 @@
 // ATENÇÃO: o mesmo ?v= vai no import map do index.astro (bump dos dois lados juntos,
 // senão o navegador serve módulos JS velhos do cache — causa raiz de "correções que
 // não chegavam ao usuário" por dias).
-export const VERSION = '2.0.0-alpha.50';
+export const VERSION = '2.0.0-alpha.51';
 
 /* POR QUE 2.0.0-alpha E NÃO 3.3.0 (04/08/2026)
    O número tinha saltado de 1.15.0 para 3.1.0 sem nenhum release no meio: nenhuma das

--- a/tools/eval/ARCH.md
+++ b/tools/eval/ARCH.md
@@ -3,7 +3,7 @@
 <!-- BEGIN:GERADO — não edite à mão, rode `npm run arch` -->
 
 > Gerado por `node tools/gen-arch.mjs`. **Não edite este bloco à mão.**
-> Versão do jogo: 2.0.0-alpha.50 · `npm run arch` para regenerar · `npm run arch:check` no CI.
+> Versão do jogo: 2.0.0-alpha.51 · `npm run arch` para regenerar · `npm run arch:check` no CI.
 
 ## Tamanho dos arquivos indexados
 

--- a/tools/eval/ARCH.md
+++ b/tools/eval/ARCH.md
@@ -10,7 +10,7 @@
 | Arquivo | Linhas | Símbolos |
 |---|---:|---:|
 | `public/js/game.js` | 6204 | 220 |
-| `public/js/main.js` | 1882 | 165 |
+| `public/js/main.js` | 1893 | 166 |
 | `public/js/glbchars.js` | 838 | 60 |
 | `public/js/characters.js` | 1067 | 41 |
 | `public/js/vmattach.js` | 629 | 4 |

--- a/tools/eval/uuid-compat-check.mjs
+++ b/tools/eval/uuid-compat-check.mjs
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const file = new URL('../../public/js/main.js', import.meta.url);
+let source = fs.readFileSync(file, 'utf8');
+const mutant = process.argv.includes('--mutante=chamada-direta');
+
+if (mutant) {
+  source = source.replace('a = clientUuid()', 'a = crypto.randomUUID()');
+  source = source.replace('t = clientUuid()', 't = crypto.randomUUID()');
+}
+
+function functionSource(name) {
+  const start = source.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`${name} nao encontrado`);
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    if (source[i] === '}' && --depth === 0) return source.slice(start, i + 1);
+  }
+  throw new Error(`${name} incompleto`);
+}
+
+const uuidFn = functionSource('clientUuid');
+const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function run(crypto) {
+  const context = vm.createContext({ crypto, Uint8Array, Math });
+  vm.runInContext(`${uuidFn}; globalThis.result = clientUuid()`, context);
+  return context.result;
+}
+
+const native = '11111111-2222-4333-8444-555555555555';
+if (run({ randomUUID: () => native }) !== native) throw new Error('nao usa randomUUID quando disponivel');
+if (!uuidRe.test(run({ getRandomValues: bytes => bytes.fill(0xab) }))) throw new Error('fallback getRandomValues invalido');
+if (!uuidRe.test(run(undefined))) throw new Error('fallback sem Web Crypto invalido');
+
+for (const name of ['getAnonId', 'getToken']) {
+  if (!functionSource(name).includes('clientUuid()')) throw new Error(`${name} ainda chama randomUUID diretamente`);
+}
+if (source.includes('crypto.randomUUID()')) throw new Error('chamada direta a crypto.randomUUID permanece');
+
+console.log('UUID1 PASS: IDs continuam UUID v4 sem depender de crypto.randomUUID');

--- a/tools/eval/uuid-compat-check.mjs
+++ b/tools/eval/uuid-compat-check.mjs
@@ -34,7 +34,12 @@ function run(crypto) {
 const native = '11111111-2222-4333-8444-555555555555';
 if (run({ randomUUID: () => native }) !== native) throw new Error('nao usa randomUUID quando disponivel');
 if (!uuidRe.test(run({ getRandomValues: bytes => bytes.fill(0xab) }))) throw new Error('fallback getRandomValues invalido');
-if (!uuidRe.test(run(undefined))) throw new Error('fallback sem Web Crypto invalido');
+try {
+  run(undefined);
+  throw new Error('sem Web Crypto gerou token fraco');
+} catch (error) {
+  if (error?.message === 'sem Web Crypto gerou token fraco') throw error;
+}
 
 for (const name of ['getAnonId', 'getToken']) {
   if (!functionSource(name).includes('clientUuid()')) throw new Error(`${name} ainda chama randomUUID diretamente`);


### PR DESCRIPTION
## Resumo
- remove os dois usos diretos de crypto.randomUUID do boot do cliente
- usa randomUUID quando disponível, getRandomValues como fallback e mantém UUID v4 válido
- cobre criação de anonId e token com régua executável
- registra a medição em KNOWN-BUGS em vez de narrar a investigação no código

## Validação
- npm run eval:uuid: 3/3 cenários passaram
- mutação chamada-direta: ficou vermelha
- npm run syntax
- npm run check:deploy
- npm run build (Node 22.19.0)
- npm run eval:boot

Closes #143

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a UUID v4 compatibility helper for browsers without crypto.randomUUID and applies it to anonymous IDs and player tokens. It also adds an executable compatibility gate to CI and updates generated documentation, but omits the required client cache-version bump.
- Uses crypto.randomUUID when available, then getRandomValues, and finally Math.random.
- Adds native, Web Crypto fallback, and no-Web-Crypto evaluation scenarios.
- Registers the regression and updates generated counts and architecture documentation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The cache-version omission must be fixed before merging so affected returning browsers actually receive the UUID compatibility change.

The fallback implementation and its CI gate cover the intended UUID paths, but this repository serves raw cached modules and the unchanged version markers can leave users executing the old boot-breaking code.

**Files Needing Attention:** public/js/main.js, public/js/version.js, src/pages/index.astro
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/js/main.js | Adds the compatibility helper and routes both ID generators through it, but the required cache-busting version was not updated. |
| tools/eval/uuid-compat-check.mjs | Adds focused executable checks for native, getRandomValues, and no-Web-Crypto UUID generation paths. |
| .github/workflows/ci.yml | Runs the new UUID compatibility evaluation as a dedicated CI step. |
| package.json | Exposes the new compatibility evaluation through npm run eval:uuid. |
| KNOWN-BUGS.md | Records the original incompatible-browser failure, measured outcomes, and mutation check. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getAnonId or getToken] --> B[clientUuid]
    B --> C{crypto.randomUUID available?}
    C -->|Yes| D[Native UUID]
    C -->|No| E{crypto.getRandomValues available?}
    E -->|Yes| F[Random bytes from Web Crypto]
    E -->|No| G[Random bytes from Math.random]
    F --> H[Set UUID v4 version and variant bits]
    G --> H
    H --> I[Format and persist UUID]
    D --> I
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apublic%2Fjs%2Fmain.js%3A439%0A**Cache%20mant%C3%A9m%20UUID%20incompat%C3%ADvel**%0A%0AQuando%20um%20navegador%20recorrente%20tem%20o%20m%C3%B3dulo%20anterior%20em%20cache%2C%20a%20aus%C3%AAncia%20do%20bump%20obrigat%C3%B3rio%20de%20%60%3Fv%3D%60%20faz%20o%20jogo%20continuar%20executando%20a%20chamada%20direta%20a%20%60crypto.randomUUID%60%2C%20causando%20a%20mesma%20falha%20de%20boot%20que%20esta%20altera%C3%A7%C3%A3o%20corrige.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rubenmarcus%2Fcsbrasil&pr=147&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
public/js/main.js:439
**Cache mantém UUID incompatível**

Quando um navegador recorrente tem o módulo anterior em cache, a ausência do bump obrigatório de `?v=` faz o jogo continuar executando a chamada direta a `crypto.randomUUID`, causando a mesma falha de boot que esta alteração corrige.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(client): gera UUID em navegadores an..."](https://github.com/rubenmarcus/csbrasil/commit/feffd97746534c77676136c93dda162d1201d3a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51600555)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->