### PR TITLE
fix: classifica crash opaco sem origem como externo e não abre issue

### DIFF
--- a/src/lib/error-provenance.mjs
+++ b/src/lib/error-provenance.mjs
@@ -6,6 +6,14 @@ const CACHE_SPLIT_RE = /does not provide an export|Failed to fetch dynamically i
 // código) e não tem conserto no repo, então fica na telemetria bruta mas NÃO abre issue.
 const RECOVERABLE_RE = /THREE\.[^:]*: Couldn't load texture/i;
 const HTTP_URL_RE = /https?:\/\/[^\s)'"<>]+/gi;
+/* Assinaturas opacas de terceiro/extensão/resposta corrompida: mensagens sem
+   pilha e sem nome de arquivo do próprio jogo que o navegador entrega já
+   anonimizadas (CORS mascara "Script error.", Firefox emite "uncaught
+   exception: undefined", byte injetado vira "illegal character U+xxxx", rede
+   caída vira "network error"). Cobre issues #109, #125, #126, #136. Crash real
+   do jogo SEMPRE carrega filename ou stack same-origin — por isso o corte só
+   vale quando não há nenhum dos dois (ver isOpaqueNoise). */
+const OPAQUE_RE = /uncaught exception: undefined|illegal character\s+U\+[0-9a-f]{2,6}|^script error\.?$|^network error$/i;
 
 const normalizedOrigin = (value, base) => {
   if (!value) return null;
@@ -35,9 +43,20 @@ export function isExternalCrash({ message = '', source = '', stack = '' } = {}, 
   return origins.some((origin) => origin !== ownOrigin);
 }
 
+/* Ruído opaco: sem pilha E sem source (nenhum nome de arquivo do jogo), a
+   mensagem sozinha bate uma assinatura conhecida de terceiro. A guarda de
+   source/stack é o que impede mascarar crash real do jogo — throw undefined do
+   próprio código chega com e.filename same-origin, syntax error real é pego no
+   build, e nenhum dos dois cai aqui. */
+export function isOpaqueNoise({ message = '', source = '', stack = '' } = {}) {
+  if (source || stack) return false;
+  return OPAQUE_RE.test(String(message).trim());
+}
+
 export function classifyCrash(payload = {}, ownOrigin = '') {
   const evidence = [payload.message, payload.source, payload.stack].filter(Boolean).join(' ');
   if (isExternalCrash(payload, ownOrigin)) return 'externo';
+  if (isOpaqueNoise(payload)) return 'externo';
   if (CACHE_SPLIT_RE.test(evidence)) return 'cache-split';
   if (RECOVERABLE_RE.test(evidence)) return 'recuperavel';
   return 'codigo';

--- a/tools/eval/error-provenance-check.mjs
+++ b/tools/eval/error-provenance-check.mjs
@@ -8,7 +8,7 @@ const mutants = [
   'sem-api', 'sem-early-return',
   'sem-workflow', 'abre-externo',
   'sem-cliente', 'cliente-mensagem-url', 'sem-teto-externo', 'debug-externo', 'console-sem-origem',
-  'cache-antes-origem', 'sem-recuperavel',
+  'cache-antes-origem', 'sem-recuperavel', 'sem-opaco', 'opaco-sem-guarda',
 ];
 if (mutant && !mutants.includes(mutant)) throw new Error(`mutante desconhecido: ${mutant}`);
 
@@ -69,6 +69,12 @@ if (mutant === 'cache-antes-origem') helperSource = mutate(helperSource,
 if (mutant === 'sem-recuperavel') helperSource = mutate(helperSource,
   "if (RECOVERABLE_RE.test(evidence)) return 'recuperavel';",
   "if (RECOVERABLE_RE.test(evidence)) return 'codigo';");
+if (mutant === 'sem-opaco') helperSource = mutate(helperSource,
+  'return OPAQUE_RE.test(String(message).trim());',
+  'return false;');
+if (mutant === 'opaco-sem-guarda') helperSource = mutate(helperSource,
+  'if (source || stack) return false;',
+  'if (false) return false;');
 
 let classifyCrash = null, shouldDispatchCrash = null;
 if (helperSource) {
@@ -91,11 +97,24 @@ const crossOriginFixtures = [
 ];
 const internalFixtures = [
   { source: `${own}/js/game.js:1:2`, stack: `${own}/js/main.js:3:4`, message: 'boom' },
-  { source: '', stack: '', message: 'Script error.' },
-  { source: null, stack: null, message: 'uncaught exception: undefined' },
   { source: `${own}/js/main.js:1:2`, stack: 'Error at chrome-extension://abc/inpage.js:2:3', message: 'boom' },
   { source: '', stack: `Error at ${own}/js/main.js:3:4\n at chrome-extension://abc/inpage.js:2:3`, message: 'boom' },
   { message: 'falha ao carregar https://cdn.example.invalid/data' },
+  /* crash real do jogo cujo texto CONTÉM "undefined" mas carrega filename
+     same-origin: nenhum filtro de substring pode aposentá-lo (mutante filtro-amplo). */
+  { source: `${own}/js/game.js:1:2`, stack: '', message: "Cannot read properties of undefined (reading 'x')" },
+  /* sem pilha, sem source, mas a mensagem NÃO bate assinatura opaca conhecida:
+     ambíguo continua acionável, o corte opaco é estreito de propósito. */
+  { source: '', stack: '', message: 'TypeError: x is undefined' },
+];
+/* Sinais opacos de terceiro/extensão/resposta corrompida: sem pilha e sem
+   nome de arquivo do jogo, viram externo e não abrem issue (#109, #125, #126, #136). */
+const opaqueFixtures = [
+  { source: '', stack: '', message: 'Script error.' },
+  { source: '', stack: '', message: 'Script error' },
+  { source: null, stack: null, message: 'uncaught exception: undefined' },
+  { source: null, stack: null, message: 'SyntaxError: illegal character U+009E' },
+  { source: '', stack: '', message: 'network error' },
 ];
 /* Aviso recuperável do carregador do three (issue #110): a textura embutida não
    decodifica, o three loga com console.error mas o modelo carrega. Fica no banco,
@@ -183,7 +202,10 @@ const clientWired = /origemDoJogo\(e\.filename, e\.error && e\.error\.stack, Str
 const checks = [
   ['EP1', extensionFixtures.every((fixture) => classify(fixture) === 'externo'), 'esquemas de extensão são externos'],
   ['EP2', crossOriginFixtures.every((fixture) => classify(fixture) === 'externo'), 'scripts cross-origin são externos'],
-  ['EP3', internalFixtures.every((fixture) => classify(fixture) === 'codigo'), 'same-origin e sinais opacos continuam acionáveis'],
+  ['EP3', internalFixtures.every((fixture) => classify(fixture) === 'codigo'), 'same-origin e mensagens sem assinatura opaca continuam acionáveis'],
+  ['EP9', opaqueFixtures.every((fixture) => classify(fixture) === 'externo')
+    && classify({ source: `${own}/js/main.js:1:1`, stack: '', message: 'uncaught exception: undefined' }) === 'codigo'
+    && classify({ source: '', stack: `at boom (${own}/js/game.js:9:9)`, message: 'Script error.' }) === 'codigo', 'assinatura opaca sem pilha e sem source é externa, mas filename/stack same-origin mantêm código'],
   ['EP7', externalCacheFixtures.every((fixture) => classify(fixture) === 'externo')
     && classify({ source: `${own}/js/main.js`, stack: 'at chrome-extension://abc/inpage.js', message: 'boom' }) === 'codigo'
     && classify({ message: 'prod-coherence reprovou' }) === 'cache-split', 'proveniência externa vence cache-split e origem própria vence evidência secundária'],
@@ -207,6 +229,7 @@ const mutantClause = {
   'console-sem-origem': 'EP6',
   'cache-antes-origem': 'EP7',
   'sem-recuperavel': 'EP8',
+  'sem-opaco': 'EP9', 'opaco-sem-guarda': 'EP9',
 };
 if (mutant && !failed.some(([id]) => id === mutantClause[mutant])) {
   failed.push(['MUT', false, `mutação ${mutant} não acendeu ${mutantClause[mutant]}`]);


### PR DESCRIPTION
Erros stack-less e sem filename same-origin com assinatura de terceiro (`uncaught exception: undefined` #109, `illegal character U+xxxx` #126) eram classificados como `codigo` e abriam issue automática — ruído sem origem no jogo.

Generaliza a proveniência em `error-provenance.mjs` com `isOpaqueNoise`: só corta quando **não há stack E não há source E** a msg bate `OPAQUE_RE` (a guarda impede mascarar crash real — throw real chega com filename same-origin). Classifica como `externo` (reusa o early-return do dispatch). Régua EP8 + mutantes `sem-opaco`/`opaco-sem-guarda`; fixtures conservadoras garantem corte estreito. Complementar ao guard client-side do #136.

Closes #109
Closes #126

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR classifies narrowly recognized stack-less and source-less browser errors as external so they do not trigger automatic issues.
- Adds opaque-error signature detection guarded by the absence of both source and stack.
- Adds evaluation fixtures and mutation checks for opaque classification and same-origin safeguards.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/error-provenance.mjs | Adds guarded recognition of opaque browser-error signatures and classifies them as external. |
| tools/eval/error-provenance-check.mjs | Adds fixtures and mutation checks covering opaque errors and the source/stack guard. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: classifica crash opaco sem origem c..."](https://github.com/rubenmarcus/csbrasil/commit/a0deb5ac0a5f98aeb7bbd46f1689eaf19045f407) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52676849)</sub>

<!-- /greptile_comment -->