### PR TITLE
fix(boot): watchdog distingue rede lenta de travamento (#265)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -292,9 +292,18 @@ const IMPORTMAP = JSON.stringify({
       if (alvo.id === 'boot-splash') {
         var prompt = document.getElementById('splash-enter');
         var pronto = prompt && !prompt.classList.contains('hidden');
-        if (!window.__CS_MAIN_READY__ && (erroDoBoot || Date.now() - inicio > 22000)) {
-          lancamento.fail(erroDoBoot || new Error('carregamento inicial não respondeu'), 'boot-watchdog');
-        } else if (window.__CS_MAIN_READY__ || pronto) {
+        if (!window.__CS_MAIN_READY__) {
+          if (erroDoBoot || window.__CS_MAIN_FAILED) {
+            lancamento.fail(erroDoBoot || new Error('o código do jogo não chegou (verifique a conexão)'), 'boot-watchdog');
+          } else if (!window.__CS_MAIN_LOADED) {
+            /* Rede lenta (#265): failsafe abre a splash antes do main.js chegar; clicar
+               não é defeito. Informa e espera, sem virar crash-auto. */
+            var st = document.getElementById('boot-status');
+            if (st) st.textContent = 'CONEXÃO LENTA - AINDA BAIXANDO O JOGO…';
+          } else if (Date.now() - inicio > 22000) {
+            lancamento.fail(new Error('carregamento inicial não respondeu'), 'boot-watchdog');
+          }
+        } else if (pronto) {
           lancamento.begin('entrada', 3000, function(){
             var splash = document.getElementById('boot-splash');
             return !splash || splash.classList.contains('gone');
@@ -1072,6 +1081,6 @@ const IMPORTMAP = JSON.stringify({
   }
 </script>
 
-<script type="module" src={`/js/main.js?v=${V}-${JS_REV}`} is:inline></script>
+<script type="module" src={`/js/main.js?v=${V}-${JS_REV}`} is:inline onload="window.__CS_MAIN_LOADED=1" onerror="window.__CS_MAIN_FAILED=1"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #265.

## Causa raiz
O failsafe abre a splash em **20s** ANTES do main.js terminar de baixar (rede lenta). O jogador clica no "entrar" e o boot-watchdog (**22s**) transforma a espera em crash-auto **"carregamento inicial não respondeu"** — sem nenhum defeito no jogo. A mensagem ser a variante "sem erro" confirma: não houve `erroDoBoot`, o módulo só **não tinha chegado**.

## Correção
1. Flags \`onload\`/\`onerror\` na tag do main.js → \`__CS_MAIN_LOADED\` / \`__CS_MAIN_FAILED\`.
2. Watchdog network-aware no clique da splash:
   - **ainda baixando** → \`CONEXÃO LENTA — AINDA BAIXANDO O JOGO…\` no boot-status (sem fail, sem crash-auto);
   - **falhou de verdade** (404/erro) → fail com motivo real;
   - **baixou e travou** (hang de avaliação, o caso real) → fail "não respondeu" como antes.

## Validação
- \`eval:error-console\`, \`eval:webglguard\`, \`syntax\` verdes
- \`boot-status\` existe no DOM (mensagem aparece)
- \`eval:boot\` (browser) roda no preview/deploy — os caminhos B1-B6 não foram tocados (só o branch de pointerdown da splash)

## Nota
#241 (mesma família, "tempo limite ao abrir **partida**") é OUTRO caminho: o watchdog de 60s do startGame (preload pesado dos GLBs em rede lenta). Fica pra frente seguinte.

Agent: OpenCode