### PR TITLE
feat(portões): pre-push roda o CI antes do push, e o cache para de raspar o teto de 10 GB

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Roda ANTES do push o que hoje só falha depois: no CI, ou na revisão.
+#
+# O QUE ELE EVITA, E O QUE NÃO EVITA
+# Evita a ida-e-volta MECÂNICA: bloco gerado desatualizado, ARCH.md velho, travessão em
+# src/, sintaxe, contrato de mapa, trailer `Agent:` faltando. Foi essa classe que deixou
+# `pr-fast` vermelho em toda PR aberta por um dia inteiro.
+#
+# NÃO evita comentário de revisor de IA. Greptile aponta julgamento — cláusula que
+# promete mais do que mede, caminho não validado, história de investigação colada no
+# código. Script local não substitui isso, e prometer que substitui seria a mesma
+# mentira que a régua que não morde. O que fecha esse lado é bloquear merge com fio
+# aberto (ver docs/quality-gates.md), não um hook.
+#
+# Pular: `git push --no-verify` (ou PREPUSH=0). Custa ~4 s.
+set -uo pipefail
+[ "${PREPUSH:-1}" = "0" ] && exit 0
+
+remoto="$1"
+falhas=()
+t0=$(date +%s)
+
+echo "pre-push: portões locais (~4 s; PREPUSH=0 pula)"
+
+# Trailer `Agent:` nos commits que ESTÃO SUBINDO. O commit-msg já cobra, mas ele não
+# roda em rebase, cherry-pick, amend com -F, nem em clone sem `npm run setup`.
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    intervalo=$(git rev-list --max-count=50 "$local_sha" --not --remotes="$remoto")
+  else
+    intervalo=$(git rev-list "$remote_sha..$local_sha")
+  fi
+  for sha in $intervalo; do
+    if ! git show -s --format='%B' "$sha" | grep -Eqi '^Agent:[[:space:]]*[^[:space:]]'; then
+      falhas+=("commit ${sha:0:8} sem trailer 'Agent:' — $(git show -s --format='%s' "$sha" | cut -c1-50)")
+    fi
+  done
+done
+
+# package.json e version.js têm que concordar (o portão versao-bumpada cobra isso).
+if [ -f package.json ] && [ -f public/js/version.js ]; then
+  pj=$(node -pe 'require("./package.json").version' 2>/dev/null)
+  vj=$(grep -o "VERSION = '[^']*'" public/js/version.js 2>/dev/null | cut -d"'" -f2)
+  [ -n "$pj" ] && [ "$pj" != "$vj" ] && falhas+=("package.json ($pj) != version.js ($vj)")
+fi
+
+for portao in syntax docs:check arch:check travessao:check eval:mapcontrato; do
+  if ! npm run "$portao" --silent >/tmp/prepush-$$.log 2>&1; then
+    falhas+=("$portao — $(grep -m1 -E '✗|FALHA|error' /tmp/prepush-$$.log | cut -c1-90)")
+  fi
+done
+rm -f /tmp/prepush-$$.log
+
+if [ ${#falhas[@]} -gt 0 ]; then
+  echo ""
+  echo "  PUSH BLOQUEADO — ${#falhas[@]} portão(ões) reprovando:"
+  for f in "${falhas[@]}"; do echo "    x $f"; done
+  echo ""
+  echo "  docs/ARCH desatualizado:  npm run docs && node tools/gen-arch.mjs"
+  echo "  trailer faltando:         git commit --amend --trailer 'Agent: <nome>'"
+  echo "  pular mesmo assim:        git push --no-verify"
+  exit 1
+fi
+
+echo "pre-push: ok ($(( $(date +%s) - t0 ))s)"
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,12 +22,12 @@ t0=$(date +%s)
 
 echo "pre-push: portões locais (~4 s; PREPUSH=0 pula)"
 
-# Trailer `Agent:` nos commits que ESTÃO SUBINDO. O commit-msg já cobra, mas ele não
-# roda em rebase, cherry-pick, amend com -F, nem em clone sem `npm run setup`.
+# Trailer `Agent:` em TODO commit que sobe: o commit-msg não roda em rebase nem em
+# clone sem `npm run setup`.
 while read -r _local_ref local_sha _remote_ref remote_sha; do
   [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
   if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-    intervalo=$(git rev-list --max-count=50 "$local_sha" --not --remotes="$remoto")
+    intervalo=$(git rev-list "$local_sha" --not --remotes="$remoto")
   else
     intervalo=$(git rev-list "$remote_sha..$local_sha")
   fi

--- a/.github/workflows/cache-limpeza.yml
+++ b/.github/workflows/cache-limpeza.yml
@@ -1,0 +1,68 @@
+# Cache do Actions tem teto de 10 GB por repositório, e passar dele faz o GitHub
+# despejar por LRU — o cache do `main` é expulso por lixo de PR morta e o build fica
+# lento EM SILÊNCIO, sem erro nenhum.
+#
+# Medido em 13/08: 99 caches, 9,97 GB (99,7% da cota). Composição: 61 de PR já fechada
+# (6,3 GB) e 29 no `main` (2,7 GB). Os do `main` acumulam porque `cache: npm` chaveia
+# pelo hash do `package-lock.json` e TODO release bumpa a versão dentro dele — cada
+# release cria um cache novo que nunca mais será reusado. Limpeza manual levou a 12
+# caches / 1,2 GB.
+#
+# Este workflow evita a volta: apaga o cache de PR ao fechar, e semanalmente poda o
+# excedente do `main` guardando os 3 mais recentes (o mais novo serve de restore-key
+# para as PRs; os antigos são só peso).
+name: cache-limpeza
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  limpar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: cache da PR que fechou
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+          ids=$(gh api "repos/$REPO/actions/caches?per_page=100" \
+                --jq ".actions_caches[] | select(.ref==\"$REF\") | .id")
+          n=0
+          for id in $ids; do gh api -X DELETE "repos/$REPO/actions/caches/$id" && n=$((n+1)); done
+          echo "apagados $n cache(s) de $REF"
+
+      - name: poda do main (guarda os 3 mais recentes)
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          antes=$(gh api "repos/$REPO/actions/cache/usage" --jq '.active_caches_size_in_bytes')
+          # Ordena por último acesso e descarta do 4º em diante.
+          ids=$(gh api "repos/$REPO/actions/caches?per_page=100&sort=last_accessed_at&direction=desc" \
+                --jq '[.actions_caches[] | select(.ref=="refs/heads/main")] | .[3:] | .[].id')
+          n=0
+          for id in $ids; do gh api -X DELETE "repos/$REPO/actions/caches/$id" && n=$((n+1)); done
+          # Órfãos: ref de PR que já não está aberta.
+          abertas=$(gh pr list --repo "$REPO" --state open --limit 200 --json number --jq '[.[].number] | join(" ")')
+          for linha in $(gh api "repos/$REPO/actions/caches?per_page=100" --jq '.actions_caches[] | "\(.id):\(.ref)"'); do
+            id=${linha%%:*}; ref=${linha#*:}
+            case "$ref" in refs/pull/*) num=$(echo "$ref" | tr -dc '0-9');;
+                           *) continue;; esac
+            case " $abertas " in *" $num "*) continue;; esac
+            gh api -X DELETE "repos/$REPO/actions/caches/$id" && n=$((n+1))
+          done
+          depois=$(gh api "repos/$REPO/actions/cache/usage" --jq '.active_caches_size_in_bytes')
+          echo "apagados $n cache(s) · $((antes/1048576)) MB -> $((depois/1048576)) MB"

--- a/.github/workflows/cache-limpeza.yml
+++ b/.github/workflows/cache-limpeza.yml
@@ -1,16 +1,6 @@
-# Cache do Actions tem teto de 10 GB por repositório, e passar dele faz o GitHub
-# despejar por LRU — o cache do `main` é expulso por lixo de PR morta e o build fica
-# lento EM SILÊNCIO, sem erro nenhum.
-#
-# Medido em 13/08: 99 caches, 9,97 GB (99,7% da cota). Composição: 61 de PR já fechada
-# (6,3 GB) e 29 no `main` (2,7 GB). Os do `main` acumulam porque `cache: npm` chaveia
-# pelo hash do `package-lock.json` e TODO release bumpa a versão dentro dele — cada
-# release cria um cache novo que nunca mais será reusado. Limpeza manual levou a 12
-# caches / 1,2 GB.
-#
-# Este workflow evita a volta: apaga o cache de PR ao fechar, e semanalmente poda o
-# excedente do `main` guardando os 3 mais recentes (o mais novo serve de restore-key
-# para as PRs; os antigos são só peso).
+# Teto de 10 GB por repositório: passar dele faz o GitHub despejar por LRU, e o build
+# fica lento sem erro. Guarda os 3 caches mais recentes do main (o mais novo serve de
+# restore-key às PRs) e descarta o resto. Ver docs/quality-gates.md.
 name: cache-limpeza
 
 on:
@@ -36,7 +26,7 @@ jobs:
           REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
           set -euo pipefail
-          ids=$(gh api "repos/$REPO/actions/caches?per_page=100" \
+          ids=$(gh api --paginate "repos/$REPO/actions/caches?per_page=100" \
                 --jq ".actions_caches[] | select(.ref==\"$REF\") | .id")
           n=0
           for id in $ids; do gh api -X DELETE "repos/$REPO/actions/caches/$id" && n=$((n+1)); done
@@ -51,13 +41,13 @@ jobs:
           set -euo pipefail
           antes=$(gh api "repos/$REPO/actions/cache/usage" --jq '.active_caches_size_in_bytes')
           # Ordena por último acesso e descarta do 4º em diante.
-          ids=$(gh api "repos/$REPO/actions/caches?per_page=100&sort=last_accessed_at&direction=desc" \
+          ids=$(gh api --paginate "repos/$REPO/actions/caches?per_page=100&sort=last_accessed_at&direction=desc" \
                 --jq '[.actions_caches[] | select(.ref=="refs/heads/main")] | .[3:] | .[].id')
           n=0
           for id in $ids; do gh api -X DELETE "repos/$REPO/actions/caches/$id" && n=$((n+1)); done
           # Órfãos: ref de PR que já não está aberta.
           abertas=$(gh pr list --repo "$REPO" --state open --limit 200 --json number --jq '[.[].number] | join(" ")')
-          for linha in $(gh api "repos/$REPO/actions/caches?per_page=100" --jq '.actions_caches[] | "\(.id):\(.ref)"'); do
+          for linha in $(gh api --paginate "repos/$REPO/actions/caches?per_page=100" --jq '.actions_caches[] | "\(.id):\(.ref)"'); do
             id=${linha%%:*}; ref=${linha#*:}
             case "$ref" in refs/pull/*) num=$(echo "$ref" | tr -dc '0-9');;
                            *) continue;; esac

--- a/.github/workflows/csbrasil-bot-pr-classify.yml
+++ b/.github/workflows/csbrasil-bot-pr-classify.yml
@@ -1,8 +1,16 @@
 name: csbrasil-bot-pr-classify
 
 on:
+  # `pull_request_target` dispara no PUSH — e o Greptile comenta DEPOIS do push. Com
+  # só esses gatilhos o rotulador rodava antes de existir comentário, não achava nada
+  # e nunca mais rodava: era estruturalmente cego para o que devia detectar. Medido na
+  # PR #240, que fechou com 4 fios do Greptile abertos e NENHUMA etiqueta.
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Três buracos no laço de revisão, todos medidos hoje.

## 1 · Não existia pre-push

Só `commit-msg` e `prepare-commit-msg`. Tudo que é mecânico — bloco gerado velho, `ARCH.md` defasado, travessão em `src/`, contrato de mapa — só falhava **depois** do push. Foi essa classe que deixou `pr-fast` vermelho em **toda PR aberta** por um dia inteiro.

`.githooks/pre-push` roda em **~4 s**: `syntax`, `docs:check`, `arch:check`, `travessao:check`, `eval:mapcontrato`, consistência `package.json`×`version.js`, e o trailer `Agent:` nos commits que estão subindo.

**Provado que morde:**

```
doc desatualizado    → PUSH BLOQUEADO — docs:check ✗ DOCS1
version.js 9.9.9     → PUSH BLOQUEADO — package.json (alpha.95) != version.js (9.9.9)
árvore limpa         → ok (4s)
PREPUSH=0            → pula
```

**O que ele NÃO faz:** evitar comentário de revisor de IA. Greptile aponta julgamento — cláusula que promete mais do que mede, caminho não validado. Script local não substitui isso, e dizer que substitui seria a mesma mentira de uma régua que não morde.

## 2 · O rotulador de Greptile era cego por construção

`csbrasil-bot-pr-classify` disparava só em `opened/synchronize` — no **push**. O Greptile comenta **depois** do push, então o rotulador rodava antes de existir comentário, não achava nada, e nunca mais rodava.

**Medido:** a #240 fechou com 4 fios do Greptile abertos e **nenhuma etiqueta**. Acrescentados `pull_request_review` e `pull_request_review_comment`.

⚠️ **Isto não fecha sozinho.** `check_automerge.py` já respeita `needs-greptile-resolution`, mas só o bot obedece: `gh pr merge` manual passa direto — foi exatamente como mergeei a #240 com os 4 fios abertos. Fechar de verdade exige **branch protection** exigindo threads resolvidas, que só o dono habilita.

## 3 · Cache em 99,7% da cota

| | antes | depois |
|---|---:|---:|
| caches | 99 | 12 |
| tamanho | **9,97 GB** | **1,20 GB** |

Composição medida: **61 de PR já fechada** (6,3 GB) e **29 no `main`** (2,7 GB) — estes porque `cache: npm` chaveia pelo hash do `package-lock.json` e **todo release bumpa a versão dentro dele**, criando um cache novo que nunca será reusado.

Passando de 10 GB o GitHub despeja por LRU: o cache do `main` é expulso por lixo de PR morta e o build fica lento **em silêncio**, sem erro. Já limpei manualmente; `cache-limpeza.yml` evita a volta — apaga o cache da PR ao fechar, e semanalmente poda o excedente do `main` guardando os 3 mais recentes.

## Não feito, e com motivo

Um lint de "orçamento de comentário" (o 4º apontamento do Greptile na #240) foi **considerado e descartado**. Medida a distribuição real em 142 arquivos de `tools/eval`:

```
mediana 0,21 · p75 0,32 · p90 0,42 · máx 0,79
```

O máximo — o arquivo mais comentado do repo — é o `cena-tetos.mjs`, que é justamente o arquivo-decisão mais valioso da base. **Um lint de razão reprovaria o melhor código do projeto.** O que o Greptile apontou não é razão, é *tipo* de conteúdo (história de investigação vs invariante), e isso não é mecanicamente verificável.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a local pre-push quality gate, schedules cleanup of GitHub Actions caches, and reruns PR classification when reviews or review comments arrive.
- Validates generated documentation, architecture, syntax, map contracts, versions, and commit trailers before push.
- Deletes caches for closed pull requests and retains the three most recently accessed caches on `main`.
- Extends classifier triggers to review submission, dismissal, and review-comment creation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .githooks/pre-push | Adds local checks for mechanical quality gates, version consistency, and commit trailers before a push. |
| .github/workflows/cache-limpeza.yml | Adds closed-PR and scheduled cache cleanup with pagination and retention of recent main-branch caches. |
| .github/workflows/csbrasil-bot-pr-classify.yml | Adds review and review-comment events so classification reruns after Greptile activity. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Push[Local git push] --> Hook[pre-push checks]
  Hook -->|pass| Remote[Remote push]
  Hook -->|fail| Block[Block push]
  Remote --> Review[Greptile review activity]
  Review --> Classifier[PR classifier]
  Classifier --> Labels[Refresh PR labels]
  Closed[PR closed] --> Cleanup[Cache cleanup]
  Schedule[Weekly schedule] --> Cleanup
  Cleanup --> Retain[Retain three recent main caches]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rubenmarcus%2Fcsbrasil%20PR%20%23243%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rubenmarcus%2Fcsbrasil&pr=243&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix(portoes): os 3 apontamentos do Grept..."](https://github.com/rubenmarcus/csbrasil/commit/79b5e3e367424a5e2155e8c5a23b1f761beb2110) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52819206)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->