### PR TITLE
fix(telemetria): sem_webgl é ambiente, não defeito de código (#277)

### DIFF
--- a/src/lib/error-provenance.mjs
+++ b/src/lib/error-provenance.mjs
@@ -18,6 +18,10 @@ const HTTP_URL_RE = /https?:\/\/[^\s)'"<>]+/gi;
    do jogo SEMPRE carrega filename ou stack same-origin — por isso o corte só
    vale quando não há nenhum dos dois (ver isOpaqueNoise). */
 const OPAQUE_RE = /uncaught exception: undefined|illegal character\s+U\+[0-9a-f]{2,6}|^script error\.?$|^network error$/i;
+/* sem_webgl: o jogo DETECTOU que o browser não tem WebGL (driver desligado/bloqueado)
+   e já exibiu o painel amigável (BUG-44). É ambiente do jogador, não defeito de código —
+   não abre issue (#277/#276/#274: 3 issues automáticas pela mesma causa num dia). */
+const AMBIENTE_RE = /^sem_webgl:/i;
 
 const normalizedOrigin = (value, base) => {
   if (!value) return null;
@@ -63,6 +67,7 @@ export function classifyCrash(payload = {}, ownOrigin = '') {
   const evidence = [payload.message, payload.source, payload.stack].filter(Boolean).join(' ');
   if (isExternalCrash(payload, ownOrigin)) return 'externo';
   if (isOpaqueNoise(payload)) return 'externo';
+  if (AMBIENTE_RE.test(String(payload.message || ''))) return 'externo';
   if (CACHE_SPLIT_RE.test(evidence)) return 'cache-split';
   if (RECOVERABLE_RE.test(evidence)) return 'recuperavel';
   return 'codigo';

--- a/tools/eval/error-provenance-check.mjs
+++ b/tools/eval/error-provenance-check.mjs
@@ -9,7 +9,7 @@ const mutants = [
   'sem-workflow', 'abre-externo',
   'sem-cliente', 'cliente-mensagem-url', 'sem-teto-externo', 'debug-externo', 'console-sem-origem',
   'cache-antes-origem', 'sem-recuperavel', 'sem-opaco', 'opaco-sem-guarda',
-  'sem-vercel-helper', 'sem-vercel-cliente',
+  'sem-vercel-helper', 'sem-vercel-cliente', 'sem-webgl',
 ];
 if (mutant && !mutants.includes(mutant)) throw new Error(`mutante desconhecido: ${mutant}`);
 
@@ -79,6 +79,9 @@ if (mutant === 'sem-recuperavel') helperSource = mutate(helperSource,
 if (mutant === 'sem-opaco') helperSource = mutate(helperSource,
   'return OPAQUE_RE.test(String(message).trim());',
   'return false;');
+if (mutant === 'sem-webgl') helperSource = mutate(helperSource,
+  "if (AMBIENTE_RE.test(String(payload.message || ''))) return 'externo';",
+  'if (false) return false;');
 if (mutant === 'opaco-sem-guarda') helperSource = mutate(helperSource,
   'if (source || stack) return false;',
   'if (false) return false;');
@@ -107,6 +110,12 @@ const crossOriginFixtures = [
 const vendorFixtures = [
   { source: `${own}/_vercel/insights/script.js:1:2317`, message: "Cannot assign to read only property 'pushState' of object '#<History>'" },
   { stack: `TypeError\n    at ${own}/_vercel/speed-insights/script.js:1:12505`, message: "Cannot assign to read only property 'pushState'" },
+];
+/* #277/#276/#274: sem_webgl é o jogo DETECTANDO browser sem WebGL (painel amigável do
+   BUG-44 já tratou). É ambiente do jogador — mesmo same-origin, não é defeito de código. */
+const ambienteFixtures = [
+  { source: `${own}/js/glcontext.js:105:1`, message: 'sem_webgl: nenhum contexto foi criado · experimental-webgl/economia: Could not create a WebGL context, VENDOR = 0x8086' },
+  { source: `${own}/js/glcontext.js:105:1`, message: 'sem_webgl: nenhum contexto foi criado · webgl2/economia: WebGL is currently disabled.' },
 ];
 const internalFixtures = [
   { source: `${own}/js/game.js:1:2`, stack: `${own}/js/main.js:3:4`, message: 'boom' },
@@ -240,6 +249,9 @@ const checks = [
   ['EP10', vendorFixtures.every((fixture) => classify(fixture) === 'externo')
     && classify({ source: `${own}/js/game.js:1:2`, message: 'boom' }) === 'codigo'
     && vendorBehavior, 'bundles /_vercel/ da Vercel são externos no helper e no cliente; /js/ do jogo continua acionável'],
+  ['EP11', ambienteFixtures.every((fixture) => classify(fixture) === 'externo')
+    && classify({ source: `${own}/js/glcontext.js:105:1`, message: 'outra falha qualquer de contexto' }) === 'codigo',
+    'sem_webgl é ambiente (browser sem WebGL, painel do BUG-44 já tratou): externo, sem issue; falha de contexto FORA da assinatura continua acionável'],
 ];
 const failed = checks.filter(([, ok]) => !ok);
 for (const [id, ok, description] of checks) console.log(`${ok ? '\x1b[32m✓' : '\x1b[31m✗'} ${id} ${description}\x1b[0m`);
@@ -250,7 +262,7 @@ const mutantClause = {
   'sem-workflow': 'EP5', 'abre-externo': 'EP5',
   'sem-cliente': 'EP6', 'cliente-mensagem-url': 'EP6', 'sem-teto-externo': 'EP6', 'debug-externo': 'EP6',
   'console-sem-origem': 'EP6',
-  'cache-antes-origem': 'EP7',
+  'cache-antes-origem': 'EP7', 'sem-webgl': 'EP11',
   'sem-recuperavel': 'EP8',
   'sem-opaco': 'EP9', 'opaco-sem-guarda': 'EP9',
   'sem-vercel-helper': 'EP10', 'sem-vercel-cliente': 'EP10',


### PR DESCRIPTION
Closes #277, closes #276, closes #274.

## O quê
\`sem_webgl: nenhum contexto foi criado\` é o jogo DETECTANDO browser sem WebGL e exibindo o painel amigável (BUG-44). Mas o \`console.error\` é same-origin → classificado \`codigo\` → abria issue automática (**3 num dia**: #277/#276/#274).

## Correção
\`AMBIENTE_RE = /^sem_webgl:/i\` → classifica \`externo\` (ambiente do jogador). Falha de contexto FORA da assinatura continua acionável.

## Régua
EP11 nova (fixtures de ambiente + contraprova same-origin) + mutante \`--mutante=sem-webgl\` (remove a linha → EP11 vermelha). Régua verde sem mutante, vermelha com.

Agent: OpenCode