### PR TITLE
fix(bot): rótulo automático volta sem depender de PAT

### DIFF
--- a/.github/workflows/csbrasil-bot-automerge.yml
+++ b/.github/workflows/csbrasil-bot-automerge.yml
@@ -28,7 +28,7 @@ jobs:
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "CSBRASIL_BOT_TOKEN is not configured; skipping bot job."
+            echo "::warning title=Bot inerte::CSBRASIL_BOT_TOKEN nao configurado — este workflow esta pulando. Ele PRECISA de PAT: merge/push com o GITHUB_TOKEN padrao nao dispara os workflows a jusante, entao a PR entraria sem rodar os portoes."
           fi
 
   automerge:

--- a/.github/workflows/csbrasil-bot-issue-pr-bootstrap.yml
+++ b/.github/workflows/csbrasil-bot-issue-pr-bootstrap.yml
@@ -24,7 +24,7 @@ jobs:
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "CSBRASIL_BOT_TOKEN is not configured; skipping bot job."
+            echo "::warning title=Bot inerte::CSBRASIL_BOT_TOKEN nao configurado — este workflow esta pulando. Ele PRECISA de PAT: merge/push com o GITHUB_TOKEN padrao nao dispara os workflows a jusante, entao a PR entraria sem rodar os portoes."
           fi
 
   bootstrap:

--- a/.github/workflows/csbrasil-bot-issue-sweep.yml
+++ b/.github/workflows/csbrasil-bot-issue-sweep.yml
@@ -11,28 +11,10 @@ permissions:
   pull-requests: read
 
 jobs:
-  bot-token:
-    runs-on: ubuntu-latest
-    outputs:
-      available: ${{ steps.check.outputs.available }}
-    steps:
-      - id: check
-        env:
-          BOT_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN }}
-        run: |
-          if [ -n "$BOT_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "CSBRASIL_BOT_TOKEN is not configured; skipping bot job."
-          fi
-
   review-open-issues:
-    needs: bot-token
     runs-on: ubuntu-latest
-    if: needs.bot-token.outputs.available == 'true'
     env:
-      GH_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN || github.token }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/.github/workflows/csbrasil-bot-issue-triage.yml
+++ b/.github/workflows/csbrasil-bot-issue-triage.yml
@@ -15,28 +15,10 @@ permissions:
   issues: write
 
 jobs:
-  bot-token:
-    runs-on: ubuntu-latest
-    outputs:
-      available: ${{ steps.check.outputs.available }}
-    steps:
-      - id: check
-        env:
-          BOT_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN }}
-        run: |
-          if [ -n "$BOT_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "CSBRASIL_BOT_TOKEN is not configured; skipping bot job."
-          fi
-
   triage:
-    needs: bot-token
     runs-on: ubuntu-latest
-    if: needs.bot-token.outputs.available == 'true'
     env:
-      GH_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN || github.token }}
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/csbrasil-bot-pr-classify.yml
+++ b/.github/workflows/csbrasil-bot-pr-classify.yml
@@ -24,28 +24,10 @@ permissions:
   issues: write
 
 jobs:
