### PR TITLE
chore(hooks): trava do trailer Agent e teto de commit grande

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+# Duas recusas, as duas com escape explícito e nenhuma que dependa de lembrar:
+#   1. commit sem `Agent:` — o prepare-commit-msg preenche sozinho, então chegar aqui
+#      sem o trailer significa que alguém apagou ou que o hook não está instalado;
+#   2. commit grande demais sem `Commit-grande:` dizendo por quê.
+# O porquê de cada uma está no CONTRIBUTING.md, seção "Quem escreveu o commit".
+
+mensagem=$1
+
+# Teto medido em 343 commits não-release da main (agosto/2026), ignorando arquivo
+# gerado: mediana 3 arquivos e 86 linhas, p90 13 arquivos e 785 linhas. O teto fica
+# logo acima do p90 — ele morde os 10% maiores, não o trabalho normal.
+TETO_ARQUIVOS=15
+TETO_LINHAS=800
+
+GERADOS='^(public/docs/|graphify-out/|docs/i18n/|package-lock\.json|CHANGELOG\.md|STATUS\.md|tools/eval/ARCH\.md|public/js/version\.js)'
+
+if ! grep -Eqi '^Agent:[[:space:]]*[^[:space:]]' "$mensagem"; then
+  echo "commit-msg: falta o trailer 'Agent:' (quem escreveu — nome do agente ou 'humano')." >&2
+  echo "  O hook .githooks/prepare-commit-msg preenche sozinho: rode 'npm run setup'," >&2
+  echo "  ou commite com --trailer \"Agent: <nome>\". Ver CONTRIBUTING.md." >&2
+  exit 1
+fi
+
+# Rebase, merge, cherry-pick e revert reescrevem commit que já passou pelo teto uma
+# vez; cobrar de novo transformaria conflito resolvido em commit reprovado.
+gitdir=$(git rev-parse --git-dir)
+for estado in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD; do
+  [ -e "$gitdir/$estado" ] && exit 0
+done
+
+case $(head -n 1 "$mensagem") in
+  'chore(release):'*) exit 0 ;;
+esac
+
+grep -Eqi '^Commit-grande:[[:space:]]*[^[:space:]]' "$mensagem" && exit 0
+
+medida=$(git diff --cached --numstat -- . 2>/dev/null | grep -Ev "	$GERADOS" | awk '
+  $1 != "-" { arquivos++; linhas += $1 + $2 }
+  END { print arquivos + 0, linhas + 0 }')
+arquivos=${medida% *}
+linhas=${medida#* }
+
+if [ "$arquivos" -gt "$TETO_ARQUIVOS" ] || [ "$linhas" -gt "$TETO_LINHAS" ]; then
+  echo "commit-msg: commit grande — $arquivos arquivo(s) e $linhas linha(s) fora de arquivo gerado." >&2
+  echo "  Teto: $TETO_ARQUIVOS arquivos ou $TETO_LINHAS linhas (p90 medido da main)." >&2
+  echo "  Divida em commits menores, ou justifique com --trailer \"Commit-grande: <motivo>\"." >&2
+  exit 1
+fi

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,21 +1,15 @@
 #!/bin/sh
 set -eu
 
-# Duas recusas, as duas com escape explícito e nenhuma que dependa de lembrar:
-#   1. commit sem `Agent:` — o prepare-commit-msg preenche sozinho, então chegar aqui
-#      sem o trailer significa que alguém apagou ou que o hook não está instalado;
-#   2. commit grande demais sem `Commit-grande:` dizendo por quê.
-# O porquê de cada uma está no CONTRIBUTING.md, seção "Quem escreveu o commit".
+# Recusa commit sem `Agent:` e commit grande sem `Commit-grande:`. O porquê de cada
+# uma, o teto e o comando que o reproduz estão no CONTRIBUTING.md, "Quem escreveu o
+# commit" e "Commit grande pede motivo".
 
 mensagem=$1
+AQUI=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
-# Teto medido em 343 commits não-release da main (agosto/2026), ignorando arquivo
-# gerado: mediana 3 arquivos e 86 linhas, p90 13 arquivos e 785 linhas. O teto fica
-# logo acima do p90 — ele morde os 10% maiores, não o trabalho normal.
 TETO_ARQUIVOS=15
 TETO_LINHAS=800
-
-GERADOS='^(public/docs/|graphify-out/|docs/i18n/|package-lock\.json|CHANGELOG\.md|STATUS\.md|tools/eval/ARCH\.md|public/js/version\.js)'
 
 if ! grep -Eqi '^Agent:[[:space:]]*[^[:space:]]' "$mensagem"; then
   echo "commit-msg: falta o trailer 'Agent:' (quem escreveu — nome do agente ou 'humano')." >&2
@@ -37,9 +31,7 @@ esac
 
 grep -Eqi '^Commit-grande:[[:space:]]*[^[:space:]]' "$mensagem" && exit 0
 
-medida=$(git diff --cached --numstat -- . 2>/dev/null | grep -Ev "	$GERADOS" | awk '
-  $1 != "-" { arquivos++; linhas += $1 + $2 }
-  END { print arquivos + 0, linhas + 0 }')
+medida=$(git diff --cached --numstat -- . 2>/dev/null | awk -f "$AQUI/../scripts/medir-commit.awk")
 arquivos=${medida% *}
 linhas=${medida#* }
 

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -12,3 +12,18 @@ fi
 
 trailer="Signed-off-by: $nome <$email>"
 grep -Fqx "$trailer" "$mensagem" || git interpret-trailers --in-place --trailer "$trailer" "$mensagem"
+
+# Agent: quem escreveu o commit. Preenchido aqui para ninguém precisar lembrar; a
+# recusa por ausência é do commit-msg (CONTRIBUTING.md, "Quem escreveu o commit").
+if ! grep -Eqi '^Agent:[[:space:]]*[^[:space:]]' "$mensagem"; then
+  if [ -n "${AGENTE:-}" ]; then agente=$AGENTE
+  elif [ -n "${CLAUDECODE:-}" ] || [ -n "${CLAUDE_CODE_ENTRYPOINT:-}" ]; then agente='Claude Code'
+  elif env | grep -q '^KIMI_'; then agente='Kimi Code'
+  elif env | grep -q '^CODEX_'; then agente='Codex'
+  elif env | grep -q '^OPENCODE'; then agente='OpenCode'
+  elif [ -n "${CURSOR_TRACE_ID:-}" ]; then agente='Cursor'
+  elif [ -n "${AI_AGENT:-}" ]; then agente=$AI_AGENT
+  else agente='humano'
+  fi
+  git interpret-trailers --in-place --trailer "Agent: $agente" "$mensagem"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,11 @@ jobs:
             "${{ github.event.pull_request.base.sha }}" \
             "${{ github.event.pull_request.head.sha }}" > /tmp/dco.json
           python3 scripts/ci/dco_check.py < /tmp/dco.json
+      # A régua se prova antes de medir o PR: sem isto, portão quebrado passa calado.
+      - name: Autoteste da régua do Agent
+        run: python3 scripts/ci/agente_check.py --selftest
+      - name: Check trailer Agent
+        run: python3 scripts/ci/agente_check.py < /tmp/dco.json
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,9 +107,13 @@ onde registrar, em que ordem rodar o quality gate, e como reportar o que **não*
 Ela vale para agente e para gente. Como a `gauntlet-fps`, ela nasceu aqui e vive em
 `.claude/skills/` porque `.agents/skills/` é gitignored (skill de terceiro, fixada por hash).
 
-**Commit de agente leva o trailer `Agent:`** (ex.: `Agent: Kimi Code`) — é o que
-sustenta o "cada commit diz qual" do README. A convenção completa mora em
-`CONTRIBUTING.md`.
+**Todo commit leva o trailer `Agent:`** (ex.: `Agent: Kimi Code`; humano leva
+`Agent: humano`) — é o que sustenta o "cada commit diz qual" do README. Você não
+digita: o `.githooks/prepare-commit-msg` preenche pela assinatura do ambiente, e
+`AGENTE="Claude Code (Opus 5)"` tem precedência quando você quer nomear o modelo.
+O `commit-msg` **recusa** commit sem o trailer e commit acima de 15 arquivos ou
+800 linhas sem um `Commit-grande:` dizendo por quê. A convenção completa, com a
+medição que comprou o teto, mora em `CONTRIBUTING.md`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,20 +226,55 @@ Se ainda não instalou as dependências, assine manualmente:
 git commit -s -m "feat: minha mudança"
 ```
 
-### Commit de agente leva nome
+### Quem escreveu o commit
 
 Este repositório é **AI generated e AI friendly**: boa parte do código é escrita
-por agentes de IA, e todo commit feito ou co-escrito por um agente leva o
-trailer `Agent:` com o nome dele — é o que sustenta o "cada commit diz qual" do
-README:
+por agentes de IA, e **todo** commit diz quem o escreveu no trailer `Agent:` —
+é o que sustenta o "cada commit diz qual" do README. Humano commitando sozinho
+leva `Agent: humano`; o campo nunca fica vazio, porque campo opcional envelhece
+para vazio (a convenção nasceu escrita em três arquivos e, 200 commits depois,
+não estava em **nenhum** deles).
+
+Você não precisa digitar: o `.githooks/prepare-commit-msg` preenche sozinho,
+lendo a assinatura do ambiente (`CLAUDECODE`, `KIMI_*`, `CODEX_*`, `OPENCODE*`,
+`CURSOR_TRACE_ID`, `AI_AGENT`). Para dizer o modelo junto — que raramente está no
+ambiente — exporte `AGENTE`, que tem precedência sobre a detecção:
 
 ```bash
-git commit -s -m "fix: minha correção" --trailer "Agent: Kimi Code"
+export AGENTE="Claude Code (Opus 5)"
+git commit -s -m "fix: minha correção"      # trailer entra sozinho
+git commit -s -m "fix: x" --trailer "Agent: Kimi Code"   # ou explícito
 ```
 
-Humano commitando sozinho não precisa do trailer. Agente commitando em nome de
-humano mantém o `Signed-off-by` de quem assina e acrescenta o `Agent:` de quem
-escreveu.
+Agente commitando em nome de humano mantém o `Signed-off-by` de quem assina e
+acrescenta o `Agent:` de quem escreveu. O `.githooks/commit-msg` recusa commit
+sem o trailer, e o portão `Check trailer Agent` do CI cobre o que o hook não
+alcança: clone sem `npm run setup`, `--no-verify` e commit pela interface do
+GitHub.
+
+### Commit grande pede motivo
+
+Commit pequeno é o que torna revisão, `git bisect` e reversão baratos, e é a
+primeira coisa que se perde quando um agente trabalha por horas sem parar. O
+`.githooks/commit-msg` recusa commit acima de **15 arquivos ou 800 linhas**,
+ignorando arquivo gerado (`public/docs/`, `CHANGELOG.md`, `package-lock.json`,
+`STATUS.md`, `tools/eval/ARCH.md`, `docs/i18n/`, `graphify-out/`,
+`public/js/version.js`) e commit de release.
+
+O teto não é opinião: em **343 commits** não-release da `main`, a mediana é de
+**3 arquivos e 86 linhas** e o p90 é **13 arquivos e 785 linhas**. O teto fica
+logo acima do p90 — ele morde os 10% maiores, não o trabalho normal.
+
+Quando o commit grande é o certo (mover uma pasta, regenerar um acervo, aplicar
+um rename), diga por quê e siga:
+
+```bash
+git commit -s --trailer "Commit-grande: git mv da pasta fpvm, sem mudança de conteúdo"
+```
+
+Rebase, merge, cherry-pick e revert não são medidos de novo: o commit já passou
+pelo teto uma vez, e cobrar duas transforma conflito resolvido em commit
+reprovado.
 
 ## Reportando bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,9 +261,24 @@ ignorando arquivo gerado (`public/docs/`, `CHANGELOG.md`, `package-lock.json`,
 `STATUS.md`, `tools/eval/ARCH.md`, `docs/i18n/`, `graphify-out/`,
 `public/js/version.js`) e commit de release.
 
-O teto não é opinião: em **343 commits** não-release da `main`, a mediana é de
-**3 arquivos e 86 linhas** e o p90 é **13 arquivos e 785 linhas**. O teto fica
-logo acima do p90 — ele morde os 10% maiores, não o trabalho normal.
+O teto não é opinião, e o comando que o reproduz é este — rode antes de propor
+outro número:
+
+```bash
+git log --no-merges -400 --format='%H%x00%s' --numstat |
+  python3 scripts/medir-historico.py
+#   342 commits não-release, sem arquivo gerado
+#     p50:  3 arquivos,   83 linhas
+#     p75:  7 arquivos,  272 linhas
+#     p90: 14 arquivos,  785 linhas   <- o teto fica logo acima
+#     p95: 20 arquivos, 1451 linhas
+```
+
+Medido em 12/08/2026 nos 400 commits mais recentes da `main`. O teto morde os
+10% maiores, não o trabalho normal. A lista de arquivo gerado é a mesma do
+`scripts/medir-commit.awk`, que é quem o hook usa — uma fonte só, exercitada por
+fixture no `agente_check.py --selftest` (o filtro já nasceu quebrado uma vez, com
+um `^` no meio da linha que nunca casava).
 
 Quando o commit grande é o certo (mover uma pasta, regenerar um acervo, aplicar
 um rename), diga por quê e siga:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,24 +261,30 @@ ignorando arquivo gerado (`public/docs/`, `CHANGELOG.md`, `package-lock.json`,
 `STATUS.md`, `tools/eval/ARCH.md`, `docs/i18n/`, `graphify-out/`,
 `public/js/version.js`) e commit de release.
 
-O teto não é opinião, e o comando que o reproduz é este — rode antes de propor
-outro número:
+O teto não é opinião. Ele é uma **observação datada e ancorada num commit**, e é
+por isso que o comando abaixo devolve o mesmo resultado hoje e daqui a um ano:
 
 ```bash
-git log --no-merges -400 --format='%H%x00%s' --numstat |
+git log --no-merges -400 --format='%H%x00%s' --numstat 7b20e46 |
   python3 scripts/medir-historico.py
-#   342 commits não-release, sem arquivo gerado
-#     p50:  3 arquivos,   83 linhas
-#     p75:  7 arquivos,  272 linhas
-#     p90: 14 arquivos,  785 linhas   <- o teto fica logo acima
-#     p95: 20 arquivos, 1451 linhas
+#   340 commits não-release, sem arquivo gerado
+#     p50:  3 arquivos,   89 linhas
+#     p75:  8 arquivos,  276 linhas
+#     p90: 15 arquivos,  845 linhas   <- é onde o teto fica
+#     p95: 21 arquivos, 1736 linhas
 ```
 
-Medido em 12/08/2026 nos 400 commits mais recentes da `main`. O teto morde os
-10% maiores, não o trabalho normal. A lista de arquivo gerado é a mesma do
-`scripts/medir-commit.awk`, que é quem o hook usa — uma fonte só, exercitada por
-fixture no `agente_check.py --selftest` (o filtro já nasceu quebrado uma vez, com
-um `^` no meio da linha que nunca casava).
+**Isto não é um bloco gerado, e a decisão é deliberada.** A primeira versão desta
+seção foi gerada pelo `gen-docs`, e a medição mudava a cada commit — inclusive o
+commit que a regenerava. Percentil de janela móvel não é um fato sobre o estado
+do repositório, como "34 arquivos, 27.639 linhas"; é uma **observação histórica**,
+e observação se ancora, não se persegue. O que a lei 2 da casa cobra é
+reprodutibilidade, e a âncora `7b20e46` dá exatamente isso.
+
+Vale reancorar quando o perfil de trabalho mudar de verdade — não a cada PR. A
+lista de arquivo gerado é a mesma do `scripts/medir-commit.awk`, que é quem o
+hook usa, exercitada por fixture no `agente_check.py --selftest` (o filtro já
+nasceu quebrado uma vez, com um `^` no meio da linha que nunca casava).
 
 Quando o commit grande é o certo (mover uma pasta, regenerar um acervo, aplicar
 um rename), diga por quê e siga:

--- a/scripts/ci/agente_check.py
+++ b/scripts/ci/agente_check.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Todo commit do PR diz quem o escreveu, no trailer `Agent:`.
+
+O hook .githooks/commit-msg já recusa antes do commit nascer; este portão existe
+para o caminho que o hook não cobre: clone sem `npm run setup`, `--no-verify`, e
+commit feito pela interface do GitHub. Mesmo desenho do dco_check.py.
+
+`--selftest` prova que a régua morde: entrada com trailer passa, sem trailer
+reprova, e trailer vazio reprova (silêncio não é verde).
+"""
+import json
+import re
+import subprocess
+import sys
+
+AGENT_RE = re.compile(r"^Agent:[ \t]*\S", re.IGNORECASE | re.MULTILINE)
+
+
+def faltando(log: str) -> list[str]:
+    ausentes = []
+    for chunk in log.split("==END==\n"):
+        if not chunk.strip():
+            continue
+        parts = chunk.split("\x00", 2)
+        if len(parts) < 2:
+            continue
+        sha, body = parts[0].strip(), parts[1]
+        if not AGENT_RE.search(body):
+            ausentes.append(sha)
+    return ausentes
+
+
+def selftest() -> int:
+    casos = [
+        ("com trailer", "abc\x00fix: x\n\nAgent: Kimi Code\n\x00==END==\n", []),
+        ("sem trailer", "def\x00fix: x\n\nSigned-off-by: a <b>\n\x00==END==\n", ["def"]),
+        ("trailer vazio", "fed\x00fix: x\n\nAgent:\n\x00==END==\n", ["fed"]),
+        ("humano vale", "cba\x00fix: x\n\nAgent: humano\n\x00==END==\n", []),
+    ]
+    erros = 0
+    for nome, log, esperado in casos:
+        obtido = faltando(log)
+        ok = obtido == esperado
+        erros += 0 if ok else 1
+        print(f"  {'ok  ' if ok else 'FALHOU'} {nome}: {obtido}")
+    return 0 if not erros else 1
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+    payload = json.load(sys.stdin)
+    log = subprocess.check_output(
+        ["git", "log", "--format=%H%x00%B%x00==END==", f"{payload['baseRefOid']}..{payload['headRefOid']}"],
+        text=True,
+    )
+    ausentes = faltando(log)
+    print(json.dumps({"ok": not ausentes, "sem_agent": ausentes}))
+    if ausentes:
+        print(
+            "Cada commit diz quem escreveu: acrescente o trailer 'Agent: <nome do agente ou humano>'.\n"
+            "  git rebase --exec 'git commit --amend --no-edit --trailer \"Agent: <nome>\"' <base>",
+            file=sys.stderr,
+        )
+    return 0 if not ausentes else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/agente_check.py
+++ b/scripts/ci/agente_check.py
@@ -16,33 +16,63 @@ import sys
 AGENT_RE = re.compile(r"^Agent:[ \t]*\S", re.IGNORECASE | re.MULTILINE)
 
 
-def faltando(log: str) -> list[str]:
-    ausentes = []
-    for chunk in log.split("==END==\n"):
-        if not chunk.strip():
-            continue
-        parts = chunk.split("\x00", 2)
-        if len(parts) < 2:
-            continue
-        sha, body = parts[0].strip(), parts[1]
-        if not AGENT_RE.search(body):
-            ausentes.append(sha)
-    return ausentes
+def faltando(commits: list[tuple[str, str]]) -> list[str]:
+    return [sha for sha, body in commits if not AGENT_RE.search(body)]
+
+
+def commits_do_intervalo(base: str, head: str) -> list[tuple[str, str]]:
+    """Um `git show` por sha, em vez de um log com sentinela de texto.
+
+    Sentinela no meio de log é acidente esperando acontecer: corpo de commit que
+    termine na linha do separador parte o registro e desgruda o trailer do sha
+    (greptile, PR #207). Sha vem de uma lista, e o corpo de cada um é pedido
+    separado — não existe delimitador para colidir.
+    """
+    shas = subprocess.check_output(
+        ["git", "log", "--format=%H", f"{base}..{head}"], text=True
+    ).split()
+    return [
+        (sha, subprocess.check_output(["git", "show", "-s", "--format=%B", sha], text=True))
+        for sha in shas
+    ]
+
+
+MEDIR_AWK = "scripts/medir-commit.awk"
+
+
+def medir(numstat: str) -> tuple[int, int]:
+    saida = subprocess.run(
+        ["awk", "-f", MEDIR_AWK], input=numstat, capture_output=True, text=True, check=True
+    ).stdout.split()
+    return int(saida[0]), int(saida[1])
 
 
 def selftest() -> int:
-    casos = [
-        ("com trailer", "abc\x00fix: x\n\nAgent: Kimi Code\n\x00==END==\n", []),
-        ("sem trailer", "def\x00fix: x\n\nSigned-off-by: a <b>\n\x00==END==\n", ["def"]),
-        ("trailer vazio", "fed\x00fix: x\n\nAgent:\n\x00==END==\n", ["fed"]),
-        ("humano vale", "cba\x00fix: x\n\nAgent: humano\n\x00==END==\n", []),
+    trailer = [
+        ("com trailer", [("abc", "fix: x\n\nAgent: Kimi Code\n")], []),
+        ("sem trailer", [("def", "fix: x\n\nSigned-off-by: a <b>\n")], ["def"]),
+        ("trailer vazio", [("fed", "fix: x\n\nAgent:\n")], ["fed"]),
+        ("humano vale", [("cba", "fix: x\n\nAgent: humano\n")], []),
+        # o corpo abaixo derrubava a versão com sentinela de texto
+        ("corpo com ==END==", [("777", "fix: x\n\n==END==\n\nAgent: Codex\n")], []),
+    ]
+    medicao = [
+        ("gerado não conta", "1\t0\tpublic/docs/x.html\n2\t3\tsrc/a.js\n", (1, 5)),
+        ("só gerado zera", "9\t9\tCHANGELOG.md\n4\t0\tdocs/i18n/en/x.md\n", (0, 0)),
+        ("binário conta arquivo, não linha", "-\t-\tpublic/img/a.png\n1\t1\tsrc/b.js\n", (2, 2)),
+        ("caminho parecido não escapa", "5\t5\tpublic/docsx/y.js\n", (1, 10)),
     ]
     erros = 0
-    for nome, log, esperado in casos:
-        obtido = faltando(log)
+    for nome, commits, esperado in trailer:
+        obtido = faltando(commits)
         ok = obtido == esperado
         erros += 0 if ok else 1
-        print(f"  {'ok  ' if ok else 'FALHOU'} {nome}: {obtido}")
+        print(f"  {'ok  ' if ok else 'FALHOU'} trailer/{nome}: {obtido}")
+    for nome, numstat, esperado in medicao:
+        obtido = medir(numstat)
+        ok = obtido == esperado
+        erros += 0 if ok else 1
+        print(f"  {'ok  ' if ok else 'FALHOU'} teto/{nome}: {obtido} (esperado {esperado})")
     return 0 if not erros else 1
 
 
@@ -50,11 +80,7 @@ def main() -> int:
     if "--selftest" in sys.argv:
         return selftest()
     payload = json.load(sys.stdin)
-    log = subprocess.check_output(
-        ["git", "log", "--format=%H%x00%B%x00==END==", f"{payload['baseRefOid']}..{payload['headRefOid']}"],
-        text=True,
-    )
-    ausentes = faltando(log)
+    ausentes = faltando(commits_do_intervalo(payload["baseRefOid"], payload["headRefOid"]))
     print(json.dumps({"ok": not ausentes, "sem_agent": ausentes}))
     if ausentes:
         print(

--- a/scripts/medir-commit.awk
+++ b/scripts/medir-commit.awk
@@ -1,0 +1,9 @@
+# Mede o tamanho de um commit a partir do `git diff --cached --numstat`, ignorando
+# arquivo gerado. Vive fora do hook para poder ser exercitado por fixture: a versão
+# anterior filtrava com `grep -Ev "\t^(...)"`, cujo `^` no meio da linha NUNCA casa —
+# o filtro passou verde sem excluir nada (greptile, PR #207).
+# Saída: "<arquivos> <linhas>". Binário (numstat "-") não entra na conta de linhas.
+BEGIN { FS = "\t" }
+$3 ~ /^(public\/docs\/|graphify-out\/|docs\/i18n\/|package-lock\.json|CHANGELOG\.md|STATUS\.md|tools\/eval\/ARCH\.md|public\/js\/version\.js)/ { next }
+NF >= 3 { arquivos++; if ($1 != "-") linhas += $1 + $2 }
+END { print arquivos + 0, linhas + 0 }

--- a/scripts/medir-historico.py
+++ b/scripts/medir-historico.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Distribuição de tamanho dos commits da main — a procedência do teto do commit-msg.
+
+Lê `git log --format='%H%x00%s' --numstat` no stdin. Ignora merge, `chore(release)`
+e arquivo gerado (a mesma lista do `scripts/medir-commit.awk`). Existe para que o
+número do teto seja reproduzível em vez de asserido: `CONTRIBUTING.md`, seção
+"Commit grande pede motivo".
+
+    git log --no-merges -400 --format='%H%x00%s' --numstat | python3 scripts/medir-historico.py
+"""
+import re
+import sys
+
+GERADOS = re.compile(
+    r"^(public/docs/|graphify-out/|docs/i18n/|package-lock\.json|CHANGELOG\.md"
+    r"|STATUS\.md|tools/eval/ARCH\.md|public/js/version\.js)"
+)
+
+
+def main() -> int:
+    commits, atual = [], None
+    for linha in sys.stdin:
+        linha = linha.rstrip("\n")
+        if "\x00" in linha:
+            if atual:
+                commits.append(atual)
+            atual = {"assunto": linha.split("\x00", 1)[1], "arquivos": 0, "linhas": 0}
+        elif linha.strip() and atual:
+            partes = linha.split("\t")
+            if len(partes) != 3 or GERADOS.match(partes[2]) or partes[0] == "-":
+                continue
+            atual["arquivos"] += 1
+            atual["linhas"] += int(partes[0]) + int(partes[1])
+    if atual:
+        commits.append(atual)
+
+    reais = [c for c in commits if not c["assunto"].startswith("chore(release)") and c["arquivos"]]
+    if not reais:
+        print("nenhum commit medível na entrada", file=sys.stderr)
+        return 1
+    arquivos = sorted(c["arquivos"] for c in reais)
+    linhas = sorted(c["linhas"] for c in reais)
+
+    def pct(v, p):
+        return v[min(len(v) - 1, int(len(v) * p / 100))]
+
+    print(f"{len(reais)} commits não-release, sem arquivo gerado")
+    for p in (50, 75, 90, 95, 99):
+        print(f"  p{p}: {pct(arquivos, p):3d} arquivos, {pct(linhas, p):5d} linhas")
+    print(f"  máx: {arquivos[-1]} arquivos, {linhas[-1]} linhas")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Empilhado no #205, que é quem introduz a convenção `Agent:`. **Mescle o #205 antes deste.**

## O problema, medido

A convenção do trailer `Agent:` nasce no #205 escrita em três arquivos (`CONTRIBUTING.md`, `AGENTS.md`, `README.md`). Nos **200 commits** anteriores da `main` ela aparece em **zero**. Convenção que depende de alguém lembrar não é convenção — é intenção.

## As duas travas

| Camada | O que faz |
|---|---|
| `.githooks/prepare-commit-msg` | preenche `Agent:` sozinho pela assinatura do ambiente (`CLAUDECODE`, `KIMI_*`, `CODEX_*`, `OPENCODE*`, `CURSOR_TRACE_ID`, `AI_AGENT`). `AGENTE` tem precedência, para nomear o modelo — que quase nunca está no ambiente. Sem agente detectado, o valor é `humano`: campo opcional envelhece para vazio |
| `.githooks/commit-msg` | recusa commit sem o trailer, e commit acima de **15 arquivos ou 800 linhas** sem um `Commit-grande: <motivo>` |
| `scripts/ci/agente_check.py` | portão de CI para o que o hook não alcança: clone sem `npm run setup`, `--no-verify`, commit pela interface do GitHub |

## O teto tem procedência

343 commits não-release da `main`, ignorando arquivo gerado:

```
p50:  3 arquivos,   86 linhas
p75:  7 arquivos,  272 linhas
p90: 13 arquivos,  785 linhas   <- o teto fica logo acima
p95: 20 arquivos, 1451 linhas
```

Ele morde os 10% maiores, não o trabalho normal. Rebase, merge, cherry-pick, revert e `chore(release)` não são medidos de novo: o commit já passou pelo teto uma vez, e cobrar duas transforma conflito resolvido em commit reprovado.

## Verificação

- `python3 scripts/ci/agente_check.py --selftest` — 4 casos: trailer presente, ausente, **vazio** (silêncio não é verde) e `humano`. Roda no CI **antes** da medição, pela lei 3 da casa
- hooks exercitados à mão: preenchimento automático, `AGENTE` com precedência, recusa sem trailer, recusa em 20 arquivos, liberação com `Commit-grande:`, liberação em `chore(release)`
- `npm run check:deploy` — 16/16
- os 3 commits deste PR nasceram com o trailer preenchido pelo próprio hook

## Não entra aqui

Micro commit não vira trava de tamanho mínimo: nenhum hook sabe se um diff *devia* ter sido dois commits. O que dá para fazer é o teto acima, que é atrito deliberado no lugar certo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up adds commit attribution enforcement, a large-commit justification gate, CI validation, and reproducible historical measurement tooling.
- Adds hooks that populate and validate `Agent:` trailers.
- Rejects oversized commits unless they include a `Commit-grande:` justification.
- Adds CI self-tests and checks for attribution metadata.
- Documents the workflow and its anchored threshold measurement.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .githooks/commit-msg | Adds attribution and large-commit enforcement with exemptions for rewritten and release commits. |
| .githooks/prepare-commit-msg | Detects common agent environments and automatically inserts a non-empty Agent trailer. |
| .github/workflows/ci.yml | Runs the attribution checker's self-test before validating the PR commit range. |
| scripts/ci/agente_check.py | Validates Agent trailers per commit using collision-free per-SHA message retrieval. |
| scripts/medir-commit.awk | Centralizes staged-diff measurement and generated-file exclusions for the commit hook. |
| scripts/medir-historico.py | Computes anchored historical commit-size percentiles used to document the thresholds. |
| CONTRIBUTING.md | Documents attribution, large-commit justification, exemptions, and the anchored measurement command. |
| AGENTS.md | Summarizes the new trailer and large-commit requirements and links to the canonical guide. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[prepare-commit-msg] --> B[Populate Agent trailer]
  B --> C[commit-msg]
  C --> D{Agent present?}
  D -- No --> E[Reject commit]
  D -- Yes --> F{Rewrite or release?}
  F -- Yes --> G[Accept commit]
  F -- No --> H[Measure staged diff]
  H --> I{Over file or line limit?}
  I -- No --> G
  I -- Yes --> J{Commit-grande present?}
  J -- No --> E
  J -- Yes --> G
  K[Pull request CI] --> L[Run Agent checker self-test]
  L --> M[Validate every PR commit]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs: o teto vira observação ancorada nu..."](https://github.com/rubenmarcus/csbrasil/commit/3b68a9335338faf6cf2d1b43b7e56d726cdb1685) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52434586)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->