### PR TITLE
ci(release): push do bump autentica como csbrasil-BOT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Push do bump autenticado como csbrasil-BOT: o ruleset da main (protecao-main)
+      # não permite bypass do github-actions[bot]; o guard "chore(release):" impede o loop do PAT.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: 22 }


### PR DESCRIPTION
## Summary

- O `release.yml` agora faz checkout com `RELEASE_TOKEN` (PAT da csbrasil-BOT), para o push do bump autenticar como essa conta
- Preparação do ruleset `protecao-main` (item 1 do handoff de 18/08): o push com `GITHUB_TOKEN` é atribuído ao `github-actions[bot]`, que **não pode receber bypass** em ruleset de repo — com PR obrigatório na main, a esteira de release pararia
- O anti-loop já existia: o guard `pula se o commit já é do bot de release` cobre o push via PAT (que re-dispara workflows)
- Efeito colateral aceito: o commit de bump passa a rodar o `build` do ci.yml (~1 run extra por release)

## Issue

- Faz parte do item 1 (branch protection) do PRÓXIMA-SESSÃO.md

## Risk

- [x] low — docs/tooling/text only

## Validation

- [ ] `npm run build` — coberto pelo CI deste PR (workflow-only, sem mudança de runtime)
- E2E: o merge dispara o release.yml com o novo token — bump `.151` verde COM o push autenticado como csbrasil-BOT prova a mudança, ainda sem ruleset ativo

## Bot notes

- [x] ok to label `safe-automerge`