### PR TITLE
fix(release): assina commit automatico

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: bash -n scripts/*.sh
       - name: Fronteira de confiança dos workflows
         run: python3 scripts/ci/workflow_security_check.py --selftest
+      - name: Contrato do release (nome, créditos e DCO do bot)
+        run: npm run eval:release
       - name: Syntax check do jogo (public/js)
         run: npm run syntax
       - name: UUID compatível com navegadores antigos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
             exit 1
           fi
           git add package.json package-lock.json public/js/version.js README.md docs/ tools/eval/ARCH.md
-          git commit -m "chore(release): $NEW"
+          git commit -s -m "chore(release): $NEW"
           # Tag ANOTADA + push explícito do ref. `--follow-tags` só sobe tag anotada, e
           # `git tag` sem `-a` cria tag LEVE: o alpha.38 (08/08) nasceu leve, ficou só no
           # runner, e o `gh release create` abortou com "tag exists locally but has not

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eval:invariants": "node tools/eval/invariants.mjs",
     "//prod:coherence": "Mede o que o EDGE está servindo, não o repo: baixa o HTML de produção, segue o import map e verifica que todo import nomeado existe como export no módulo alvo. Nasceu do apagão de 08/08 (cache split-brain: main.js de um deploy com fparms.js de outro — BUG-39). NÃO entra no check:fast (precisa de rede e de produção no ar); quem roda é o prod-watch.yml a cada 15 min. `--selftest` é a mutação que prova que morde.",
     "prod:coherence": "node tools/eval/prod-coherence.mjs",
-    "//eval:release": "Todo caminho de GitHub Release usa o nome CSBR e as notas nativas do GitHub, que ligam PRs e contribuidores às contas. Nasceu do alpha.47 (BUG-40): o fallback `git log --oneline` mostrou o commit do #119 sem creditar @EmersonGarrido, e o título ainda dizia CORO SOLTO. `--mutante=nome-antigo|semcreditos` prova as duas cláusulas.",
+    "//eval:release": "Todo caminho de GitHub Release usa o nome CSBR, notas nativas que ligam PRs/contribuidores às contas e `git commit -s` para o bump automático. Nasceu do alpha.47 (BUG-40, crédito perdido) e do incidente alpha.56 (release bot sem DCO). `--mutante=nome-antigo|semcreditos|semdco` prova as três cláusulas.",
     "eval:release": "node tools/eval/release-check.mjs",
     "eval:uuid": "node tools/eval/uuid-compat-check.mjs",
     "//eval:prune": "KEEP_FPVM preserva só models/fpvm; dev.html continua podado dos dois destinos publicados. Nasceu do #131: a saída antecipada expunha a bancada local. --mutante=early-exit devolve o bug.",

--- a/tools/eval/release-check.mjs
+++ b/tools/eval/release-check.mjs
@@ -5,7 +5,9 @@
  * documenta que `--generate-notes` inclui PRs e contribuidores; esta régua cobra
  * isso em todo caminho que chama `gh release create`.
  *
- * Mutações: --mutante=nome-antigo | semcreditos.
+ * RLS3: o alpha.56 entrou sem trailer; cobra DCO em todo commit automático de release.
+ *
+ * Mutações: --mutante=nome-antigo | semcreditos | semdco.
  */
 import { readFileSync } from 'node:fs';
 
@@ -15,23 +17,33 @@ let comandos = arquivos.flatMap((arquivo) => readFileSync(arquivo, 'utf8')
   .split('\n')
   .filter((linha) => /(?:^\s*|run:\s*)gh release create/.test(linha))
   .map((linha) => ({ arquivo, linha })));
