### PR TITLE
fix(docs): tabela de licença conta ocorrências, não anota número de linha

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,18 +197,18 @@ mesmo commit (metade trocada é pior que nenhuma). A tabela é gerada:
 
 | Superfície | Arquivo | Onde diz `AGPL-3.0` |
 |---|---|---|
-| licença canônica | `LICENSE` | linhas 1, 10, 42, 63 (+7)  |
-| badge + seção de licenças | `README.md` | linhas 3, 383, 389, 390 (+1)  |
-| termo que o contribuidor aceita | `CONTRIBUTING.md` | linhas 183, 186, 189, 198 (+2)  |
-| rodapé do site | `src/layouts/Layout.astro` | linha 610  |
-| JSON-LD do jogo | `src/pages/index.astro` | linha 408  |
-| página `/sobre` | `src/pages/sobre.astro` | linhas 121, 124, 133  |
-| `llms.txt` (resposta para LLM) | `public/llms.txt` | linhas 10, 48  |
+| licença canônica | `LICENSE` | 11×  |
+| badge + seção de licenças | `README.md` | 5×  |
+| termo que o contribuidor aceita | `CONTRIBUTING.md` | 6×  |
+| rodapé do site | `src/layouts/Layout.astro` | 1×  |
+| JSON-LD do jogo | `src/pages/index.astro` | 1×  |
+| página `/sobre` | `src/pages/sobre.astro` | 3×  |
+| `llms.txt` (resposta para LLM) | `public/llms.txt` | 2×  |
 | rodapé desta documentação | `docs/docusaurus.config.js` | — (não nomeia a licença)  |
 
 **29 ocorrências** de `AGPL-3.0` em **7** das 8 superfícies declaradas. Trocar a licença é mudar **todas elas no mesmo commit**: metade trocada é pior que nenhuma, porque cada arquivo passa a responder uma coisa diferente para quem pergunta.
 
-**Outros nomes de licença citados nessas superfícies:** `MIT` em `README.md` (linhas 389, 390, 391, 395), `MIT` em `CONTRIBUTING.md` (linhas 186, 187, 188, 211), `MIT` em `src/pages/sobre.astro` (linha 123), `MIT` em `public/llms.txt` (linha 49), `MIT` em `docs/docusaurus.config.js` (linha 150). Citar não é declarar — essas linhas são histórico da migração ou crédito a dependência de terceiro. A regra continua a mesma: **só o `LICENSE` declara**, e hoje ele diz `AGPL-3.0`.
+**Outros nomes de licença citados nessas superfícies:** `MIT` em `README.md` (4×), `MIT` em `CONTRIBUTING.md` (4×), `MIT` em `src/pages/sobre.astro` (1×), `MIT` em `public/llms.txt` (1×), `MIT` em `docs/docusaurus.config.js` (1×). Citar não é declarar — essas linhas são histórico da migração ou crédito a dependência de terceiro. A regra continua a mesma: **só o `LICENSE` declara**, e hoje ele diz `AGPL-3.0`.
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `grep -n dos nomes de licença conhecidos, nas superfícies declaradas em tools/gen-docs.mjs`
 

