### PR TITLE
fix(eval): os 4 apontamentos do Greptile na régua de contrato — e um defeito real que o MC3 achou

### DIFF
--- a/tools/eval/map-contrato-check.mjs
+++ b/tools/eval/map-contrato-check.mjs
@@ -36,31 +36,27 @@ const CONSUMIDO = [
 
 const tipoDe = (v) => (Array.isArray(v) ? 'array' : typeof v);
 
-/* DÍVIDA DECLARADA DE CONEXIDADE — mesmo desenho do `cena-tetos.mjs`: o número sai da
-   medição, não de escolha, e serve de trava contra piorar. Estes dois mapas já estão
-   em produção com o grafo partido; a régua nasceu depois deles e não pode reprovar o
-   que já roda, mas também não vai abençoar. Mapa FORA desta lista tem de ser conexo.
+/* Teto de nós INALCANÇÁVEIS por mapa. Contar alcançados deixaria a dívida crescer:
+   mapa que ganha nós ilhados mantendo o componente atual passaria. Mapa fora da
+   lista tem de ser conexo. Ver docs/quality-gates.md. */
+const ILHADOS_MAX = { loja_h: 491, ferro_velho: 15 };
 
-   Medido em 13/08 na alpha.95 (`node tools/eval/map-contrato-check.mjs`). Baixar o
-   número é conserto e deve vir com a lista atualizada; subir é regressão e reprova. */
-const CONEXIDADE_DIVIDA = {
-  loja_h: 143,        // de 634 nós — 77% do grafo inalcançável a partir do nó 0
-  ferro_velho: 281,   // de 296 nós — 15 ilhados
-};
-
-/* Conexidade: BFS do nó 0, mesmo critério da validatePlan de map_json.js. */
+/* BFS do nó 0, mesmo critério da validatePlan de map_json.js. Linha de adjacência
+   não-array é defeito e não lista vazia: o jogo itera sobre ela e lança. */
 function alcance(nodes, adj) {
   const visto = new Uint8Array(nodes.length);
   const fila = [0];
   visto[0] = 1;
   let n = 1;
+  const malformadas = [];
   while (fila.length) {
     const i = fila.pop();
-    for (const j of (Array.isArray(adj[i]) ? adj[i] : [])) {
+    if (!Array.isArray(adj[i])) { malformadas.push(i); continue; }
+    for (const j of adj[i]) {
       if (Number.isInteger(j) && j >= 0 && j < nodes.length && !visto[j]) { visto[j] = 1; n++; fila.push(j); }
     }
   }
-  return n;
+  return { n, malformadas };
 }
 
 async function medir(id, buildFn) {
@@ -94,13 +90,17 @@ async function medir(id, buildFn) {
 
     /* MC2: o caminho é consumido como ÍNDICE de nodes (game.js:4306). Entrada fora da
        faixa, não-inteira ou undefined faz o bot ler waypoint inexistente. */
-    const i = W.nearestWaypoint(0, 0);
-    const p = W.findPath(i, Math.min(nodes.length - 1, i + 1));
-    const chamavel = Number.isInteger(i) && i >= 0 && i < nodes.length
-      && Array.isArray(p) && p.length > 0
-      && p.every((n) => Number.isInteger(n) && n >= 0 && n < nodes.length);
+    let chamavel, rotaErro = null;
+    try {
+      const i = W.nearestWaypoint(0, 0);
+      const p = W.findPath(i, Math.min(nodes.length - 1, i + 1));
+      chamavel = Number.isInteger(i) && i >= 0 && i < nodes.length
+        && Array.isArray(p) && p.length > 0
+        && p.every((n) => Number.isInteger(n) && n >= 0 && n < nodes.length);
+    } catch (e) { chamavel = false; rotaErro = String((e && e.message) || e); }
 
-    return { id, faltando: [], opcionais, nos: nodes.length, arestas, chamavel, alcancados: alcance(nodes, adj) };
+    const { n: alcancados, malformadas } = alcance(nodes, adj);
+    return { id, faltando: [], opcionais, nos: nodes.length, arestas, chamavel, rotaErro, alcancados, malformadas };
   } catch (e) {
     return { id, erro: String((e && e.message) || e) };
   }
@@ -118,12 +118,10 @@ if (EXTRA) {
   linhas.push(await medir(`extra:${b[0]}`, b[1]));
 }
 
-const mc1 = linhas.filter((r) => r.erro || r.faltando?.length);
+const mc1 = linhas.filter((r) => r.erro || r.faltando?.length || r.malformadas?.length);
 const mc2 = linhas.filter((r) => r.chamavel === false);
-const divida = (r) => CONEXIDADE_DIVIDA[r.id];
-/* Reprova se: mapa sem dívida declarada não é conexo, OU mapa com dívida piorou. */
-const mc3 = linhas.filter((r) => r.nos != null && r.alcancados !== r.nos
-  && !(divida(r) != null && r.alcancados >= divida(r)));
+const ilhados = (r) => r.nos - r.alcancados;
+const mc3 = linhas.filter((r) => r.nos != null && ilhados(r) > (ILHADOS_MAX[r.id] ?? 0));
 
 if (JSONOUT) {
   console.log(JSON.stringify({ mapas: linhas, mutante: MUTANTE || null }, null, 1));
@@ -137,16 +135,18 @@ if (JSONOUT) {
       continue;
     }
     const opt = r.opcionais.length ? `  (sem ${r.opcionais.map((o) => o.chave).join('/')} — opcional)` : '';
-    const d = CONEXIDADE_DIVIDA[r.id];
-    const conexo = r.alcancados === r.nos ? 'conexo'
-      : (d != null && r.alcancados >= d) ? `partido ${r.alcancados}/${r.nos} (dívida declarada)`
-      : `PARTIDO ${r.alcancados}/${r.nos}`;
-    console.log(`  ${r.chamavel && !mc3.includes(r) ? 'ok' : ' x'} ${r.id.padEnd(16)} ${String(r.nos).padStart(4)} nós · ${String(r.arestas).padStart(5)} arestas · rota ${r.chamavel ? 'ok' : 'FALHA'} · ${conexo}${opt}`);
+    const il = r.nos - r.alcancados;
+    const teto = ILHADOS_MAX[r.id] ?? 0;
+    const conexo = il === 0 ? 'conexo'
+      : il <= teto ? `${il} ilhados (teto ${teto})`
+      : `${il} ILHADOS > teto ${teto}`;
+    if (r.malformadas.length) console.log(`  x ${r.id.padEnd(16)} adj não-array em ${r.malformadas.length} linha(s): ${r.malformadas.slice(0, 5).join(', ')}`);
+    console.log(`  ${r.chamavel && !mc3.includes(r) ? 'ok' : ' x'} ${r.id.padEnd(16)} ${String(r.nos).padStart(4)} nós · ${String(r.arestas).padStart(5)} arestas · rota ${r.chamavel ? 'ok' : `FALHA${r.rotaErro ? ` (${r.rotaErro.slice(0, 40)})` : ''}`} · ${conexo}${opt}`);
   }
   console.log('');
   console.log(`  MC1 contrato completo        ${mc1.length ? `FALHA — ${mc1.map((r) => r.id).join(', ')}` : 'PASSA'}`);
-  console.log(`  MC2 rota indexa nós válidos  ${mc2.length ? `FALHA — ${mc2.map((r) => r.id).join(', ')}` : 'PASSA'}`);
-  console.log(`  MC3 grafo conexo             ${mc3.length ? `FALHA — ${mc3.map((r) => `${r.id} ${r.alcancados}/${r.nos}`).join(', ')}` : `PASSA (${Object.keys(CONEXIDADE_DIVIDA).length} com dívida declarada)`}`);
+  console.log(`  MC2 rota indexa nós válidos  ${mc2.length ? `FALHA — ${mc2.map((r) => `${r.id}${r.rotaErro ? ` (lançou)` : ''}`).join(', ')}` : 'PASSA'}`);
+  console.log(`  MC3 grafo conexo             ${mc3.length ? `FALHA — ${mc3.map((r) => `${r.id} ${r.nos - r.alcancados} ilhados > ${ILHADOS_MAX[r.id] ?? 0}`).join(', ')}` : `PASSA (${Object.keys(ILHADOS_MAX).length} com teto de ilhados)`}`);
 }
 
 process.exit(mc1.length + mc2.length + mc3.length ? 1 : 0);

--- a/tools/eval/map-contrato-check.mjs
+++ b/tools/eval/map-contrato-check.mjs
@@ -41,17 +41,21 @@ const tipoDe = (v) => (Array.isArray(v) ? 'array' : typeof v);
    lista tem de ser conexo. Ver docs/quality-gates.md. */
 const ILHADOS_MAX = { loja_h: 491, ferro_velho: 15 };
 
-/* BFS do nó 0, mesmo critério da validatePlan de map_json.js. Linha de adjacência
-   não-array é defeito e não lista vazia: o jogo itera sobre ela e lança. */
+/* BFS do nó 0, mesmo critério da validatePlan de map_json.js.
+   A varredura de linha malformada é SEPARADA da BFS de propósito: dentro dela, nó de
+   componente que o nó 0 não alcança nunca seria visitado, e o `adj` quebrado dele
+   passaria — até um bot chegar lá e o jogo lançar. */
 function alcance(nodes, adj) {
+  const malformadas = [];
+  for (let i = 0; i < nodes.length; i++) if (!Array.isArray(adj[i])) malformadas.push(i);
+
   const visto = new Uint8Array(nodes.length);
   const fila = [0];
   visto[0] = 1;
   let n = 1;
-  const malformadas = [];
   while (fila.length) {
     const i = fila.pop();
-    if (!Array.isArray(adj[i])) { malformadas.push(i); continue; }
+    if (!Array.isArray(adj[i])) continue;
     for (const j of adj[i]) {
       if (Number.isInteger(j) && j >= 0 && j < nodes.length && !visto[j]) { visto[j] = 1; n++; fila.push(j); }
     }

--- a/tools/eval/map-contrato-check.mjs
+++ b/tools/eval/map-contrato-check.mjs
@@ -1,43 +1,16 @@
-/* map-contrato-check.mjs — TODO MAPA TEM DE DEVOLVER O QUE O JOGO CONSOME.
- * ══════════════════════════════════════════════════════════════════════════════════
- * POR QUE EXISTE
+/* map-contrato-check.mjs — todo mapa do registro devolve o que o `game.js` consome.
  *
- * O contrato de `build(scene, T)` nunca esteve escrito em lugar nenhum. Ele existia
- * como acordo tácito entre os `map_*.js` escritos à mão e o `game.js` — e acordo
- * tácito não reprova nada.
+ * Irmã da `eval:mapjson`, que valida um spec JSON ANTES do build; esta valida o
+ * registro DEPOIS do build, inclusive os mapas escritos à mão.
  *
- * O defeito que fez esta régua nascer: o editor de mapa (repo privado) tem DOIS
- * caminhos para a mesma cena. O "▶ Testar mapa" roda `buildEditorMap()`, que devolve
- * `waypoints`, `nearestWaypoint` e `findPath`. O "⬇ Exportar .js" roda `exportCode()`,
- * que NAO devolve nenhum dos tres. O comentario do proprio builder promete
- * "testar == o que voce vai exportar", e a promessa e' mantida a mao.
+ * `obrigatorio` não é juízo de valor: é chave que o `game.js` desreferencia SEM guarda.
+ * Marcar como obrigatória uma chave guardada reprova mapa que funciona.
  *
- * O jogo desreferencia os tres SEM GUARDA:
- *     game.js:4157   const nd = this.world.waypoints.nodes;
- *     game.js:4292   let from = W.nearestWaypoint(b.pos.x, b.pos.z);
- *     game.js:4298   b.path = W.findPath(...)
+ * MC3 usa o MESMO critério de conexidade da `validatePlan` (map_json.js): BFS do nó 0
+ * alcança todos. Dois limiares para o mesmo conceito é a LIÇÃO 2 do docs/LICOES.md.
  *
- * Ou seja: o mapa que voce TESTOU tem IA de bot, e o mapa que voce EXPORTOU quebra
- * nela. E' a pior forma do defeito — o teste passa e a entrega falha.
- *
- * O QUE ELA MEDE
- *  MC1  todo mapa do registro devolve as chaves que o jogo consome
- *  MC2  as funcoes do contrato sao chamaveis e devolvem o tipo certo
- *  MC3  o grafo de navegacao nao nasce vazio nem desconexo do proprio mapa
- *
- * A LISTA DE CHAVES NAO E' OPINIAO. Ela foi extraida do que `game.js` de fato le
- * de `this.world` / `W`; ver `CONSUMIDO`, com arquivo:linha em cada entrada. Chave
- * nova no jogo entra aqui, e a regua avisa quando um mapa nao a tiver.
- *
- * USO
- *   node tools/eval/map-contrato-check.mjs
- *   node tools/eval/map-contrato-check.mjs --mutante=sem-waypoints   # o teste do teste
- *   node tools/eval/map-contrato-check.mjs --extra=/caminho/map_x.js # mapa AINDA nao registrado
- *   node tools/eval/map-contrato-check.mjs --json
- *
- * O `--extra` existe para o caso que mais importa: mapa recem-saido do editor, antes de
- * alguem registra-lo no `maps.js`. Descobrir que ele quebra a IA de bot DEPOIS de estar
- * no registro e' descobrir tarde.
+ *   node tools/eval/map-contrato-check.mjs [--extra=map_x.js] [--json]
+ *   node tools/eval/map-contrato-check.mjs --mutante=sem-waypoints|grafo-partido
  */
 import { THREE, MAPS, initTextures } from './harness.mjs';
 
@@ -48,110 +21,132 @@ const arg = (n, d) => {
 const MUTANTE = arg('mutante', '');
 const JSONOUT = process.argv.includes('--json');
 
-/* O CONTRATO — E ELE NAO E' OPINIAO MINHA.
- *
- * `obrigatorio` nao quer dizer "eu acho importante": quer dizer que o `game.js`
- * DESREFERENCIA a chave sem guarda, entao mapa sem ela derruba o frame. `opcional`
- * quer dizer que o jogo escreveu a guarda e tem fallback.
- *
- * A primeira versao desta regua marcou `slowAt` e `groundHeightAt` como obrigatorios
- * e reprovou 8 dos 10 mapas que estao EM PRODUCAO E FUNCIONANDO. Os mapas estavam
- * certos e a regua errada — os dois sao guardados. Regua que reprova o que funciona
- * treina quem a le' a ignora-la, que e' o mesmo estrago de nao ter regua.
- *
- * Ao acrescentar chave aqui: cite arquivo:linha e diga se HA guarda no ponto de uso. */
 const CONSUMIDO = [
-  { chave: 'root', tipo: 'object', obrigatorio: true, onde: 'game.js — scene.add / dispose' },
-  { chave: 'colliders', tipo: 'array', obrigatorio: true, onde: 'game.js — _collide' },
-  { chave: 'occluders', tipo: 'array', obrigatorio: true, onde: 'game.js:2926 — intersectObjects, sem guarda' },
-  { chave: 'spawns', tipo: 'object', obrigatorio: true, onde: 'game.js — _startRound' },
-  { chave: 'bounds', tipo: 'object', obrigatorio: true, onde: 'game.js:4462 — const B = this.world.bounds' },
-  { chave: 'waypoints', tipo: 'object', obrigatorio: true, onde: 'game.js:4157 — this.world.waypoints.nodes, sem guarda' },
-  { chave: 'nearestWaypoint', tipo: 'function', obrigatorio: true, onde: 'game.js:4292 — sem guarda' },
-  { chave: 'findPath', tipo: 'function', obrigatorio: true, onde: 'game.js:4298 — sem guarda' },
-  { chave: 'groundHeightAt', tipo: 'function', obrigatorio: false, onde: 'game.js:1973 — guardado (? :), cai pra 0' },
-  { chave: 'slowAt', tipo: 'function', obrigatorio: false, onde: 'game.js:4329 — guardado (&&), cai pra normal' },
+  { chave: 'root', tipo: 'object', obrigatorio: true, onde: 'scene.add / dispose' },
+  { chave: 'colliders', tipo: 'array', obrigatorio: true, onde: '_collide' },
+  { chave: 'occluders', tipo: 'array', obrigatorio: true, onde: 'game.js:2926 intersectObjects' },
+  { chave: 'spawns', tipo: 'object', obrigatorio: true, onde: '_startRound' },
+  { chave: 'bounds', tipo: 'object', obrigatorio: true, onde: 'game.js:4462' },
+  { chave: 'waypoints', tipo: 'object', obrigatorio: true, onde: 'game.js:4157 .nodes, sem guarda' },
+  { chave: 'nearestWaypoint', tipo: 'function', obrigatorio: true, onde: 'game.js:4292, sem guarda' },
+  { chave: 'findPath', tipo: 'function', obrigatorio: true, onde: 'game.js:4298, sem guarda' },
+  { chave: 'groundHeightAt', tipo: 'function', obrigatorio: false, onde: 'game.js:1973 guardado' },
+  { chave: 'slowAt', tipo: 'function', obrigatorio: false, onde: 'game.js:4329 guardado' },
 ];
 
 const tipoDe = (v) => (Array.isArray(v) ? 'array' : typeof v);
 
+/* DÍVIDA DECLARADA DE CONEXIDADE — mesmo desenho do `cena-tetos.mjs`: o número sai da
+   medição, não de escolha, e serve de trava contra piorar. Estes dois mapas já estão
+   em produção com o grafo partido; a régua nasceu depois deles e não pode reprovar o
+   que já roda, mas também não vai abençoar. Mapa FORA desta lista tem de ser conexo.
+
+   Medido em 13/08 na alpha.95 (`node tools/eval/map-contrato-check.mjs`). Baixar o
+   número é conserto e deve vir com a lista atualizada; subir é regressão e reprova. */
+const CONEXIDADE_DIVIDA = {
+  loja_h: 143,        // de 634 nós — 77% do grafo inalcançável a partir do nó 0
+  ferro_velho: 281,   // de 296 nós — 15 ilhados
+};
+
+/* Conexidade: BFS do nó 0, mesmo critério da validatePlan de map_json.js. */
+function alcance(nodes, adj) {
+  const visto = new Uint8Array(nodes.length);
+  const fila = [0];
+  visto[0] = 1;
+  let n = 1;
+  while (fila.length) {
+    const i = fila.pop();
+    for (const j of (Array.isArray(adj[i]) ? adj[i] : [])) {
+      if (Number.isInteger(j) && j >= 0 && j < nodes.length && !visto[j]) { visto[j] = 1; n++; fila.push(j); }
+    }
+  }
+  return n;
+}
+
 async function medir(id, buildFn) {
   const scene = new THREE.Scene();
   const T = await initTextures();
-  let W;
+  /* Um try só em volta de build E validação: builder que devolve null ou `adj`
+     não-array lançava FORA do catch e matava o relatório dos outros mapas. */
   try {
-    W = (buildFn || MAPS[id].build)(scene, T);
+    let W = (buildFn || MAPS[id].build)(scene, T);
+    if (!W || typeof W !== 'object') return { id, erro: `build devolveu ${W === null ? 'null' : typeof W}` };
+
+    if (MUTANTE === 'sem-waypoints') { delete W.waypoints; delete W.nearestWaypoint; delete W.findPath; }
+    if (MUTANTE === 'grafo-partido' && W.waypoints && Array.isArray(W.waypoints.adj)) {
+      const meio = Math.floor(W.waypoints.nodes.length / 2);
+      W = { ...W, waypoints: { nodes: W.waypoints.nodes, adj: W.waypoints.adj.map((l, i) => (Array.isArray(l) ? l.filter((j) => (i < meio) === (j < meio)) : l)) } };
+    }
+
+    const faltando = [], opcionais = [];
+    for (const c of CONSUMIDO) {
+      const v = W[c.chave];
+      const p = (v === undefined || v === null) ? 'ausente' : (tipoDe(v) !== c.tipo ? tipoDe(v) : null);
+      if (p) (c.obrigatorio ? faltando : opcionais).push({ ...c, viu: p });
+    }
+    if (faltando.length) return { id, faltando, opcionais };
+
+    const nodes = W.waypoints.nodes, adj = W.waypoints.adj;
+    if (!Array.isArray(nodes) || !Array.isArray(adj)) {
+      return { id, faltando: [{ chave: 'waypoints.nodes/adj', viu: 'não-array', tipo: 'array', onde: 'game.js:4157/4199' }], opcionais };
+    }
+    const arestas = adj.reduce((a, l) => a + (Array.isArray(l) ? l.length : 0), 0);
+
+    /* MC2: o caminho é consumido como ÍNDICE de nodes (game.js:4306). Entrada fora da
+       faixa, não-inteira ou undefined faz o bot ler waypoint inexistente. */
+    const i = W.nearestWaypoint(0, 0);
+    const p = W.findPath(i, Math.min(nodes.length - 1, i + 1));
+    const chamavel = Number.isInteger(i) && i >= 0 && i < nodes.length
+      && Array.isArray(p) && p.length > 0
+      && p.every((n) => Number.isInteger(n) && n >= 0 && n < nodes.length);
+
+    return { id, faltando: [], opcionais, nos: nodes.length, arestas, chamavel, alcancados: alcance(nodes, adj) };
   } catch (e) {
-    return { id, erro: String(e && e.message || e) };
+    return { id, erro: String((e && e.message) || e) };
   }
-  /* MUTANTE: arranca do mapa exatamente o que o `exportCode()` nao emite. Se a regua
-     continuar verde com isto, ela nao esta medindo o defeito que a fez nascer. */
-  if (MUTANTE === 'sem-waypoints') {
-    delete W.waypoints; delete W.nearestWaypoint; delete W.findPath;
-  }
-
-  const faltando = [], ausentes_opcionais = [];
-  for (const c of CONSUMIDO) {
-    const v = W[c.chave];
-    const problema = (v === undefined || v === null) ? 'ausente'
-      : (tipoDe(v) !== c.tipo) ? tipoDe(v) : null;
-    if (!problema) continue;
-    (c.obrigatorio ? faltando : ausentes_opcionais).push({ ...c, viu: problema });
-  }
-
-  /* MC2/MC3 so' rodam se as chaves existirem — nao adianta empilhar erro derivado. */
-  let nos = null, arestas = null, chamavel = null;
-  if (!faltando.length) {
-    const wp = W.waypoints || {};
-    nos = (wp.nodes || []).length;
-    arestas = (wp.adj || []).reduce((a, l) => a + (l ? l.length : 0), 0);
-    try {
-      const i = W.nearestWaypoint(0, 0);
-      const p = W.findPath(i, Math.min(nos - 1, i + 1));
-      chamavel = Number.isInteger(i) && Array.isArray(p) && p.length > 0;
-    } catch (e) { chamavel = false; }
-  }
-  return { id, faltando, ausentes_opcionais, nos, arestas, chamavel };
 }
 
-const ids = Object.keys(MAPS);
 const linhas = [];
-for (const id of ids) linhas.push(await medir(id));
+for (const id of Object.keys(MAPS)) linhas.push(await medir(id));
 
 const EXTRA = arg('extra', '');
 if (EXTRA) {
   const url = new URL(EXTRA.startsWith('/') ? `file://${EXTRA}` : EXTRA, `file://${process.cwd()}/`);
   const mod = await import(url.href);
-  const build = Object.entries(mod).find(([k, v]) => k.startsWith('build') && typeof v === 'function');
-  if (!build) {
-    console.error(`x ${EXTRA}: nenhum export build* encontrado`);
-    process.exit(1);
-  }
-  linhas.push(await medir(`extra:${build[0]}`, build[1]));
+  const b = Object.entries(mod).find(([k, v]) => k.startsWith('build') && typeof v === 'function');
+  if (!b) { console.error(`x ${EXTRA}: nenhum export build* encontrado`); process.exit(1); }
+  linhas.push(await medir(`extra:${b[0]}`, b[1]));
 }
 
-const mc1 = linhas.filter((r) => r.erro || (r.faltando && r.faltando.length));
+const mc1 = linhas.filter((r) => r.erro || r.faltando?.length);
 const mc2 = linhas.filter((r) => r.chamavel === false);
-const mc3 = linhas.filter((r) => r.nos !== null && (r.nos < 4 || r.arestas === 0));
+const divida = (r) => CONEXIDADE_DIVIDA[r.id];
+/* Reprova se: mapa sem dívida declarada não é conexo, OU mapa com dívida piorou. */
+const mc3 = linhas.filter((r) => r.nos != null && r.alcancados !== r.nos
+  && !(divida(r) != null && r.alcancados >= divida(r)));
 
 if (JSONOUT) {
   console.log(JSON.stringify({ mapas: linhas, mutante: MUTANTE || null }, null, 1));
 } else {
-  console.log(`CONTRATO DE MAPA — ${ids.length} mapas do registro${MUTANTE ? `  [mutante: ${MUTANTE}]` : ''}\n`);
+  console.log(`CONTRATO DE MAPA — ${linhas.length} mapas${MUTANTE ? `  [mutante: ${MUTANTE}]` : ''}\n`);
   for (const r of linhas) {
-    if (r.erro) { console.log(`  x ${r.id.padEnd(16)} build lancou: ${r.erro}`); continue; }
+    if (r.erro) { console.log(`  x ${r.id.padEnd(16)} ${r.erro}`); continue; }
     if (r.faltando.length) {
       console.log(`  x ${r.id.padEnd(16)} faltam ${r.faltando.length}:`);
       for (const f of r.faltando) console.log(`      ${f.chave} (${f.viu}, esperado ${f.tipo})  <- ${f.onde}`);
-    } else {
-      const opt = r.ausentes_opcionais.length ? `  (sem ${r.ausentes_opcionais.map((o) => o.chave).join('/')} — opcional)` : '';
-      console.log(`  ok ${r.id.padEnd(16)} ${String(r.nos).padStart(4)} nos · ${String(r.arestas).padStart(5)} arestas · rota ${r.chamavel ? 'ok' : 'FALHA'}${opt}`);
+      continue;
     }
+    const opt = r.opcionais.length ? `  (sem ${r.opcionais.map((o) => o.chave).join('/')} — opcional)` : '';
+    const d = CONEXIDADE_DIVIDA[r.id];
+    const conexo = r.alcancados === r.nos ? 'conexo'
+      : (d != null && r.alcancados >= d) ? `partido ${r.alcancados}/${r.nos} (dívida declarada)`
+      : `PARTIDO ${r.alcancados}/${r.nos}`;
+    console.log(`  ${r.chamavel && !mc3.includes(r) ? 'ok' : ' x'} ${r.id.padEnd(16)} ${String(r.nos).padStart(4)} nós · ${String(r.arestas).padStart(5)} arestas · rota ${r.chamavel ? 'ok' : 'FALHA'} · ${conexo}${opt}`);
   }
   console.log('');
   console.log(`  MC1 contrato completo        ${mc1.length ? `FALHA — ${mc1.map((r) => r.id).join(', ')}` : 'PASSA'}`);
-  console.log(`  MC2 rota chamavel            ${mc2.length ? `FALHA — ${mc2.map((r) => r.id).join(', ')}` : 'PASSA'}`);
-  console.log(`  MC3 grafo nao nasce vazio    ${mc3.length ? `FALHA — ${mc3.map((r) => r.id).join(', ')}` : 'PASSA'}`);
+  console.log(`  MC2 rota indexa nós válidos  ${mc2.length ? `FALHA — ${mc2.map((r) => r.id).join(', ')}` : 'PASSA'}`);
+  console.log(`  MC3 grafo conexo             ${mc3.length ? `FALHA — ${mc3.map((r) => `${r.id} ${r.alcancados}/${r.nos}`).join(', ')}` : `PASSA (${Object.keys(CONEXIDADE_DIVIDA).length} com dívida declarada)`}`);
 }
 
 process.exit(mc1.length + mc2.length + mc3.length ? 1 : 0);


### PR DESCRIPTION
Revisão do Greptile na #240, com a régua já mergeada. **Os quatro procedem.**

### 1 · MC2 aceitava caminho inválido
`findPath` devolve índices que o `game.js:4306` usa direto em `waypoints.nodes[...]`. A checagem só exigia array não-vazio — caminho com string, índice fora da faixa ou `undefined` passava, e o bot leria waypoint inexistente. Agora exige inteiro em `[0, nós)`.

### 2 · MC3 prometia mais do que media — e medir de verdade achou defeito
A cláusula se chamava *"grafo não nasce vazio nem desconexo"* e o predicado era `nós >= 4 && arestas > 0`, que passa com o grafo partido em componentes. É exatamente a régua-que-mente sobre a qual escrevi no commit da própria #240.

Agora faz BFS do nó 0 e exige alcançar todos — **mesmo critério** da `validatePlan` do `map_json.js` (dois limiares para o mesmo conceito é a LIÇÃO 2).

**E aí apareceu defeito em produção:**

```
loja_h        143 de 634 nós alcançáveis   ← 77% do grafo de navegação ilhado
ferro_velho   281 de 296                   ← 15 ilhados
```

Os dois entram como **dívida declarada** com o número medido, no desenho do `cena-tetos.mjs`: não reprova o que já roda, trava contra piorar, e mapa fora da lista tem de ser conexo. Baixar o número é conserto; subir é regressão.

Vale investigar em separado — grafo partido degrada rota de bot, e o BOT8 (bot com LOS e sem atirar) é dívida antiga justamente nesses mapas.

### 3 · Builder malformado escapava do diagnóstico
`--extra` devolvendo `null`/`undefined`, ou `waypoints.adj` não-array, lançava fora do `catch` e matava o relatório dos outros mapas. Um `try` só em volta de build e validação.

### 4 · Comentário acima do orçamento
O `AGENTS.md` é explícito: *"comentários no código têm orçamento quase zero… não cole o histórico da investigação"*. Eu colei o histórico inteiro no cabeçalho — e ele já estava no commit, que é o lugar dele. De ~40 linhas de narrativa para 14 de invariante.

### Mutação nova

`--mutante=grafo-partido` corta as arestas entre as duas metades. Sem ela, nada provava que o MC3 mede conexidade.

```
limpo            PASSA (2 com dívida declarada)
grafo-partido    FALHA nos 5 · exit 1
sem-waypoints    FALHA · exit 1
--extra builder null   → "build devolveu null", sem stack trace
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR strengthens the map-contract evaluator's path, adjacency, and connectivity checks while preserving explicit debt ceilings for two existing maps.
- Validates waypoint indices returned by sampled routes.
- Scans all adjacency rows and isolates route errors in MC2 diagnostics.
- Measures disconnected-node debt and adds a split-graph mutation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/eval/map-contrato-check.mjs | Strengthens contract diagnostics, validates route indices and adjacency rows, and replaces the reachable-node floor with disconnected-node ceilings. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Build map] --> B{Contract fields valid?}
  B -- No --> M1[MC1 fails]
  B -- Yes --> C{Route returns valid node indices?}
  C -- No --> M2[MC2 fails]
  C -- Yes --> D[Scan adjacency rows]
  D --> E{Rows are arrays?}
  E -- No --> M1
  E -- Yes --> F[Traverse from node 0]
  F --> G{Unreachable nodes exceed ceiling?}
  G -- Yes --> M3[MC3 fails]
  G -- No --> P[Map passes]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rubenmarcus%2Fcsbrasil%20PR%20%23242%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rubenmarcus%2Fcsbrasil&pr=242&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (3): Last reviewed commit: ["fix(eval): linha de adjacência malformad..."](https://github.com/rubenmarcus/csbrasil/commit/2681e4317090a9bc0e319303beb17c3853a504ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52815689)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->