### PR TITLE
ci(release): run mais novo cancela o velho no ar (atomic push failed da .152)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,13 @@ on:
   push:
     branches: [main]
 
-# Dois merges quase juntos: serializa em vez de correr. O rebase no passo de bump cobre
-# a janela residual (main andou entre o evento e a execução).
+# Dois merges quase juntos: o run MAIS NOVO cancela o velho no ar. Como a main é
+# fast-forward-only (ruleset), a head nova sempre contém a velha — o run velho
+# empurrando depois de a main andar é exatamente o "atomic push failed" da .152
+# (03:21 de 18/08): rebase cobre a janela evento→execução, não a janela execução→push.
 concurrency:
   group: release-main
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Dois merges 23 s apart (03:21 de 18/08) produziram "atomic push failed for ref refs/heads/main" no release da head antiga: o `concurrency` serializa, mas o run velho empurra depois de a main andar — o rebase cobre a janela evento→execução, não a janela execução→push
- Com a main fast-forward-only (ruleset ativo hoje), a head nova **sempre contém** a velha: `cancel-in-progress: true` mata o run velho no ar e só o novo corre — resultado sempre completo, sem corrida

## Issue

- Nenhuma — incidente presenciado no merge sequencial dos PRs #348/#347 (run 32095173619)

## Risk

- [x] low — workflow-only; o guarda "tag já existe" continua cobrindo sobreposição residual

## Validation

- [x] `workflow_security_check.py --selftest`: 9/9 mutações vermelhas
- [x] Este PR em si exercita o pipeline protegido (ruleset ativo: checks requeridos + squash merge)

## Bot notes

- [x] ok to label `safe-automerge`