### PR TITLE
fix(audio): troca voz do Faria Limer

### DIFF
--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -2371,6 +2371,17 @@ publicação em potencial, e o `.gitignore` não protege de um deploy local.
 
 ## Relatos recentes e resolução
 
+- **~~BUG-66 · Faria Limer ainda fala com a voz do Lula~~ · RESOLVIDO 16/08.** Palavras do dono: *"o farialimer
+  ainda tá com som do Lula; precisamos usar um do time do Bolsonaro"*. O vínculo explícito
+  criado no BUG-65 aponta para `55678d5886537476`, hash do arquivo-fonte `cana_doce.mp3`:
+  ele estava classificado dentro da pasta do Time B, mas o conteúdo continua sendo a voz
+  errada. A substituição escolhida vem do mesmo pool B e tem fonte nominal
+  `bolsonaro-acabou-porra.mp3` (`fc5bf11f5b8287f5`); os hashes SHA-1 do fonte e do asset
+  publicado são idênticos. Antes, `eval:charvoice` deixava VOICE10 e VOICE12 vermelhas;
+  depois, passa com o runtime e o deploy no `audio-pack-v6`. Os mutantes
+  `faria-volta-lula` e `pack-antigo` reacendem uma cláusula cada. Custo declarado: nenhum
+  áudio novo; só muda a reserva de um clipe que já pertencia ao pool B.
+
 - **~~BUG-65 · bordões da seleção pertenciam à posição, não ao personagem~~ · RESOLVIDO 16/08.**
   Palavras do dono: *"o Faria Limer tá usando um áudio do Lula"*, *"o Clubber não pode ser
   bomboclaat, tem que ser o ai delícia; o bomboclaat é o Rasta"* e *"o Funk Raiz é o coé,

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "eval:loadingwall": "node tools/eval/loading-wallpaper-check.mjs",
     "//eval:matchoptions": "Opções do mapa em tela cheia precisam atravessar o estado e governar o Game real; testa 1/3/5/7 rounds nos dois modos e os padrões históricos.",
     "eval:matchoptions": "node tools/eval/match-options-check.mjs",
-    "//eval:charvoice": "O clique no avatar toca uma fala determinística e exclusiva; bordões declarados mantêm a identidade mesmo se o pool mudar. A seleção automática abre muda. Mutantes: sem-clique|auto-fala|mesmo-som|sem-identidade|troca-clubber-rasta|pack-antigo.",
+    "//eval:charvoice": "O clique no avatar toca uma fala determinística e exclusiva; bordões declarados mantêm a identidade mesmo se o pool mudar. A seleção automática abre muda. Mutantes: sem-clique|auto-fala|mesmo-som|sem-identidade|troca-clubber-rasta|faria-volta-lula|pack-antigo.",
     "eval:charvoice": "node tools/eval/character-select-voice-check.mjs",
     "eval:mat": "node tools/eval/mat-check.mjs",
     "//eval:seo": "LÊ dist/client/ — o HTML publicado, não o .astro. Rode `npm run build` antes, ou use `npm run check:seo`, que já faz os dois. `--mutate` prova que a régua morde.",