--- a/tools/gen-docs.mjs
+++ b/tools/gen-docs.mjs
@@ -480,10 +480,9 @@ const BLOCOS = {
   licenca_pontos: (f) => [
     `| Superfície | Arquivo | Onde diz \`${f.licenca.atual || '?'}\` |`,
     '|---|---|---|',
-    /* Contagem, não número de linha. O número desloca quando alguém insere qualquer linha
-       acima dele, e o bloco gerado reprova o `docs:check` de PR que não chegou perto de
-       licença (foi o que segurou a #221). A régua afirma que a superfície NOMEIA a licença;
-       a contagem preserva isso inteiro e não depende de onde o texto caiu no arquivo. */
+    /* Contagem, não número de linha: o número desloca a cada inserção acima e desatualiza
+       o bloco sozinho. A régua afirma que a superfície NOMEIA a licença — e isso não
+       depende de onde o texto caiu no arquivo. */
     ...f.licenca.superficies.map((s) => `| ${s.rotulo} | \`${s.arquivo}\` | ${
       !s.existe ? '**arquivo não existe**'
         : s.linhas.length ? `${s.linhas.length}×`

--- a/tools/gen-docs.mjs
+++ b/tools/gen-docs.mjs
@@ -480,12 +480,13 @@ const BLOCOS = {
   licenca_pontos: (f) => [
     `| Superfície | Arquivo | Onde diz \`${f.licenca.atual || '?'}\` |`,
     '|---|---|---|',
-    /* Teto de 4 linhas por superfície: o corpo do `LICENSE` nomeia a própria licença onze
-       vezes, e uma célula com onze números não informa mais que uma com quatro — informa
-       menos, porque ninguém lê. O total honesto vai no `+N` e na contagem abaixo da tabela. */
+    /* Contagem, não número de linha. O número desloca quando alguém insere qualquer linha
+       acima dele, e o bloco gerado reprova o `docs:check` de PR que não chegou perto de
+       licença (foi o que segurou a #221). A régua afirma que a superfície NOMEIA a licença;
+       a contagem preserva isso inteiro e não depende de onde o texto caiu no arquivo. */
     ...f.licenca.superficies.map((s) => `| ${s.rotulo} | \`${s.arquivo}\` | ${
       !s.existe ? '**arquivo não existe**'
-        : s.linhas.length ? `linha${s.linhas.length > 1 ? 's' : ''} ${s.linhas.slice(0, 4).join(', ')}${s.linhas.length > 4 ? ` (+${s.linhas.length - 4})` : ''}`
+        : s.linhas.length ? `${s.linhas.length}×`
           : '— (não nomeia a licença)'}  |`),
     '',
     `**${f.licenca.superficies.reduce((a, s) => a + s.linhas.length, 0)} ocorrências** de ` +
@@ -494,7 +495,7 @@ const BLOCOS = {
     'metade trocada é pior que nenhuma, porque cada arquivo passa a responder uma coisa diferente para quem pergunta.',
     '',
     f.licenca.outrasMencoes.length
-      ? `**Outros nomes de licença citados nessas superfícies:** ${f.licenca.outrasMencoes.map((m) => `\`${m.nome}\` em \`${m.arquivo}\` (linha${m.linhas.length > 1 ? 's' : ''} ${m.linhas.join(', ')})`).join(', ')}. ` +
+      ? `**Outros nomes de licença citados nessas superfícies:** ${f.licenca.outrasMencoes.map((m) => `\`${m.nome}\` em \`${m.arquivo}\` (${m.linhas.length}×)`).join(', ')}. ` +
         'Citar não é declarar — essas linhas são histórico da migração ou crédito a dependência de terceiro. ' +
         `A regra continua a mesma: **só o \`LICENSE\` declara**, e hoje ele diz \`${f.licenca.atual}\`.`
       : 'Nenhuma superfície cita outro nome de licença.',


### PR DESCRIPTION
## O que estava acontecendo

O bloco gerado da tabela de licença anotava **em que linha** cada superfície nomeia a licença:

```
| JSON-LD do jogo | `src/pages/index.astro` | linha 408 |
```

Número de linha desloca quando alguém insere qualquer linha acima dele. O bloco desatualiza, e o `docs:check` reprova uma PR que não chegou perto de licença nenhuma.

Foi exatamente o que segurou a **#221**: cinco linhas em `src/pages/index.astro` empurraram o JSON-LD de 408 para 413. Nenhuma das 5 PRs abertas do @EmersonGarrido passa nesse portão, e nenhuma delas por mérito próprio.

## O que muda

A afirmação que a régua precisa fazer é *"esta superfície nomeia a licença"*. Isso a contagem preserva inteiro, sem depender de onde o texto caiu.

| antes | depois |
|---|---|
| `linhas 1, 10, 42, 63 (+7)` | `11×` |
| `linha 408` | `1×` |

De quebra para de mentir por omissão — a célula do `LICENSE` mostrava quatro números de onze.

## Verificação

- Portões `syntax`, `docs:check`, `arch:check`, `travessao:check` verdes.
- **Mutação:** inserir uma linha acima do JSON-LD e rodar `docs:check` — reprovava antes, passa agora.

## O que este PR NÃO conserta

Medido no caminho e registrado para não sumir: trocar o nome da licença numa superfície (`AGPL-3.0` → outro texto) **não** reprova o `docs:check`, nem antes nem depois desta mudança. É a afirmação central da régua e ela não morde. Buraco pré-existente, merece issue própria.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes the generated license documentation to report occurrence counts rather than unstable source line numbers.
- Renders each declared license surface as an occurrence count.
- Applies the same count format to mentions of other license names.
- Regenerates the corresponding license table in `CONTRIBUTING.md`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/gen-docs.mjs | Replaces rendered license line-number lists with stable occurrence counts. |
| CONTRIBUTING.md | Updates the generated license documentation to reflect the new count-based format. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rubenmarcus%2Fcsbrasil%20PR%20%23244%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rubenmarcus%2Fcsbrasil&pr=244&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): comentário no orçamento do AG..."](https://github.com/rubenmarcus/csbrasil/commit/25279ee9c11bfed312bbd621040058afed017b46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52835514)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rubenmarcus/csbrasil/blob/main/AGENTS.md))

<!-- /greptile_comment -->