### PR TITLE
docs(contributing): divisão de bots — estraga-codigo conserta, regras de fork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,28 @@ E teste à mão: o jogo abre, o console fica limpo, uma partida completa roda
    > compatível: elas seguem MIT dentro do conjunto, que é distribuído sob
    > AGPL-3.0. Se isso for decisivo pra você, pergunte antes de abrir o PR.
 
+## Quem conserta o quê (bots da casa)
+
+**`csbrasil-bot` é pipeline** (classificação, portões, deploy). **`estraga-codigo` é quem
+revisa e conserta** — o nome é ironia: ele existe pra *desestragar*. Divisão do dono
+(17/08): quem abriu o PR não precisa esperar humano pra ver um fio major virar conserto.
+
+Regras de atuação do `estraga-codigo` (o caso #310, 16/08, pagou a lição):
+
+1. **Nunca pusha em fork de contribuidor** — o "permission denied" do #310 não era falta
+   de permissão ajustável: push em fork só com convite de colaborador do dono do fork,
+   e isso não se pede a contribuidor casual.
+2. **Fix mora em branch do repo base**: `estraga-codigo/fix-<n>-<slug>` criada da head
+   do PR + commit de conserto. O autor do PR continua creditado (a branch preserva os
+   commits dele); o dono mergeia o PR original atualizado ou o da fix, como preferir.
+3. **Patch `git am` sempre no comentário** — quem prefere aplicar no próprio fork
+   aplica (é o que o `git am` preserva: autoria e mensagem).
+4. **Não mergeia o que consertou** — revisão adversarial é de outro par de olhos
+   (humano ou a esteira de portões).
+
+Permissões hoje: `write` no repo base (suficiente para 1-3). `maintain` (editar
+metadata de PR de terceiro) exige membro da org — pendente de convite pelo dono.
+
 ### As superfícies da licença
 
 Estes arquivos **repetem o nome da licença** — uma troca de licença muda todos no


### PR DESCRIPTION
## Summary

Divisão do dono (17/08): `csbrasil-bot` é pipeline; `estraga-codigo` é o revisor que conserta (ironia do nome: existe pra *desestragar*).

Regras de atuação nascidas do caso **#310** (16/08), em que o push do fix pro fork do contribuidor deu `permission denied` — que não é permissão ajustável, é como forks funcionam:

1. **Nunca push em fork de contribuidor**
2. Fix mora em branch do repo base (`estraga-codigo/fix-<n>-<slug>`), da head do PR + commit de conserto; **crédito preservado** (commits do autor seguem na branch)
3. Patch `git am` sempre no comentário (quem prefere aplicar no próprio fork, aplica)
4. **Não mergeia o que consertou** — revisão adversarial é de outro par de olhos

Estado de permissões registrado: `estraga-codigo` hoje tem `write` (suficiente para as regras 1-3); `maintain` exige convite de org (ação do dono).

## Risk
- [x] low — só documentação de processo

## Validation
- [x] `npm run travessao:check` verde

## Bot notes
- [x] ok to label `safe-automerge`