### PR TITLE
fix(eval): SG6 — régua do teto de kills do submit_match (issue #116, BUG-54)

### DIFF
--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -413,7 +413,45 @@ passava na asserção de nome — furo achado pelo próprio mutante `sem-teto`) 
 solto por frame proibido. Mutantes `--mutante=clamp-frame` (3 vermelhas) e
 `--mutante=sem-teto` (1) executados.
 
+### ~~BUG-54 · "kills além do fisicamente possível" numa partida de captura legítima~~ · CONSERTO PRONTO 15/08, migration 024 PENDENTE de aplicação (issue #116)
+
+**Palavras de quem reportou** (issue #116): *"A partida terminou normalmente, mas as stats
+não foram enviadas e apareceu a mensagem: 'stats não enviados: kills além do fisicamente
+possível'. No final da partida eu estava com 95 kills e 6 mortes."*
+
+**Causa raiz.** A cláusula (a) do `submit_match` (`~/db-privado/supabase/schema.sql`)
+exigia `p_kills ≤ 45 * p_rounds`. O comentário dizia *"respawn de 2,5s => teto teórico
+~40/round"* — premissa do modo **ABATE**, onde a rodada É uma janela de 99 s. No
+**CAPTURA** a partida inteira são **2 rodadas** (`CTF_ROUNDS_TO_WIN`, `game.js:114`), então
+o teto dava **90 kills na partida** — numa modalidade sem janela de tempo, com respawn
+contínuo por até ~960 s. É o mesmo defeito de premissa do BUG-35/#87 (migration 015), um
+ramo acima: lá o piso de TEMPO, aqui o teto de KILLS. E igualmente chamava `_flag()` antes
+de recusar — **três partidas boas de captura escondiam o jogador do ranking**.
+
+**O número novo não é palpite** — é a física do jogo: no CAPTURA o limitante é o
+`RESPAWN_DELAY = 2,2 s` (`game.js:88`): para matar de novo, um inimigo tem que renascer.
+Teto honesto: `greatest(45 * rounds, floor(seconds / 2.2))` — o ramo por rodada continua
+amarrando partida de abate de relógio travado.
+
+| caso | teto antigo (45×rounds) | teto novo | veredito |
+|---|---|---|---|
+| reportado (#116): 95 kills · 2 rodadas · 480 s | 90 → **RECUSAVA** | greatest(90, 218) = 218 | passa |
+| trainer: 150 kills · 30 s | 90 → recusava | greatest(90, 13) = 90 | continua recusado |
+| cliente velho (seconds=0) | 90 | greatest(90, 0) = 90 | idêntico a hoje |
+
+**Régua.** Cláusula **SG6** do `tools/eval/submit-guard-check.mjs` (lê o SQL de
+`~/db-privado/`, o mesmo princípio das SG4/SG5: a fonte é o banco, não uma cópia em JS).
+Vermelha no estado antigo (4 reprovações: caso #116 recusado nos 3 arquivos + `_flag` na
+cláusula); verde depois; `--mutante=kills45` devolve o mundo antigo e acende nos 3.
+
+**Falta aplicar.** `~/db-privado/supabase/migrations/024_submit_guard_kills.sql` (o
+`schema.sql` e o espelho `opcional/012` já estão atualizados nesta máquina). Aplicar em
+staging → produção pela ordem do `~/db-privado/COMO-MIGRAR.md`. Falsos positivos já
+dados pelo caminho antigo: se um jogador reportar sumir do ranking com 3+ partidas de
+captura recusadas, conferir `players.flagged_count` na mão.
+
 ### ~~BUG-35 · "partida rápida demais pra ser verdade" numa partida legítima~~ · RESOLVIDO 07/08 (issue #87)
+
 
 
 **Palavras de quem reportou** (maurodesouza, issue #87): *"Durante uma partida no modo

--- a/tools/eval/submit-guard-check.mjs
+++ b/tools/eval/submit-guard-check.mjs
@@ -275,6 +275,49 @@ for (const { arq } of ALVOS) {
 }
 console.log('');
 
+/* ═══ SG6 · O TETO DE KILLS NÃO RECUSA O QUE O CAPTURA PRODUZ (issue #116) ═══════
+   Palavras de quem reportou: *"stats não enviados: kills além do fisicamente
+   possível. No final da partida eu estava com 95 kills e 6 mortes."* No CAPTURA a
+   partida inteira são 2 rodadas (CTF_ROUNDS_TO_WIN), então o teto `45 * rounds`
+   dava 90 — o modo fechar em 2 rodadas virou acusação de trainer. Mesma premissa
+   errada do #87: a régua de kills nasceu do ABATE, onde rodada É uma janela.
+   No CAPTURA o limitante físico é o RESPAWN_DELAY: ninguém mata mais que 1 por
+   respawn, então o teto honesto é SEGUNDOS / respawn, não rounds × 45. */
+console.log('SG6 · o teto de kills aceita partida de captura que o jogo produz');
+const GAME = path.join(RAIZ, 'public/js/game.js');
+const RESP = Number((fs.readFileSync(GAME, 'utf8').match(/RESPAWN_DELAY = ([\d.]+)/) || [])[1]);
+if (!RESP) { falhas.push('SG6: não li RESPAWN_DELAY do game.js — a física do teto não tem fonte'); }
+const ALVOS_KILLS = [
+  { arq: 'supabase/schema.sql', flag: '_flag' },
+  { arq: 'supabase/migrations/024_submit_guard_kills.sql', flag: '_flag' },
+  { arq: 'supabase/opcional/012_ofuscacao_schema.sql', flag: 'fn_f9c' },
+];
+const CASO_116 = { kills: 95, rounds: 2, seconds: 480 };   // 95 kills · 2 rodadas · meia partida de 960 s
+const IMPOSSIVEL = { kills: 150, rounds: 2, seconds: 30 }; // trainer: 5 kills/s sustentados
+for (const { arq, flag } of ALVOS_KILLS) {
+  const p = path.join(DB, arq);
+  if (!fs.existsSync(p)) { console.log(`   ${arq.padEnd(48)} AUSENTE`); continue; }
+  const txt = semComentario(fs.readFileSync(p, 'utf8'));
+  const i = txt.search(/if\s+p_kills\s*>[\s\S]{0,400}?fisicamente/i);
+  if (i < 0) { falhas.push(`SG6 ${arq}: não achei a cláusula do teto de kills — foi renomeada ou sumiu`); console.log(`   ${arq.padEnd(48)} CLÁUSULA NÃO ENCONTRADA`); continue; }
+  const fim = txt.indexOf('end if;', i);
+  let bloco = txt.slice(i, fim < 0 ? i + 400 : fim);
+  if (new RegExp(`\\b${flag}\\s*\\(`).test(bloco)) falhas.push(`SG6 ${arq}: o teto de kills ainda chama ${flag}() — falso-positivo comprovado (#116) alimentando shadowban`);
+  /* O teto sob teste: mutação devolve o mundo de `45 * rounds` puro. */
+  const novo = bloco.match(/p_kills\s*>\s*greatest\(\s*45\s*\*\s*greatest\(p_rounds,\s*1\)\s*,\s*floor\(p_seconds\s*\/\s*([\d.]+)\s*\)\s*\)/);
+  const velho = bloco.match(/p_kills\s*>\s*(\d+)\s*\*\s*greatest\(p_rounds,\s*1\)/);
+  const teto = (c) => MUT === 'kills45'
+    ? 45 * Math.max(c.rounds, 1)
+    : (novo ? Math.max(45 * Math.max(c.rounds, 1), Math.floor(c.seconds / Number(novo[1]))) : Number(velho?.[1] ?? 0) * Math.max(c.rounds, 1));
+  const recusaKills = (c) => c.kills > teto(c);
+  if (novo && RESP && Number(novo[1]) < RESP) falhas.push(`SG6 ${arq}: divisor ${novo[1]} s/kill é MAIS APERTADO que o RESPAWN_DELAY ${RESP} s do jogo — o teto nega a física que ele dizia medir`);
+  if (!novo && !velho) { falhas.push(`SG6 ${arq}: o teto de kills não está em nenhuma forma conhecida`); continue; }
+  if (recusaKills(CASO_116)) falhas.push(`SG6 ${arq}: a partida REPORTADA na #116 (${CASO_116.kills} kills, ${CASO_116.rounds} rodadas de captura) é recusada — teto ${teto(CASO_116)}`);
+  if (!recusaKills(IMPOSSIVEL)) falhas.push(`SG6 ${arq}: trainer de ${IMPOSSIVEL.kills} kills em ${IMPOSSIVEL.seconds} s PASSA — o teto não morde nada`);
+  console.log(`   ${arq.padEnd(48)} ${novo ? `seconds/${novo[1]}` : `ANTIGO ${velho?.[1]}×rounds`} · caso #116 ${recusaKills(CASO_116) ? 'RECUSADO' : 'ok'} · impossível ${recusaKills(IMPOSSIVEL) ? 'recusado' : 'PASSA'}`);
+}
+console.log('');
+
 /* ═══ SG2 / SG3 · A AMOSTRA ══════════════════════════════════════════════════════
    Cara (~10 min). Fica atrás de --amostra para o portão continuar sendo segundos; o
    número dela vive na entrada do KNOWN-BUGS.md com o comando que reproduz. */


### PR DESCRIPTION
## Summary

Cláusula **SG6** no `tools/eval/submit-guard-check.mjs`: o teto de kills do `submit_match` (SQL privado em `~/db-privado/`) não pode recusar partida de captura que o jogo produz.

- Lê o teto dos 3 arquivos do banco (schema, migration 024, espelho ofuscado) — mesma regra das SG4/SG5: a fonte é o SQL, não cópia em JS
- CASO #116 (95 kills · 2 rodadas · 480 s) deve passar; trainer (150 kills · 30 s) deve continuar recusado
- Divisor do teto por segundos nunca menor que o `RESPAWN_DELAY` lido do game.js
- Sem `_flag` na cláusula (falso-positivo comprovado não alimenta shadowban)
- Mutação `--mutante=kills45` devolve o mundo antigo e acende nos 3 arquivos

Medido: **vermelha no estado atual** (caso #116 recusado + strike), **verde** com a migration 024 aplicada. Entrada BUG-54 no KNOWN-BUGS.md.

Closes #116 (código + régua; a migration mora no banco privado e o dono aplica pela ordem do COMO-MIGRAR)

## Risk
- [ ] low
- [x] medium — régua de portão de pré-deploy, lê máquina do dono
- [ ] high

## Validation
- [x] `node tools/eval/submit-guard-check.mjs` — verde (com 024 na máquina)
- [x] `--mutante=kills45` — 3 reprovações
- [x] SG1/SG4/SG5 inalteradas

## Bot notes
- [ ] ok to label `safe-automerge`
- [x] needs `needs-staging` (migration manual)
- [ ] needs `needs-human-gameplay`
- [ ] needs `needs-human-backend`