### PR TITLE
fix(webgl): WeakMap do drawBuffers não derruba mais o loop (issue #171)

### DIFF
--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -84,6 +84,27 @@ true; }`). EP4 exige early-return e dispatch único; EP5 recorta a condição
 inteira do step de issue; EP6 **executa** a `origemDoJogo` inline do cliente
 contra oito fixtures (mutantes `sem-early-return` e `abre-externo`).
 
+### ~~BUG-50 · WeakMap do Three derrubava o loop quando createFramebuffer falhava~~ · RESOLVIDO 12/08 (issue #171)
+
+**Evidência antes.** Issue #171 (fingerprint `b598fe98`, alpha.57): `TypeError:
+WeakMap keys must be objects or non-registered symbols`, stack
+`drawBuffers@three.module.js:23160` ← `setRenderTarget` ← `RenderPass` do
+`EffectComposer` (bloom) ← `game.update`. Reproduzida ainda na alpha.81.
+
+**Causa.** `drawBuffers(renderTarget, framebuffer)` chama
+`currentDrawbuffers.set(framebuffer, …)` sem guarda. Quando `gl.createFramebuffer()`
+falha — pressão de memória GL ou perda de contexto síncrona — o framebuffer fica
+nulo, o `WeakMap.set` lança e o `requestAnimationFrame` morre no meio da partida.
+
+**Correção.** Guarda no vendor: framebuffer nulo retorna sem emitir drawBuffers.
+Os três caminhos normais (alvo simples, MRT, tela) continuam emitindo os mesmos
+buffers. Arnêses `public/*.html` receberam o hash novo do vendor (`?h=`).
+
+**Régua.** SL7 do `tools/eval/shader-log-check.mjs` extrai e executa a
+`drawBuffers` real do vendor: framebuffer nulo não pode lançar nem emitir, e os
+caminhos normais têm os buffers comparados byte a byte. Mutante `framebuffer-nulo`
+remove a guarda e acende a SL7.
+
 ### ~~BUG-49 · toda página SSR servia 200 com corpo VAZIO em produção~~ · RESOLVIDO 12/08
 
 **Sintoma literal.** O dono, 12/08: *"a pagina mapa online (aovivo) esta quebrada"*.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eval:error-origin": "node tools/eval/error-provenance-check.mjs",
     "//eval:webgl": "Compatibilidade Linux/WebGL: executa a factory real com contextos controlados, exige degradação sem falso crash, fundo opcional, recuperação, qualidade temporária e zero sondas extras. Mutantes: alto-primeiro|sem-webgl1|erro-provisorio|contexto-extra|fundo-fatal|sem-context-loss|qualidade-persistida|canvas-reusado|preview-null.",
     "eval:webgl": "node tools/eval/webgl-compat-check.mjs",
-    "//eval:shaderlog": "Logs WebGL nulos viram string vazia antes de trim; rotas usam versão, arnêses usam hash do core e addons sem URL própria revalidam na origem/CDN. Mutantes: sem-guardas|sem-cache-bust|addons-immutable|cloudflare-vendor.",
+    "//eval:shaderlog": "Logs WebGL nulos viram string vazia antes de trim; framebuffer nulo não derruba o WeakMap de drawBuffers; rotas usam versão, arnêses usam hash do core e addons sem URL própria revalidam na origem/CDN. Mutantes: sem-guardas|sem-cache-bust|addons-immutable|cloudflare-vendor|framebuffer-nulo.",
     "eval:shaderlog": "node tools/eval/shader-log-check.mjs",
     "//eval:shaderbudget": "Todas as primitivas da urna precisam caber nos 8 varying vectors mínimos do WebGL1; deriva materiais, instancing, sombras/cookies, protege fog/triplanar e o grafo publicado completo do cache-bust. Mutantes: fog-separado|tri-separado|tri-varying|tri-helper-varying|sem-install|sem-patch|tri-flat|lam-flat|urna-color|urna-clearcoat|urna-anisotropy|urna-instancing|urna-segunda|sombra-extra|sombra-condicional|sombra-pontual|sombra-reativada|spot-map|cache-antigo|cache-omitido|cache-constante|cache-podado|cache-entry-site.",
     "eval:shaderbudget": "node tools/eval/shader-budget-check.mjs",

--- a/public/botview.html
+++ b/public/botview.html
@@ -5,7 +5,7 @@
 <title>bot weapon view</title>
 <style>body{margin:0;background:#2a2e35}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/charlineup.html
+++ b/public/charlineup.html
@@ -5,7 +5,7 @@
 <title>char lineup — cor e iluminação do elenco, na cena do jogo</title>
 <style>html,body{margin:0;height:100%;background:#000;overflow:hidden}canvas{display:block}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/clima.html
+++ b/public/clima.html
@@ -48,7 +48,7 @@
   #hud{position:fixed;left:8px;top:8px;color:#cfe0f0;text-shadow:0 1px 2px #000;z-index:9}
 </style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/dev.html
+++ b/public/dev.html
@@ -140,7 +140,7 @@
   .ammo{position:absolute;right:16px;bottom:14px;font-size:22px;letter-spacing:1px;color:#cfe;background:rgba(10,12,16,.6);padding:5px 12px;border-radius:7px;min-width:96px;text-align:center}
 </style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/eval.html
+++ b/public/eval.html
@@ -5,7 +5,7 @@
 <title>eval — medição de personagem</title>
 <style>html,body{margin:0;height:100%;background:#000;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#6f6;white-space:pre;z-index:9;text-shadow:0 0 3px #000}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/fveval.html
+++ b/public/fveval.html
@@ -5,7 +5,7 @@
 <title>ferro velho eval — beco oeste</title>
 <style>html,body{margin:0;height:100%;background:#8fb7e0;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#012;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/iktest.html
+++ b/public/iktest.html
@@ -6,7 +6,7 @@
 <title>IK test — mão de apoio</title>
 <style>html,body{margin:0;height:100%;background:#20242b;overflow:hidden}#hud{position:fixed;left:8px;top:8px;font:12px monospace;color:#9fe;white-space:pre;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/mapeval.html
+++ b/public/mapeval.html
@@ -5,7 +5,7 @@
 <title>map eval — landmarks</title>
 <style>html,body{margin:0;height:100%;background:#8fb7e0;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#012;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/mapview.html
+++ b/public/mapview.html
@@ -5,7 +5,7 @@
 <title>mapview — eval genérico de mapa</title>
 <style>html,body{margin:0;height:100%;background:#8fb7e0;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#012;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/modelviewer.html
+++ b/public/modelviewer.html
@@ -6,7 +6,7 @@
 <title>CS BRASIL — model viewer (dev)</title>
 <style>html,body{margin:0;height:100%;background:#20242b;overflow:hidden}#hud{position:fixed;top:8px;left:8px;font:14px monospace;color:#7CFC00;text-shadow:0 1px 2px #000}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/mounttest.html
+++ b/public/mounttest.html
@@ -6,7 +6,7 @@
 <title>mount test — arma pra frente?</title>
 <style>html,body{margin:0;height:100%;background:#20242b;overflow:hidden}#hud{position:fixed;left:8px;top:8px;font:12px monospace;color:#9fe;white-space:pre;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/vendor/three.module.js
+++ b/public/vendor/three.module.js
@@ -23161,6 +23161,9 @@ function WebGLState( gl, extensions, capabilities ) {
 
 			if ( drawBuffers === undefined ) {
 
+				// #171: createFramebuffer() pode falhar sob pressão/perda de contexto; sem a guarda o WeakMap.set lança e mata o loop
+				if ( framebuffer == null ) return;
+
 				drawBuffers = [];
 				currentDrawbuffers.set( framebuffer, drawBuffers );
 

--- a/public/vm-inspect.html
+++ b/public/vm-inspect.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html><head><meta charset="utf-8"><title>vm inspect</title>
 <style>html,body{margin:0;height:100%;background:#223}</style>
-<script type="importmap">{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }</script>
+<script type="importmap">{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }</script>
 </head><body><script type="module">
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/public/weaponeval.html
+++ b/public/weaponeval.html
@@ -5,7 +5,7 @@
 <title>weapon eval</title>
 <style>body{margin:0;background:#222;color:#eee;font:12px monospace}#hud{position:fixed;top:4px;left:8px;z-index:2}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/weapontest.html
+++ b/public/weapontest.html
@@ -6,7 +6,7 @@
 <title>weapon orientation test</title>
 <style>html,body{margin:0;height:100%;background:#22262e;overflow:hidden}#hud{position:fixed;left:8px;top:8px;font:13px monospace;color:#9fe;white-space:pre;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=ba5e961f35ac", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/tools/eval/shader-log-check.mjs
+++ b/tools/eval/shader-log-check.mjs
@@ -1,9 +1,10 @@
-/* Logs WebGL anuláveis não podem esconder o diagnóstico real do shader. */
+/* Logs WebGL anuláveis não podem esconder o diagnóstico real do shader.
+   E o WeakMap de drawBuffers não pode derrubar o loop quando createFramebuffer falha (#171). */
 import { createHash } from 'node:crypto';
 import { readFileSync, readdirSync } from 'node:fs';
 
 const mutant = (process.argv.find((arg) => arg.startsWith('--mutante=')) || '').split('=')[1] || '';
