### PR TITLE
fix(telemetria): descarta "Script error." cross-origin opaco no coletor de crash

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -251,6 +251,11 @@ const IMPORTMAP = JSON.stringify({
   window.addEventListener('error', function(e){
     var loc = e.filename ? (e.filename + ':' + e.lineno + ':' + e.colno) : '';
     var msg = (e.message || e.error || '?');
+    /* "Script error." sem filename e sem stack é o erro cross-origin opaco que o
+       browser mascara (extensão ou script de terceiro sem CORS). Como todo código
+       do jogo é same-origin (/js, /vendor), ele nunca é nosso: descartar evita lotar
+       o js_error e abrir issue automática vazia (#136). */
+    if (!e.filename && !(e.error && e.error.stack) && /^script error/i.test(String(msg))) return;
     var interna = origemDoJogo(e.filename, e.error && e.error.stack, String(msg));
     if (consoleErroNativo) {
       try { consoleErroNativo('Erro global não tratado', e.error || msg); } catch(_) {}


### PR DESCRIPTION
Fecha #136.

## Problema
O `crash-fix.yml` abriu a #136 a partir de uma linha `Script error.` na tabela `js_error` — mensagem opaca, sem stack e sem origem. É o mascaramento que o browser faz para erros de scripts **cross-origin sem CORS** (tipicamente extensões ou scripts de terceiros injetados na página).

## Causa raiz
Todo o código do jogo é servido same-origin (`/js`, `/vendor`; sem CDN/`assetsPrefix`), então um `Script error.` nunca é nosso. Mesmo assim o handler global de `error` o classificava como interno (`origemDoJogo` sem URL cai no default `!viuExterna`), lotando `js_error` e disparando issues automáticas vazias.

## Correção
Guarda no handler `error` que descarta o erro quando **não tem `filename`, não tem stack e a mensagem começa com "Script error"** — a assinatura exata do mascaramento. Erros reais do jogo (same-origin) sempre trazem filename/stack e continuam reportando normal. Sem mudança de comportamento pro jogador.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents opaque cross-origin `Script error` events without a filename or stack from entering the crash telemetry pipeline.
- Adds a targeted early return to the global browser error handler.
- Preserves reporting for errors that include source or stack information.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/pages/index.astro | Adds a narrowly scoped filter for opaque cross-origin browser errors before telemetry classification and reporting. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(telemetria): descarta &quot;Script error...."](https://github.com/rubenmarcus/csbrasil/commit/7b94e94f6e30d87b1fb20f489bff55d3304b99e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52668872)</sub>

<!-- /greptile_comment -->