### PR TITLE
fix(harness): atualiza matrizes de mundo após build para LOS headless válida

### DIFF
--- a/tools/eval/botsim.mjs
+++ b/tools/eval/botsim.mjs
@@ -146,6 +146,15 @@ function runMap(mapId, textures, seed) {
   g._ensureDolly = () => {};        // a câmera de fim de round cria um WebGLRenderer — não existe aqui
   g.killsToWin = Infinity;          // sem alvo de abates: a amostra tem que durar a corrida inteira
   g.start ? g.start() : g._startRound();
+  /* MATRIZES DE MUNDO: sem renderer ninguém chama updateMatrixWorld, e o Raycaster do three
+     assume matrizes prontas — sem esta linha os occluders ficam empilhados na ORIGEM (matriz
+     identidade) e o `_losClear` dos bots (raycast contra `world.occluders`, game.js:5044) mede
+     linha de visão contra geometria fantasma. As métricas de navegação (latFlips/fwdFlips/
+     stuck/eff) dependiam dessa LOS: eram verde de graça. Occluder é estático — uma passada
+     aqui, depois do build, basta; e updateMatrixWorld NÃO consome Math.random, então o fluxo
+     determinístico semeado fica idêntico. */
+  g.scene.updateMatrixWorld(true);
+  g.world.root.updateMatrixWorld(true);
   if (DUEL) {
     /* MODO DUELO: o jogador fica NO MAPA, parado no spawn, sem atirar, e MORTAL. Mede o que
        o dono reclamou — "matam muito fácil" e "sempre na cabeça" — em números: tiros do bot,

--- a/tools/eval/harness.mjs
+++ b/tools/eval/harness.mjs
@@ -169,5 +169,15 @@ export function bootGame(mapId, { textures, ctf = false, seed = 12345, bots = 4 
   g._ensureDolly = () => {};        // a câmera de fim de round cria um WebGLRenderer — não existe aqui
   g.killsToWin = Infinity;
   g.start ? g.start() : g._startRound();
+  /* MATRIZES DE MUNDO: no browser o WebGLRenderer.render() chama scene.updateMatrixWorld() a
+     cada quadro; no harness NÃO há renderer, então ninguém atualiza e o Raycaster do three
+     (que assume matrizes prontas) enxerga cada occluder na posição LOCAL — empilhados na
+     ORIGEM com matrixWorld identidade. Medido no piscina_treta: 92/92 occluders na origem
+     (o build do decalque atualiza 78 de raspão, sobram 14), praca_poderes 66/66, ferro_velho
+     100/100. Toda métrica de bot que depende de linha de visão (`_losClear` faz raycast
+     contra `world.occluders`, game.js:5044) estava medida contra geometria na origem — régua
+     verde de graça. Occluder é estático: uma passada aqui, depois do build, basta. */
+  g.scene.updateMatrixWorld(true);
+  g.world.root.updateMatrixWorld(true);
   return g;
 }


### PR DESCRIPTION
Sem renderer no harness/botsim, ninguém chama `scene.updateMatrixWorld()`, e o `Raycaster` do three assume matrizes prontas → occluders empilhados na origem (matrixWorld identidade). O `_losClear` dos bots media LOS contra geometria fantasma — régua verde de graça (92/92).

Correção: `updateMatrixWorld(true)` em `scene` e `world.root` após `_startRound()`, em `harness.mjs/bootGame` e `botsim.mjs`. Medido: piscina_treta 14 occluders na origem → 0 (idem praca/ferro/loja). `updateMatrixWorld` não consome `Math.random` → determinismo do botsim intacto.

Closes #51

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR synchronizes Three.js world matrices after starting headless game sessions so raycasts use the built map transforms.
- Updates matrices in both the bot simulation and reusable evaluation harness.
- Documents the relationship between renderer-free execution, occluder transforms, and LOS metrics.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge functionally, with only the non-blocking need to shorten or relocate the duplicated investigation narrative.

The added synchronization runs after synchronous world construction and correctly updates static occluder transforms; the sole accepted concern is the repository-policy violation in the accompanying comments.

**Files Needing Attention:** tools/eval/harness.mjs and tools/eval/botsim.mjs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/eval/botsim.mjs | Adds post-start matrix synchronization correctly, but accompanies it with an overlong investigation narrative contrary to the repository comment policy. |
| tools/eval/harness.mjs | Ensures reusable headless games expose current world matrices, with the same non-blocking comment-policy violation. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant H as Headless harness
    participant G as Game
    participant S as THREE.Scene
    participant R as Raycaster
    H->>G: start() / _startRound()
    G->>S: Build and attach world objects
    H->>S: updateMatrixWorld(true)
    H->>G: world.root.updateMatrixWorld(true)
    G->>R: LOS against world.occluders
    R-->>G: Intersections using synchronized transforms
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Feval%2Fharness.mjs%3A172-179%0A**Encurte%20o%20hist%C3%B3rico%20no%20coment%C3%A1rio**%0A%0AEste%20bloco%20de%20oito%20linhas%2C%20repetido%20em%20%60botsim.mjs%60%2C%20incorpora%20medi%C3%A7%C3%B5es%20e%20o%20hist%C3%B3rico%20da%20investiga%C3%A7%C3%A3o%20no%20c%C3%B3digo.%20A%20pol%C3%ADtica%20do%20reposit%C3%B3rio%20limita%20coment%C3%A1rios%20a%20duas%20linhas%20para%20invariantes%20ou%20riscos%20n%C3%A3o%20%C3%B3bvios%20e%20direciona%20esse%20tipo%20de%20evid%C3%AAncia%20para%20a%20documenta%C3%A7%C3%A3o.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rubenmarcus%2Fcsbrasil&pr=226&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/eval/harness.mjs:172-179
**Encurte o histórico no comentário**

Este bloco de oito linhas, repetido em `botsim.mjs`, incorpora medições e o histórico da investigação no código. A política do repositório limita comentários a duas linhas para invariantes ou riscos não óbvios e direciona esse tipo de evidência para a documentação.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(harness): atualiza matrizes de mundo..."](https://github.com/rubenmarcus/csbrasil/commit/92d12cb1c70c7c3743643e47e84a47c8ca939884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52676695)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->