-if (mutant && !['sem-guardas', 'sem-cache-bust', 'addons-immutable', 'cloudflare-vendor'].includes(mutant)) {
+if (mutant && !['sem-guardas', 'sem-cache-bust', 'addons-immutable', 'cloudflare-vendor', 'framebuffer-nulo'].includes(mutant)) {
   throw new Error(`mutante desconhecido: ${mutant}`);
 }
 
@@ -27,6 +28,14 @@ if (mutant === 'sem-guardas') {
     /(gl\.get(?:Shader|Program)InfoLog\([^;]+\))\s*\|\|\s*'';/g,
     '$1;',
   );
+}
+if (mutant === 'framebuffer-nulo') {
+  const before = vendor;
+  vendor = vendor.replace(
+    /\n\t\t\t\tif \( framebuffer == null \) return;[^\n]*\n/,
+    '',
+  );
+  if (vendor === before) throw new Error('MUTANTE NAO APLICOU: framebuffer-nulo');
 }
 if (mutant === 'sem-cache-bust') {
   productSources = productSources.map(([file, source]) => [file, source.replace('?v=${V}', '')]);
@@ -102,11 +111,61 @@ if (immutableVendor || !revalidatesNow || cloudflareSetup.includes('starts_with(
   failures.push('SL6 addons do Three sem URL própria precisam revalidar no servidor');
 }
 
+/* SL7 executa a drawBuffers REAL do vendor: com framebuffer nulo (falha de
+   alocação sob pressão/perda de contexto, #171) ela não pode lançar — e os
+   caminhos normais precisam continuar emitindo os mesmos draw buffers. */
+const drawBuffersMatch = vendor.match(/function drawBuffers\( renderTarget, framebuffer \) \{[\s\S]*?\n\t\}/);
+let drawBuffersFn = null;
+if (drawBuffersMatch) {
+  try {
+    drawBuffersFn = Function(
+      'defaultDrawbuffers', 'currentDrawbuffers', 'gl', 'capabilities', 'extensions',
+      `${drawBuffersMatch[0]}\nreturn drawBuffers;`,
+    );
+  } catch { /* SL7 vermelha abaixo */ }
+}
+const runDrawBuffers = (renderTarget, framebuffer) => {
+  const calls = [];
+  const gl = {
+    COLOR_ATTACHMENT0: 0x8CE0,
+    BACK: 0x0405,
+    drawBuffers: (buffers) => calls.push(buffers.slice()),
+  };
+  const extensions = { get: () => ({ drawBuffersWEBGL: (buffers) => calls.push(buffers.slice()) }) };
+  drawBuffersFn([], new WeakMap(), gl, { isWebGL2: true }, extensions)(renderTarget, framebuffer);
+  return calls;
+};
+if (!drawBuffersFn) {
+  failures.push('SL7 drawBuffers não encontrada no vendor');
+} else {
+  try {
+    const calls = runDrawBuffers({ isWebGLMultipleRenderTargets: false }, null);
+    if (calls.length) failures.push('SL7 framebuffer nulo não devia emitir drawBuffers');
+  } catch (error) {
+    failures.push(`SL7 framebuffer nulo derruba o loop: ${error.message}`);
+  }
+  const esperados = [
+    [{ isWebGLMultipleRenderTargets: false }, {}, [0x8CE0]],
+    [{ isWebGLMultipleRenderTargets: true, texture: [{}, {}] }, {}, [0x8CE0, 0x8CE1]],
+    [null, {}, [0x0405]],
+  ];
+  for (const [renderTarget, framebuffer, esperado] of esperados) {
+    try {
+      const calls = runDrawBuffers(renderTarget, framebuffer);
+      if (calls.length !== 1 || calls[0].join(',') !== esperado.join(',')) {
+        failures.push(`SL7 caminho normal alterado: [${calls.map((c) => c.join(',')).join('|')}] ≠ [${esperado.join(',')}]`);
+      }
+    } catch (error) {
+      failures.push(`SL7 caminho normal quebrou: ${error.message}`);
+    }
+  }
+}
+
 if (mutant && !failures.length) failures.push(`mutação ${mutant} não foi detectada`);
 for (const failure of failures) console.error(`  \x1b[31m✗\x1b[0m ${failure}`);
 if (failures.length) {
   console.error(`\x1b[31mSHADER-LOG ${failures.length} VERMELHA(S)\x1b[0m${mutant ? ` (mutante=${mutant})` : ''}`);
   process.exitCode = 1;
 } else {
-  console.log('\x1b[32mSHADER-LOG verde: logs nulos e entrega versionada protegidos\x1b[0m');
+  console.log('\x1b[32mSHADER-LOG verde: logs nulos, framebuffer nulo e entrega versionada protegidos\x1b[0m');
 }


### PR DESCRIPTION
## O que muda

Fecha a #171. Quando `gl.createFramebuffer()` falha — pressão de memória GL ou perda de contexto síncrona — o framebuffer fica nulo e o `currentDrawbuffers.set(framebuffer, …)` do Three lançava `TypeError: WeakMap keys must be objects`, matando o `requestAnimationFrame` no meio da partida (stack: `drawBuffers` ← `setRenderTarget` ← `RenderPass` do composer/bloom).

- **Guarda no vendor** (`three.module.js`): framebuffer nulo retorna sem emitir drawBuffers. Os três caminhos normais (alvo simples, MRT, tela) continuam emitindo exatamente os mesmos buffers.
- **Entrega**: os 13 arnêses `public/*.html` re-ancorados no hash novo do vendor (`?h=`), como manda a SL5 — sem isso o patch não chegaria a quem já jogou.

## Verificação (régua antes do conserto)

- **SL7 nova** no `shader-log-check.mjs`: extrai e executa a `drawBuffers` **real** do vendor — framebuffer nulo não pode lançar nem emitir; os caminhos normais têm os buffers comparados um a um.
- Régua **vermelha antes** (`Invalid value used as weak map key`, reproduzindo a #171) e **verde depois**.
- **5/5 mutantes** vermelhos na cláusula certa, incluindo o novo `framebuffer-nulo`.
- `check:fast` 30/31 (`audio:check` só reprova por assets não versionados no clone local — fora do diff) e `npm run build` ok.

Detalhes: `KNOWN-BUGS.md`, entrada **BUG-50**.

Agent: Kimi Code

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents Three.js from inserting a null framebuffer into the `drawBuffers` WeakMap and updates browser cache keys so the patched vendor bundle is delivered.
- Adds a null-framebuffer guard to the vendored WebGL state implementation.
- Adds regression coverage for null, single-target, MRT, and screen draw-buffer paths.
- Updates the affected HTML harnesses to the new content hash and documents BUG-50 as resolved.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/vendor/three.module.js | Adds the targeted null-key guard before the draw-buffer WeakMap is populated. |
| tools/eval/shader-log-check.mjs | Adds focused execution-based regression checks and a mutation mode for the framebuffer-null guard. |
| package.json | Updates the shader-log check description to include the new invariant and mutant. |
| KNOWN-BUGS.md | Documents the reported failure, patch, delivery update, and regression coverage. |
| public/clima.html | Updates the Three.js import-map content hash consistently with the patched vendor bundle. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[setRenderTarget] --> B[createFramebuffer]
    B -->|object| C[drawBuffers selects attachments]
    B -->|null| D[drawBuffers returns early]
    D --> E[WeakMap insertion avoided]
    C --> F[Rendering continues]
    E --> F
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(webgl): clima.html acompanha o hash ..."](https://github.com/rubenmarcus/csbrasil/commit/b6da0df07e48f31c6a0ed8b8cfe607c6f422be26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52417148)</sub>

<!-- /greptile_comment -->