--- a/public/js/audio.js
+++ b/public/js/audio.js
@@ -11,7 +11,7 @@ const GUN_VOL = (() => {
 
 export const CHARACTER_SELECT_VOICE = Object.freeze({
   gotinha: 'audio/a/cc77ec4f134a71ba.mp3',
-  farialimer: 'audio/a/55678d5886537476.mp3',
+  farialimer: 'audio/a/fc5bf11f5b8287f5.mp3',
   dollynho: 'audio/a/dc26854fa366d0ec.mp3',
   clubber: 'audio/a/08290068f8d9935f.mp3',
   reggae: 'audio/a/f180be207d0b440b.mp3',

--- a/scripts/fetch-audio.sh
+++ b/scripts/fetch-audio.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$0")/.."
 # Pacote completo — vozes/rounds/SFX/menu/ingame — com nomes hasheados
 # (decisão do dono: nenhum título legível em URL/zip). Fecha o BUG-19
 # (produção servia o pack de julho e todo som novo dava 404).
-URL="${AUDIO_PACK_URL:-https://github.com/corosolto/client/releases/download/audio-pack-v5/audio-pack.zip}"
+URL="${AUDIO_PACK_URL:-https://github.com/corosolto/client/releases/download/audio-pack-v6/audio-pack.zip}"
 DEST="public/audio"
 
 if [ -f "$DEST/manifest.json" ]; then

--- a/tools/eval/character-select-voice-check.mjs
+++ b/tools/eval/character-select-voice-check.mjs
@@ -5,7 +5,7 @@
 import { readFileSync } from 'node:fs';
 
 const mutante = process.argv.find((arg) => arg.startsWith('--mutante='))?.slice(10) || '';
-if (mutante && !['sem-clique', 'auto-fala', 'mesmo-som', 'sem-identidade', 'troca-clubber-rasta', 'pack-antigo'].includes(mutante)) {
+if (mutante && !['sem-clique', 'auto-fala', 'mesmo-som', 'sem-identidade', 'troca-clubber-rasta', 'faria-volta-lula', 'pack-antigo'].includes(mutante)) {
   console.error(`mutante desconhecido: ${mutante}`);
   process.exit(2);
 }
@@ -21,7 +21,7 @@ if (mutante === 'sem-clique') {
 if (mutante === 'auto-fala') {
   main = main.replace('if (row) selectChar(character, row);', 'row?.click();');
 }
-if (mutante === 'pack-antigo') fetchAudio = fetchAudio.replace('audio-pack-v5', 'audio-pack-v4');
+if (mutante === 'pack-antigo') fetchAudio = fetchAudio.replace('audio-pack-v6', 'audio-pack-v5');
 
 const failures = [];
 const expect = (ok, message) => { if (!ok) failures.push(message); };
@@ -41,8 +41,8 @@ expect(!/characterSelectVoice/.test(selectBody),
   'VOICE3 selectChar fala durante a montagem automática da tela');
 expect(!/row\?\.click\(\)/.test(main),
   'VOICE4 a query string simula clique humano e dispara fala');
-expect(/releases\/download\/audio-pack-v5\/audio-pack\.zip/.test(fetchAudio),
-  'VOICE12 o build não baixa o pacote que contém a vinheta do Dollynho');
+expect(/releases\/download\/audio-pack-v6\/audio-pack\.zip/.test(fetchAudio),
+  'VOICE12 o build não baixa o pacote com a voz corrigida do Faria Limer');
 
 globalThis.location ||= { search: '' };
 const { Sfx } = await import('../../public/js/audio.js');
@@ -109,7 +109,7 @@ const voice = {
 };
 const identityCases = [
   { id: 'gotinha', faction: 'E', roster: ['esquerdomacho', 'sindicato', 'mst', 'doutora', 'mistico', 'gotinha', 'hipster', 'et'], expected: 'audio/a/cc77ec4f134a71ba.mp3' },
-  { id: 'farialimer', faction: 'B', roster: ['caminhoneiro', 'sertanejo', 'coach', 'farialimer', 'bombado', 'dollynho', 'ancap', 'canarinho', 'proerd'], expected: 'audio/a/55678d5886537476.mp3' },
+  { id: 'farialimer', faction: 'B', roster: ['caminhoneiro', 'sertanejo', 'coach', 'farialimer', 'bombado', 'dollynho', 'ancap', 'canarinho', 'proerd'], expected: 'audio/a/fc5bf11f5b8287f5.mp3' },
   { id: 'dollynho', faction: 'B', roster: ['caminhoneiro', 'sertanejo', 'coach', 'farialimer', 'bombado', 'dollynho', 'ancap', 'canarinho', 'proerd'], expected: 'audio/a/dc26854fa366d0ec.mp3' },
   { id: 'clubber', faction: 'U', roster: ['emo', 'blackmetal', 'metaleiro', 'punk', 'skatista', 'clubber', 'rapper', 'reggae', 'pagodeiro'], expected: 'audio/a/08290068f8d9935f.mp3' },
   { id: 'reggae', faction: 'U', roster: ['emo', 'blackmetal', 'metaleiro', 'punk', 'skatista', 'clubber', 'rapper', 'reggae', 'pagodeiro'], expected: 'audio/a/f180be207d0b440b.mp3' },
@@ -131,6 +131,16 @@ if (mutante === 'troca-clubber-rasta') {
   identityProbe.characterSelectVoice = function (characterId, faction, rosterIds) {
     const swapped = characterId === 'clubber' ? 'reggae' : characterId === 'reggae' ? 'clubber' : characterId;
     return original.call(this, swapped, faction, rosterIds);
+  };
+}
+if (mutante === 'faria-volta-lula') {
+  const original = identityProbe.characterSelectVoice;
+  identityProbe.characterSelectVoice = function (characterId, faction, rosterIds) {
+    if (characterId === 'farialimer') {
+      this._characterSelectAudio = this._sample('audio/a/55678d5886537476.mp3');
+      return true;
+    }
+    return original.call(this, characterId, faction, rosterIds);
   };
 }
 for (const testCase of identityCases) {


### PR DESCRIPTION
## O que muda
- troca o Faria Limer do clipe `cana_doce` para um clipe nominal do Time B
- publica e passa o deploy para `audio-pack-v6`
- acrescenta mutações que devolvem a voz errada e o pacote antigo

## Evidência
- fonte e asset `fc5bf11f5b8287f5` têm o mesmo SHA-1
- `npm run eval:charvoice` verde
- `faria-volta-lula` e `pack-antigo` mordem
- `npm run check:fast`: 46/46
- `npm run build` verde

Audio pack: https://github.com/corosolto/client/releases/tag/audio-pack-v6