+let commitsRelease = readFileSync('.github/workflows/release.yml', 'utf8')
+  .split('\n')
+  .filter((linha) => /^\s*git commit(?:\s|$)/.test(linha));
 
 if (mutante) {
-  const antes = JSON.stringify(comandos);
+  const antes = JSON.stringify([comandos, commitsRelease]);
   if (mutante === 'nome-antigo') comandos[0].linha = comandos[0].linha.replace('"CSBR ', '"CORO SOLTO ');
   else if (mutante === 'semcreditos') comandos[0].linha = comandos[0].linha.replace(' --generate-notes', '');
+  else if (mutante === 'semdco') {
+    const i = commitsRelease.findIndex((linha) => /(?:^|\s)(?:-s|--signoff)(?=\s|$)/.test(linha));
+    if (i >= 0) commitsRelease[i] = commitsRelease[i].replace(/\s(?:-s|--signoff)(?=\s|$)/, '');
+  }
   else throw new Error(`mutante desconhecido: ${mutante}`);
-  if (JSON.stringify(comandos) === antes) throw new Error(`MUTANTE NAO APLICOU: ${mutante}`);
+  if (JSON.stringify([comandos, commitsRelease]) === antes) throw new Error(`MUTANTE NAO APLICOU: ${mutante}`);
 }
 
 const nomes = comandos.filter(({ linha }) => /--title "CSBR \$/.test(linha)).length;
 const creditos = comandos.filter(({ linha }) => linha.includes('--generate-notes')).length;
 const total = comandos.length;
-const ok = total > 0 && nomes === total && creditos === total;
+const dco = commitsRelease.filter((linha) => /(?:^|\s)(?:-s|--signoff)(?=\s|$)/.test(linha)).length;
+const totalCommits = commitsRelease.length;
+const ok = total > 0 && nomes === total && creditos === total && totalCommits > 0 && dco === totalCommits;
 
 console.log(`${nomes === total && total ? '✓' : '✗'} RLS1 título CSBR: ${nomes}/${total} caminhos`);
 console.log(`${creditos === total && total ? '✓' : '✗'} RLS2 notas com contribuidores: ${creditos}/${total} caminhos`);
+console.log(`${dco === totalCommits && totalCommits ? '✓' : '✗'} RLS3 commits automáticos com DCO: ${dco}/${totalCommits} caminhos`);
 if (!ok) {
-  console.error('Release sem --generate-notes perde a lista de PRs/contribuidores; corrija todos os `gh release create` e use --title "CSBR …".');
+  console.error('Release inválido: use título CSBR, --generate-notes e `git commit -s` em todo caminho automático.');
   process.exit(1);
 }


### PR DESCRIPTION
Fecha a exceção encontrada depois da #158: o hook local assina commits humanos, mas o workflow de release fabricou o alpha.56 sem `Signed-off-by`.

Mudanças:
- usa `git commit -s` no bump automático;
- estende `eval:release` com RLS3 para cobrar DCO em todo caminho de commit de release;
- acrescenta `--mutante=semdco`, que remove o sign-off e precisa reprovar.

Evidência:
- antes: RLS3 `0/1` e exit 1;
- depois: RLS3 `1/1`;
- mutantes `nome-antigo`, `semcreditos` e `semdco`: exit 1;
- `check:fast`: 21/22, única falha `audio:check` porque o pacote privado/gitignored de áudio não existe neste clone (`0 arquivos`); todos os demais passos passaram.

Commit criado sem `-s`; o hook da #158 acrescentou exatamente um trailer automaticamente.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ensures automated release commits carry the required DCO sign-off and adds CI coverage for that contract.
- Changes the release bump to use `git commit -s`.
- Extends the release evaluator with RLS3 and the `semdco` mutation.
- Runs the release contract evaluation in CI.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds the sign-off flag to the automated release commit. |
| tools/eval/release-check.mjs | Checks every detected release commit for a DCO sign-off and adds mutation coverage. |
| .github/workflows/ci.yml | Adds the release contract evaluator to the CI job. |
| package.json | Updates the release evaluator documentation to describe the DCO invariant and mutation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): assina commit automatico"](https://github.com/rubenmarcus/csbrasil/commit/208d92a9cc0b8fc7a734546e8eabb8806bfdb7c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51681845)</sub>

<!-- /greptile_comment -->