-  bot-token:
-    runs-on: ubuntu-latest
-    outputs:
-      available: ${{ steps.check.outputs.available }}
-    steps:
-      - id: check
-        env:
-          BOT_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN }}
-        run: |
-          if [ -n "$BOT_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "CSBRASIL_BOT_TOKEN is not configured; skipping bot job."
-          fi
-
   classify:
-    needs: bot-token
     runs-on: ubuntu-latest
-    if: needs.bot-token.outputs.available == 'true'
     env:
-      GH_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.CSBRASIL_BOT_TOKEN || github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
       DESIRED_BASE_BRANCH: ${{ vars.PR_DEFAULT_BASE_BRANCH || 'staging' }}
     steps:


### PR DESCRIPTION
## O que aconteceu

As labels pararam em **11/08** (última PR rotulada: #180) e o workflow continuou reportando `success` todo esse tempo.

Um job `bot-token` checa `CSBRASIL_BOT_TOKEN`; sem o segredo, o job de verdade fica `skipped` e **a corrida inteira fica verde**. O segredo não está configurado no repositório — só existem `BOT_GIT_EMAIL`, `CF_API_TOKEN`, `RELEASE_TOKEN` e `VERCEL_*`.

**Cinco** workflows dependiam dele e estavam todos inertes, em silêncio.

## A separação

| workflow | o que faz | precisa de PAT? |
|---|---|---|
| `pr-classify` | `--add-label` | não |
| `issue-triage` | `--add-label` | não |
| `issue-sweep` | `--add-label` | não |
| `automerge` | `gh pr merge --squash` | **sim** |
| `issue-pr-bootstrap` | `git push` | **sim** |

Os três que só rotulam **nunca precisaram de PAT**: rodam em `pull_request_target`, onde o `GITHUB_TOKEN` é read-write mesmo em PR de fork, e os arquivos já declaravam `pull-requests: write` e `issues: write`. Agora caem no token padrão quando o segredo falta, e o portão que os apagava saiu.

Os dois que precisam continuam pulando — merge e push com o `GITHUB_TOKEN` **não disparam os workflows a jusante**, então a PR entraria sem rodar os portões. O que muda é que o skip virou `::warning::` visível, em vez de um check verde que não quer dizer nada.

## Verificação

- Os cinco YAML parseiam; `eval:release` (que valida gatilhos de workflow) verde.
- O `pr-classify` segue com `checkout` **sem `ref:`** — pega a base, não o código do fork. O vetor de RCE do `pull_request_target` continua fechado.

## Se você quiser o automerge de volta

Precisa criar o PAT e gravá-lo como `CSBRASIL_BOT_TOKEN`. Enquanto isso, ele avisa em vez de fingir que rodou.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores three labeling workflows by falling back to GITHUB_TOKEN and makes missing-PAT skips visible in the two workflows that still require a PAT.

- Removes the token-availability gate from PR classification, issue triage, and issue sweeping.
- Retains PAT gating for automerge and issue-to-PR bootstrap while emitting workflow warnings.
- The fallback exposes an omitted permission in issue triage and changes the identity assumed by classification-comment deduplication.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until issue triage receives pull-request read access and classification comments are deduplicated for the GITHUB_TOKEN identity.

The newly activated fallback path can fail during issue review because its token lacks PR access, while repeated PR classifier events append duplicate comments because the update lookup assumes the PAT account identity.

**Files Needing Attention:** .github/workflows/csbrasil-bot-issue-triage.yml and .github/workflows/csbrasil-bot-pr-classify.yml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/csbrasil-bot-pr-classify.yml | Restores classification with GITHUB_TOKEN, but the existing author-specific comment lookup causes duplicate classification comments. |
| .github/workflows/csbrasil-bot-issue-triage.yml | Restores issue triage, but its fallback token lacks the pull-request permission required by the review step. |
| .github/workflows/csbrasil-bot-issue-sweep.yml | Removes the PAT gate and uses a token whose declared issue and pull-request permissions cover the workflow's operations. |
| .github/workflows/csbrasil-bot-automerge.yml | Preserves PAT-required gating and replaces the silent skip message with a visible warning. |
| .github/workflows/csbrasil-bot-issue-pr-bootstrap.yml | Preserves PAT-required gating for push behavior and makes missing-token skips visible. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow starts] --> B{CSBRASIL_BOT_TOKEN configured?}
    B -->|Yes| C[Use PAT]
    B -->|No, labeling workflow| D[Use github.token]
    B -->|No, merge or push workflow| E[Emit warning and skip]
    D --> F[Run labels and comments]
    F --> G[Issue triage needs PR read permission]
    F --> H[PR comment dedup must recognize github-actions bot]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rubenmarcus%2Fcsbrasil%20PR%20%23259%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rubenmarcus%2Fcsbrasil&pr=259&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fcsbrasil-bot-pr-classify.yml%3A30%0A**Token%20fallback%20breaks%20comment%20deduplication**%0A%0AWhen%20%60CSBRASIL_BOT_TOKEN%60%20is%20absent%2C%20classification%20comments%20are%20authored%20by%20%60github-actions%5Bbot%5D%60%2C%20but%20the%20update%20step%20recognizes%20only%20comments%20from%20%60csbrasil-bot%60.%20Every%20subsequent%20synchronization%2C%20review%2C%20or%20review-comment%20event%20therefore%20appends%20another%20classification%20comment%20instead%20of%20updating%20the%20existing%20one.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Fcsbrasil-bot-issue-triage.yml%3A21%0A**Fallback%20token%20lacks%20PR%20access**%0A%0AWhen%20%60CSBRASIL_BOT_TOKEN%60%20is%20absent%2C%20the%20newly%20activated%20job%20uses%20%60github.token%60%2C%20while%20its%20explicit%20permissions%20omit%20pull-request%20access.%20The%20unguarded%20%60gh%20pr%20list%60%20call%20then%20fails%20before%20the%20review%20payload%20is%20written%2C%20preventing%20the%20issue-review%20labels%20and%20comment%20from%20being%20applied.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rubenmarcus%2Fcsbrasil&pr=259&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/csbrasil-bot-pr-classify.yml:30
**Token fallback breaks comment deduplication**

When `CSBRASIL_BOT_TOKEN` is absent, classification comments are authored by `github-actions[bot]`, but the update step recognizes only comments from `csbrasil-bot`. Every subsequent synchronization, review, or review-comment event therefore appends another classification comment instead of updating the existing one.

### Issue 2
.github/workflows/csbrasil-bot-issue-triage.yml:21
**Fallback token lacks PR access**

When `CSBRASIL_BOT_TOKEN` is absent, the newly activated job uses `github.token`, while its explicit permissions omit pull-request access. The unguarded `gh pr list` call then fails before the review payload is written, preventing the issue-review labels and comment from being applied.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bot): rótulo automático volta sem de..."](https://github.com/rubenmarcus/csbrasil/commit/a4e355f127863a9de3144e35dd6e64f2154a2f35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52998335)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->