### PR TITLE
fix(webgl1): skinning compila no WebGL1 — getBoneMatrix bifurca por __VERSION__ (#275)

### DIFF
--- a/public/botview.html
+++ b/public/botview.html
@@ -5,7 +5,7 @@
 <title>bot weapon view</title>
 <style>body{margin:0;background:#2a2e35}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/charlineup.html
+++ b/public/charlineup.html
@@ -5,7 +5,7 @@
 <title>char lineup — cor e iluminação do elenco, na cena do jogo</title>
 <style>html,body{margin:0;height:100%;background:#000;overflow:hidden}canvas{display:block}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/clima.html
+++ b/public/clima.html
@@ -48,7 +48,7 @@
   #hud{position:fixed;left:8px;top:8px;color:#cfe0f0;text-shadow:0 1px 2px #000;z-index:9}
 </style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/dev.html
+++ b/public/dev.html
@@ -140,7 +140,7 @@
   .ammo{position:absolute;right:16px;bottom:14px;font-size:22px;letter-spacing:1px;color:#cfe;background:rgba(10,12,16,.6);padding:5px 12px;border-radius:7px;min-width:96px;text-align:center}
 </style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/eval.html
+++ b/public/eval.html
@@ -5,7 +5,7 @@
 <title>eval — medição de personagem</title>
 <style>html,body{margin:0;height:100%;background:#000;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#6f6;white-space:pre;z-index:9;text-shadow:0 0 3px #000}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/fveval.html
+++ b/public/fveval.html
@@ -5,7 +5,7 @@
 <title>ferro velho eval — beco oeste</title>
 <style>html,body{margin:0;height:100%;background:#8fb7e0;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#012;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/iktest.html
+++ b/public/iktest.html
@@ -6,7 +6,7 @@
 <title>IK test — mão de apoio</title>
 <style>html,body{margin:0;height:100%;background:#20242b;overflow:hidden}#hud{position:fixed;left:8px;top:8px;font:12px monospace;color:#9fe;white-space:pre;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/mapeval.html
+++ b/public/mapeval.html
@@ -5,7 +5,7 @@
 <title>map eval — landmarks</title>
 <style>html,body{margin:0;height:100%;background:#8fb7e0;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#012;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/mapview.html
+++ b/public/mapview.html
@@ -5,7 +5,7 @@
 <title>mapview — eval genérico de mapa</title>
 <style>html,body{margin:0;height:100%;background:#8fb7e0;overflow:hidden}#hud{position:fixed;left:6px;top:6px;font:11px monospace;color:#012;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/modelviewer.html
+++ b/public/modelviewer.html
@@ -6,7 +6,7 @@
 <title>CS BRASIL — model viewer (dev)</title>
 <style>html,body{margin:0;height:100%;background:#20242b;overflow:hidden}#hud{position:fixed;top:8px;left:8px;font:14px monospace;color:#7CFC00;text-shadow:0 1px 2px #000}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/mounttest.html
+++ b/public/mounttest.html
@@ -6,7 +6,7 @@
 <title>mount test — arma pra frente?</title>
 <style>html,body{margin:0;height:100%;background:#20242b;overflow:hidden}#hud{position:fixed;left:8px;top:8px;font:12px monospace;color:#9fe;white-space:pre;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/vendor/three.module.js
+++ b/public/vendor/three.module.js
@@ -14017,7 +14017,7 @@ var shadowmask_pars_fragment = "float getShadowMask() {\n\tfloat shadow = 1.0;\n
 
 var skinbase_vertex = "#ifdef USE_SKINNING\n\tmat4 boneMatX = getBoneMatrix( skinIndex.x );\n\tmat4 boneMatY = getBoneMatrix( skinIndex.y );\n\tmat4 boneMatZ = getBoneMatrix( skinIndex.z );\n\tmat4 boneMatW = getBoneMatrix( skinIndex.w );\n#endif";
 
-var skinning_pars_vertex = "#ifdef USE_SKINNING\n\tuniform mat4 bindMatrix;\n\tuniform mat4 bindMatrixInverse;\n\tuniform highp sampler2D boneTexture;\n\tmat4 getBoneMatrix( const in float i ) {\n\t\tint size = textureSize( boneTexture, 0 ).x;\n\t\tint j = int( i ) * 4;\n\t\tint x = j % size;\n\t\tint y = j / size;\n\t\tvec4 v1 = texelFetch( boneTexture, ivec2( x, y ), 0 );\n\t\tvec4 v2 = texelFetch( boneTexture, ivec2( x + 1, y ), 0 );\n\t\tvec4 v3 = texelFetch( boneTexture, ivec2( x + 2, y ), 0 );\n\t\tvec4 v4 = texelFetch( boneTexture, ivec2( x + 3, y ), 0 );\n\t\treturn mat4( v1, v2, v3, v4 );\n\t}\n#endif";
+var skinning_pars_vertex = "#ifdef USE_SKINNING\n\tuniform mat4 bindMatrix;\n\tuniform mat4 bindMatrixInverse;\n\tuniform highp sampler2D boneTexture;\n\tuniform float boneTextureSize;\n\tmat4 getBoneMatrix( const in float i ) {\n\t\t#if __VERSION__ >= 300\n\t\tint size = textureSize( boneTexture, 0 ).x;\n\t\tint j = int( i ) * 4;\n\t\tint x = j % size;\n\t\tint y = j / size;\n\t\tvec4 v1 = texelFetch( boneTexture, ivec2( x, y ), 0 );\n\t\tvec4 v2 = texelFetch( boneTexture, ivec2( x + 1, y ), 0 );\n\t\tvec4 v3 = texelFetch( boneTexture, ivec2( x + 2, y ), 0 );\n\t\tvec4 v4 = texelFetch( boneTexture, ivec2( x + 3, y ), 0 );\n\t\t#else\n\t\tfloat j = i * 4.0;\n\t\tfloat x = mod( j, boneTextureSize );\n\t\tfloat y = floor( j / boneTextureSize );\n\t\tfloat dx = 1.0 / boneTextureSize;\n\t\tfloat dy = 1.0 / boneTextureSize;\n\t\ty = dy * ( y + 0.5 );\n\t\tvec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );\n\t\tvec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );\n\t\tvec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );\n\t\tvec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );\n\t\t#endif\n\t\treturn mat4( v1, v2, v3, v4 );\n\t}\n#endif";
 
 var skinning_vertex = "#ifdef USE_SKINNING\n\tvec4 skinVertex = bindMatrix * vec4( transformed, 1.0 );\n\tvec4 skinned = vec4( 0.0 );\n\tskinned += boneMatX * skinVertex * skinWeight.x;\n\tskinned += boneMatY * skinVertex * skinWeight.y;\n\tskinned += boneMatZ * skinVertex * skinWeight.z;\n\tskinned += boneMatW * skinVertex * skinWeight.w;\n\ttransformed = ( bindMatrixInverse * skinned ).xyz;\n#endif";
 
@@ -30385,6 +30385,10 @@ class WebGLRenderer {
 						if ( skeleton.boneTexture === null ) skeleton.computeBoneTexture();
 
 						p_uniforms.setValue( _gl, 'boneTexture', skeleton.boneTexture, textures );
+						/* PATCH CSBR (#275): WebGL1 não tem textureSize/texelFetch; o chunk de
+						   skinning usa boneTextureSize (ver skinning_pars_vertex). setValue em
+						   uniform ausente é no-op, então programas sem skinning não quebram. */
+						p_uniforms.setValue( _gl, 'boneTextureSize', skeleton.boneTexture.image.width );
 
 					} else {
 

--- a/public/vm-inspect.html
+++ b/public/vm-inspect.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html><head><meta charset="utf-8"><title>vm inspect</title>
 <style>html,body{margin:0;height:100%;background:#223}</style>
-<script type="importmap">{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }</script>
+<script type="importmap">{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }</script>
 </head><body><script type="module">
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';

--- a/public/weaponeval.html
+++ b/public/weaponeval.html
@@ -5,7 +5,7 @@
 <title>weapon eval</title>
 <style>body{margin:0;background:#222;color:#eee;font:12px monospace}#hud{position:fixed;top:4px;left:8px;z-index:2}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>

--- a/public/weapontest.html
+++ b/public/weapontest.html
@@ -6,7 +6,7 @@
 <title>weapon orientation test</title>
 <style>html,body{margin:0;height:100%;background:#22262e;overflow:hidden}#hud{position:fixed;left:8px;top:8px;font:13px monospace;color:#9fe;white-space:pre;z-index:9}</style>
 <script type="importmap">
-{ "imports": { "three": "./vendor/three.module.js?h=180c93e83342", "three/addons/": "./vendor/addons/" } }
+{ "imports": { "three": "./vendor/three.module.js?h=919693a84f08", "three/addons/": "./vendor/addons/" } }
 </script>
 </head>
 <body>


### PR DESCRIPTION
Closes #275.

## Causa raiz
O chunk \`skinning_pars_vertex\` do three r160 usa \`textureSize\`/\`texelFetch\`/módulo inteiro — **GLSL ES 3.00 only, sem fallback** (grep do vendor: zero \`texture2D(boneTexture\`). No fallback WebGL1 (público do modo seguro/BUG-44), **todo personagem rigado** falhava com o log exato do #275: \`VALIDATE_STATUS false\` + \`textureSize\`/\`%\`/\`texelFetch\`.

## Correção (cirurgia no vendor, precedente BUG-45/BUG-50)
1. Chunk: \`#if __VERSION__ >= 300\` mantém texelFetch; \`#else\` lê a **mesma** boneTexture via \`texture2D\` no centro do texel (NEAREST), com uniform \`boneTextureSize\`.
2. Renderer: \`setValue('boneTextureSize', boneTexture.image.width)\` junto ao \`boneTexture\` (setValue em uniform ausente é no-op — programas sem skinning não afetados).
3. 13 arnês HTML: hash \`?h=\` regenerado (SL5 verde).

## Validação
Chrome + SwiftShader com **contexto WebGL1 real**: SkinnedMesh renderiza com zero erro de shader — \`{"ok":true,"shaderErr":[]}\`, 1 programa compilado. A "mutação" é o próprio #275: o vendor antigo produz exatamente esse log em produção.

Agent: OpenCode