### PR TITLE
fix(api): client Supabase com timeout no fetch — acaba com os 504 de 300s

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -5,8 +5,19 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 const url = import.meta.env.SUPABASE_URL;
 const key = import.meta.env.SUPABASE_SERVICE_ROLE_KEY;
 
+// fetch com TIMEOUT. Sem isto, um Supabase lento/fora pendura o await do lambda
+// até o teto de 300s da Vercel -> 504 (incidente 13/08 em /api/presence e
+// /api/funnel). Aborta em DB_TIMEOUT_MS; o try/catch fail-open de cada rota vira
+// resposta rápida (503/ok) em vez de 504-after-300s. Default 8s cobre o p95 real.
+const DB_TIMEOUT_MS = Number(import.meta.env.DB_TIMEOUT_MS) || 8000;
+const fetchTimeout: typeof fetch = (input, init) => {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), DB_TIMEOUT_MS);
+  return fetch(input, { ...init, signal: ctrl.signal }).finally(() => clearTimeout(t));
+};
+
 export const supabaseAdmin: SupabaseClient | null =
-  url && key ? createClient(url, key, { auth: { persistSession: false } }) : null;
+  url && key ? createClient(url, key, { auth: { persistSession: false }, global: { fetch: fetchTimeout } }) : null;
 
 export const NOT_CONFIGURED = JSON.stringify({
   error: 'not_configured',


### PR DESCRIPTION
## Incidente (13/08, ~23:48 UTC)
`/api/presence` e `/api/funnel` devolviam **504** com `Vercel Runtime Timeout Error: Task timed out after 300 seconds`.

## Causa raiz
`createClient(url, key, …)` em `src/lib/supabase.ts` **sem timeout no fetch**. Quando o Supabase fica lento/fora, o `await db.rpc(...)` (em `rateLimit`, `ping_presence`, `track_funnel`) pendura até o teto de **300s** do lambda → Vercel mata com 504. O `try/catch` das rotas pega **erro**, mas não pega **hang** (await pendurado não throw).

## Correção
Fetch customizado com `AbortController` (`DB_TIMEOUT_MS`, default **8s**) injetado no `global.fetch` do client. Todo rpc/fetch agora aborta em 8s → o **fail-open** de cada rota (`rateLimit` retorna `true`, `presence`/`funnel` engolem e respondem `ok`) vira resposta rápida em vez de 504-after-300s.

- Default 8s cobre o p95 real; ajustável via env `DB_TIMEOUT_MS`.
- Não muda o comportamento em DB saudável (só aborta se passar de 8s).
- `AbortError` vira `{error}` no rpc → cai no `try/catch`/fail-open existente.

## Validação
- `astro build` verde (tipos do `global.fetch` aceitos pelo supabase-js v2)
- Não há teste de integração com Supabase (sem credencial); o efeito só fica provado em prod quando o próximo incidente chegar e o 504 virar resposta < 8s

## Por que fail-open é correto aqui
Presença/funnel/telemetry são **best-effort**: o jogador não lê a resposta (vão por sendBeacon). Um DB que tose não pode derrubar o jogo — as validações reais (token, tetos) seguem no `submit_match`. O timeout só faz o degrade **rápido** em vez de **mudo por 5 min**.

Agent: OpenCode