### PR TITLE
fix(crash): não escalar aviso recuperável de textura do three como bug de código

### DIFF
--- a/.github/workflows/crash-fix.yml
+++ b/.github/workflows/crash-fix.yml
@@ -16,6 +16,9 @@
 #     pega da issue. NENHUM commit na main sai daqui.
 #   · externo (extensão ou script cross-origin): preservado na telemetria bruta,
 #     mas encerra sem issue porque não pertence ao jogo.
+#   · recuperável (aviso do carregador do three: "Couldn't load texture" — textura
+#     embutida que não decodifica em navegador minoritário): o modelo carrega sem o
+#     mapa, o jogo não trava. Fica na telemetria, mas não dispara nem abre issue.
 #
 # SECRETS: CF_API_TOKEN (Zone → Cache Purge) — sem ele o purge é pulado e a
 # classe cache-split cai direto no probe (que já falha e vira issue).

--- a/src/lib/error-provenance.mjs
+++ b/src/lib/error-provenance.mjs
@@ -1,5 +1,10 @@
 const EXTENSION_RE = /(?:chrome|moz|safari-web|safari)-extension:\/\//i;
 const CACHE_SPLIT_RE = /does not provide an export|Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|prod-coherence/i;
+// Aviso RECUPERÁVEL do carregador do three: uma textura embutida (webp) do GLB não
+// decodifica em navegador minoritário (createImageBitmap), o three loga com console.error
+// mas o modelo CARREGA sem aquele mapa — o jogo não trava. É ambiental (não é defeito de
+// código) e não tem conserto no repo, então fica na telemetria bruta mas NÃO abre issue.
+const RECOVERABLE_RE = /THREE\.[^:]*: Couldn't load texture/i;
 const HTTP_URL_RE = /https?:\/\/[^\s)'"<>]+/gi;
 
 const normalizedOrigin = (value, base) => {
@@ -34,7 +39,10 @@ export function classifyCrash(payload = {}, ownOrigin = '') {
   const evidence = [payload.message, payload.source, payload.stack].filter(Boolean).join(' ');
   if (isExternalCrash(payload, ownOrigin)) return 'externo';
   if (CACHE_SPLIT_RE.test(evidence)) return 'cache-split';
+  if (RECOVERABLE_RE.test(evidence)) return 'recuperavel';
   return 'codigo';
 }
 
-export const shouldDispatchCrash = (classification) => classification !== 'externo';
+// 'externo' e 'recuperavel' ficam gravados no banco, mas não consomem dispatch nem
+// abrem bug do jogo: um não pertence ao jogo, o outro o jogo já contornou sozinho.
+export const shouldDispatchCrash = (classification) => classification !== 'externo' && classification !== 'recuperavel';

--- a/tools/eval/error-provenance-check.mjs
+++ b/tools/eval/error-provenance-check.mjs
@@ -8,7 +8,7 @@ const mutants = [
   'sem-api', 'sem-early-return',
   'sem-workflow', 'abre-externo',
   'sem-cliente', 'cliente-mensagem-url', 'sem-teto-externo', 'debug-externo', 'console-sem-origem',
-  'cache-antes-origem',
+  'cache-antes-origem', 'sem-recuperavel',
 ];
 if (mutant && !mutants.includes(mutant)) throw new Error(`mutante desconhecido: ${mutant}`);
 
@@ -66,12 +66,15 @@ if (mutant === 'console-sem-origem') page = mutate(page,
 if (mutant === 'cache-antes-origem') helperSource = mutate(helperSource,
   "if (isExternalCrash(payload, ownOrigin)) return 'externo';\n  if (CACHE_SPLIT_RE.test(evidence)) return 'cache-split';",
   "if (CACHE_SPLIT_RE.test(evidence)) return 'cache-split';\n  if (isExternalCrash(payload, ownOrigin)) return 'externo';");
+if (mutant === 'sem-recuperavel') helperSource = mutate(helperSource,
+  "if (RECOVERABLE_RE.test(evidence)) return 'recuperavel';",
+  "if (RECOVERABLE_RE.test(evidence)) return 'codigo';");
 
-let classifyCrash = null;
+let classifyCrash = null, shouldDispatchCrash = null;
 if (helperSource) {
   try {
     const encoded = Buffer.from(helperSource).toString('base64');
-    ({ classifyCrash } = await import(`data:text/javascript;base64,${encoded}`));
+    ({ classifyCrash, shouldDispatchCrash } = await import(`data:text/javascript;base64,${encoded}`));
   } catch { /* cláusulas abaixo ficam vermelhas */ }
 }
 const own = 'https://www.csbrasil.online';
@@ -93,6 +96,13 @@ const internalFixtures = [
   { source: `${own}/js/main.js:1:2`, stack: 'Error at chrome-extension://abc/inpage.js:2:3', message: 'boom' },
   { source: '', stack: `Error at ${own}/js/main.js:3:4\n at chrome-extension://abc/inpage.js:2:3`, message: 'boom' },
   { message: 'falha ao carregar https://cdn.example.invalid/data' },
+];
+/* Aviso recuperável do carregador do three (issue #110): a textura embutida não
+   decodifica, o three loga com console.error mas o modelo carrega. Fica no banco,
+   não abre issue. Sem `source`/`stack` (o console.error do three não tem pilha). */
+const recoverableFixtures = [
+  { source: '', stack: '', message: "THREE.GLTFLoader: Couldn't load texture blob:https://www.csbrasil.online/bbaced98-44e1-4922-83b1-4564e004a737" },
+  { message: "THREE.GLTFLoader: Couldn't load texture models/characters/mst.glb" },
 ];
 const externalCacheFixtures = [
   { source: 'chrome-extension://abc/inpage.js:1:2', message: 'does not provide an export' },
@@ -177,6 +187,11 @@ const checks = [
   ['EP7', externalCacheFixtures.every((fixture) => classify(fixture) === 'externo')
     && classify({ source: `${own}/js/main.js`, stack: 'at chrome-extension://abc/inpage.js', message: 'boom' }) === 'codigo'
     && classify({ message: 'prod-coherence reprovou' }) === 'cache-split', 'proveniência externa vence cache-split e origem própria vence evidência secundária'],
+  ['EP8', recoverableFixtures.every((fixture) => classify(fixture) === 'recuperavel')
+    && classify({ source: `${own}/js/game.js:1:2`, message: 'boom' }) === 'codigo'
+    && typeof shouldDispatchCrash === 'function'
+    && shouldDispatchCrash('recuperavel') === false
+    && shouldDispatchCrash('codigo') === true, 'aviso recuperável de textura fica na telemetria mas não vira bug do jogo'],
   ['EP4', apiWired, 'API grava o erro e o early-return externo é o único corte antes do dispatch único'],
   ['EP5', workflowWired, 'workflow classifica externo sem abrir issue, em nenhum OR da condição'],
   ['EP6', clientBehavior && clientWired, 'cliente executado: mensagem não é proveniência, overlay/cota de externo são separados'],
@@ -191,6 +206,7 @@ const mutantClause = {
   'sem-cliente': 'EP6', 'cliente-mensagem-url': 'EP6', 'sem-teto-externo': 'EP6', 'debug-externo': 'EP6',
   'console-sem-origem': 'EP6',
   'cache-antes-origem': 'EP7',
+  'sem-recuperavel': 'EP8',
 };
 if (mutant && !failed.some(([id]) => id === mutantClause[mutant])) {
   failed.push(['MUT', false, `mutação ${mutant} não acendeu ${mutantClause[mutant]}`]);


### PR DESCRIPTION
Fecha #110.

## Problema
A #110 (`crash-auto`) foi aberta por um `console.error` interno do `GLTFLoader`: `THREE.GLTFLoader: Couldn't load texture blob:...`. Uma textura embutida (webp) de um GLB de personagem não decodifica em navegador minoritário (via `createImageBitmap`). O three loga o aviso, **mas o modelo carrega sem aquele mapa — o jogo não trava**.

## Investigação
Não há defeito no carregamento: nenhum blob de textura é criado/revogado no repositório (os loaders usam o `GLTFLoader` padrão; o three gere o ciclo do blob e o revoga certo). A falha é ambiental (decode de webp no cliente) e sem conserto no código.

## Correção
O defeito real estava na **classificação**: esse aviso recuperável caía em `codigo` e disparava issue automática. Adiciono a classe `recuperavel` em `error-provenance.mjs` — gravada na telemetria bruta, mas **sem dispatch nem issue**, igual ao tratamento já existente de `externo`. Régua nova (`EP8`) + mutante `sem-recuperavel` provam o corte; classe documentada no cabeçalho do `crash-fix.yml`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR recognizes a recoverable Three.js texture-loading warning as `recuperavel` and prevents that classification from triggering crash dispatch while retaining raw telemetry.
- Adds recoverable-warning classification and dispatch suppression.
- Extends the provenance evaluator with fixtures, an EP8 check, and a mutation case.
- Documents the new classification in the crash-fix workflow header.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/error-provenance.mjs | Adds recognition of recoverable Three.js texture warnings and excludes that classification from crash dispatch. |
| tools/eval/error-provenance-check.mjs | Adds recoverable-warning fixtures, dispatch assertions, and a mutation check covering the new classification. |
| .github/workflows/crash-fix.yml | Updates the workflow header to describe how recoverable texture warnings are handled. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Crash payload] --> B{External origin?}
  B -- Yes --> C[externo]
  B -- No --> D{Cache-split evidence?}
  D -- Yes --> E[cache-split]
  D -- No --> F{Recoverable Three.js texture warning?}
  F -- Yes --> G[recuperavel]
  F -- No --> H[codigo]
  C --> I[Store telemetry without dispatch]
  G --> I
  E --> J[Dispatch crash workflow]
  H --> J
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(crash): não escalar aviso recuperáve..."](https://github.com/rubenmarcus/csbrasil/commit/fe14f5e395cd4742bae8fe8fd82a5d5c0eeb889a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52668950)</sub>

<!-- /greptile_comment -->