### PR TITLE
fix(eval): reconcilia decal-probe com o medirParede da Quebrada (#75)

### DIFF
--- a/tools/eval/decal-probe.mjs
+++ b/tools/eval/decal-probe.mjs
@@ -29,23 +29,49 @@
      V=1 node tools/eval/decal-probe.mjs [mapId] # + uma linha por peça
    ============================================================================ */
 import { THREE, MAPS, initTextures } from './harness.mjs';
-import { paredeAtras } from '../../public/js/map_decals.js';
+import { paredeAtras, medirParede } from '../../public/js/map_decals.js';
 
 const T = initTextures();
 const ONLY = process.argv[2];
 const VERBOSE = process.env.V === '1';
 const H_CARTAZ = 2.2;   // altura do cartaz do Piscinão — a régua de tamanho do dono
 
-/* ── PAREDE ATRÁS (04/08) ───────────────────────────────────────────────────────
+/* ── PAREDE ATRÁS (04/08, reconciliada 12/08 — issue #75) ────────────────────────
    Reprovação literal do dono: "os graffites que colocaste, colocaste em lugares
    que não são parede". Esta régua repete, DEPOIS de construído, o mesmo raycast
    que os mapas rodam ANTES de desenhar — de propósito com a MESMA função
    (`public/js/map_decals.js`), pra não haver duas medidas discordando por causa do
-   instrumento. Se alguém tirar a chamada de dentro de um `decal()`, a peça errada
-   nasce e ESTA contagem sobe; é a mutação que faz a régua morder.
+   instrumento. Se um decalque não tem parede atrás por NENHUM critério da casa, a
+   contagem sobe; é a mutação que faz a régua morder.
+
+   ── POR QUE DUAS FUNÇÕES E NÃO UMA (issue #75) ──────────────────────────────────
+   A 1ª versão media TODO mapa só com `paredeAtras` — o que estava certo enquanto
+   TODO `decal()` validava com `paredeAtras`. Mas a Quebrada evoluiu (06/08): o
+   `decal()` dela valida com `medirParede` (acha a face VISÍVEL do barraco GLB) e
+   AINDA MOVE a peça `recuo` metros até colar nela. `paredeAtras` (25 raios, plano de
+   25 cm, alcance 0,8 m) é mais DURO que `medirParede` (3×3 amostras, tolera 3 de 9
+   vazias pra vão de porta/janela, degrau até 0,6 m) — então re-medir com `paredeAtras`
+   uma peça que nasceu e foi colada por `medirParede` reprovava 92 peças LEGÍTIMAS,
+   concentradas nas vielas de x=±21 (barraco baixo, peça no topo do muro, micro-recuo).
+   Era a régua acusando a peça por causa do instrumento, não do jogo.
+
+   O conserto NÃO é trocar uma função pela outra: se a Quebrada passasse a medir só
+   com `medirParede`, o Piscinão (que valida com `paredeAtras` e NÃO move a peça)
+   ganharia 6 falsos positivos no sentido inverso. O conserto é perguntar pelas MESMAS
+   réguas que a casa usa pra construir: uma peça TEM parede se QUALQUER uma delas acha
+   sólido atrás —
+     · `paredeAtras(solids)`   — o raycast contra os sólidos DECLARADOS do mapa
+       (malha `[root]` em piscina/havan/quebrada; caixas giradas no ferrovelho);
+     · `paredeAtras(colliders)` — o mesmo, mas contra as CAIXAS AABB, que pegam a peça
+       alta encostada num muro-caixa de 2,2 m (o topo escapa da amostra de malha, a
+       caixa não);
+     · `medirParede([root])`   — a face VISÍVEL, com a tolerância de vão que a Quebrada
+       exige (é literalmente a função que o `decal()` dela rodou pra criar a peça).
+   Peça no ar de verdade (nenhuma parede em 1,2 m) falha as três e continua acusada —
+   a mutação segue mordendo. Cola um decalque a 5 m do nada e a contagem sobe.
 
    `decalSolids` sai do `buildWorld` e é declaração, não geometria nova: em havan,
-   pool_day e quebrada ele É o `colliders`; em ferrovelho leva as duas folhas
+   pool_day e quebrada ele É o `[root]`; em ferrovelho leva as duas folhas
    giradas do portão e em brasilia as empenas dos ministérios (GLB sem collider).
 
    LIMITE CONHECIDO: em node NENHUM GLB carrega, então os ministérios da Brasília
@@ -58,6 +84,12 @@ for (const [id, m] of Object.entries(MAPS)) {
   const W = m.build(scene, T);
   const files = new Map(), linhas = [], soltas = [];
   const solids = W.decalSolids || W.colliders || [];
+  const boxes = W.colliders || [];
+  // TEM parede atrás por QUALQUER régua da casa? (ver docstring — reconciliação #75)
+  const temParede = (x, y, z, ry, w, h) =>
+    paredeAtras(solids, x, y, z, ry, w, h)
+    || paredeAtras(boxes, x, y, z, ry, w, h)
+    || medirParede([W.root], x, y, z, ry, w, h) !== null;
   let n = 0, menor = Infinity, maior = 0;
   /* ── AS PEÇAS DA PASSADA NÃO SÃO MEDIDAS AQUI, E ISSO É DE PROPÓSITO (07/08) ──
      A passada de grafite (`public/js/graffiti_pass.js`) resolve a colocação NO
@@ -80,7 +112,7 @@ for (const [id, m] of Object.entries(MAPS)) {
     n++; files.set(f, (files.get(f) || 0) + 1);
     menor = Math.min(menor, h); maior = Math.max(maior, h);
     const p = o.getWorldPosition(new THREE.Vector3());
-    if (!paredeAtras(solids, p.x, p.y, p.z, o.rotation.y, w, h)) {
+    if (!temParede(p.x, p.y, p.z, o.rotation.y, w, h)) {
       soltas.push(`    SEM PAREDE  ${w.toFixed(2)} × ${h.toFixed(2)} m  ry=${o.rotation.y.toFixed(2)}  `
         + `(${p.x.toFixed(2)}, ${p.y.toFixed(2)}, ${p.z.toFixed(2)})  ${f}`);
     }


### PR DESCRIPTION
O `decal-probe` media todo mapa com `paredeAtras`, correto enquanto todo `decal()` validava com `paredeAtras`. Mas o `decal()` da Quebrada evoluiu pra `medirParede`, que acha a face visível do barraco e **move a peça até colar nela**. Como `paredeAtras` (25 raios, plano 25cm, 0,8m) é mais duro que `medirParede`, re-medir com `paredeAtras` reprovava 92 peças legítimas nas vielas x=±21 — a régua acusando o instrumento.

Conserto: peça tem parede se **qualquer** régua da casa acha sólido atrás — `paredeAtras(solids)` OU `paredeAtras(colliders)` OU `medirParede([root])`. Peça no ar de verdade falha as três (mutação preservada). SEM PAREDE: 92/93 → 1 (o restante é um floater real a 2,15m, fica pra captura no navegador).

Closes #75

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reconciles the decal evaluation probe with the two wall-detection strategies used by map builders.
- Imports and invokes `medirParede` alongside `paredeAtras`.
- Accepts a decal when declared solids, collider boxes, or visible root geometry identify a wall.
- Adds extensive inline documentation explaining issue #75 and the detector differences.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge functionally, with only a non-blocking need to move the extensive investigation narrative out of the source comment.

The new detector call is reachable with valid roots in every registered map and uses the same coordinates and yaw conventions as placement code; the remaining accepted concern is source-comment maintainability.

**Files Needing Attention:** tools/eval/decal-probe.mjs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/eval/decal-probe.mjs | The detector union matches current map placement strategies, but the added investigation narrative violates the repository’s concise-comment convention. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Feval%2Fdecal-probe.mjs%3A34-69%0A**Reduza%20o%20hist%C3%B3rico%20no%20coment%C3%A1rio**%0A%0AEste%20bloco%20incorpora%20cronologia%2C%20medi%C3%A7%C3%B5es%20e%20detalhes%20da%20investiga%C3%A7%C3%A3o%20no%20c%C3%B3digo-fonte%2C%20ocultando%20a%20invariante%20relevante%20e%20aumentando%20o%20custo%20de%20manuten%C3%A7%C3%A3o%20e%20diverg%C3%AAncia%3B%20mantenha%20aqui%20apenas%20uma%20explica%C3%A7%C3%A3o%20curta%20com%20refer%C3%AAncia%20%C3%A0%20issue%20%2375%20e%20mova%20o%20hist%C3%B3rico%20para%20a%20documenta%C3%A7%C3%A3o.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rubenmarcus%2Fcsbrasil&pr=231&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/eval/decal-probe.mjs:34-69
**Reduza o histórico no comentário**

Este bloco incorpora cronologia, medições e detalhes da investigação no código-fonte, ocultando a invariante relevante e aumentando o custo de manutenção e divergência; mantenha aqui apenas uma explicação curta com referência à issue #75 e mova o histórico para a documentação.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(eval): reconcilia decal-probe com o ..."](https://github.com/rubenmarcus/csbrasil/commit/86984798f633e34526ba91e24bef92056e210393) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52677783)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->