### PR TITLE
fix(ci): guarda de dedupe na shell — triage não morre mais em issue não-crash

### DIFF
--- a/.github/workflows/csbrasil-bot-issue-triage.yml
+++ b/.github/workflows/csbrasil-bot-issue-triage.yml
@@ -65,6 +65,7 @@ jobs:
           PY
       - name: Suggest crash duplicate
         run: |
+          rm -f /tmp/crashes.json
           python3 - <<'PY'
           import json, subprocess, pathlib
           current = json.load(open('/tmp/issue.json'))
@@ -81,6 +82,13 @@ jobs:
               'others': data,
           }))
           PY
+          # Guarda na SHELL: SystemExit(0) do python só encerra o INTERPRETADOR —
+          # a shell seguia pra ler /tmp/crashes.json que não existia e o passo
+          # morria em TODA issue não-crash (8 failures seguidas, 17-18/08).
+          if [ ! -f /tmp/crashes.json ]; then
+            echo "issue não é crash-auto — dedupe pulado"
+            exit 0
+          fi
           python3 scripts/ci/crash_dedupe.py < /tmp/crashes.json > /tmp/dup.json
           python3 - <<'PY'
           import json, os, subprocess

--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -2454,6 +2454,7 @@ publicação em potencial, e o `.gitignore` não protege de um deploy local.
 
 ## Relatos recentes e resolução
 
+- **~~BUG-69 · triage de issue morria em toda issue não-crash~~ · RESOLVIDO 18/08.** Evidência: `csbrasil-bot-issue-triage` com **8 failures consecutivos** (17/08 23:06 → 18/08 05:42), todos em issues `[plantão]`/`[invariante]` do estraga-codigo, todos no passo "Suggest crash duplicate": `line 17: /tmp/crashes.json: No such file or directory`. Causa: o guarda `raise SystemExit(0)` dentro do heredoc python encerra o INTERPRETADOR, não o PASSO — a shell seguia para `crash_dedupe.py < /tmp/crashes.json` que jamais fora escrito. Labels e comentário de review eram aplicados antes do passo final, então o defeito passava despercebido: vermelho silencioso em toda issue de bot desde 17/08. Correção: guarda na SHELL (`if [ ! -f /tmp/crashes.json ]`) + `rm -f` pré-heredoc; aplicado no `csbrasil-bot-issue-triage.yml` e no `issues-bot.yml` (consolidação local). Mutante: remover o `if` reabre o `No such file or directory` na próxima issue não-crash.
 - **~~BUG-68 · classify postava comentários repetidos como `github-actions[bot]`~~ · RESOLVIDO 18/08.** Palavras do
   dono: *"ele comenta a mesma coisa varias vezes e idealmente usaria o csbrasil-BOT"*. Evidência: PR #348 com 5
   comentários `## csbrasil-bot classification`, 4 deles num intervalo de 2 s (03:21:19–03:21:21), todos de


### PR DESCRIPTION
## Summary

- **BUG-69**: o guarda `raise SystemExit(0)` no heredoc python encerra o interpretador, não o passo — a shell continuava e morria lendo `/tmp/crashes.json` nunca escrito. **8 failures consecutivos** do `csbrasil-bot-issue-triage` em toda issue não-crash (17/08 23:06 → 18/08 05:42), silencioso porque labels/comentário eram aplicados antes do passo final.
- Fix: `rm -f` pré-heredoc + `if [ ! -f /tmp/crashes.json ]` na SHELL. Mutante: remover o `if` reabre o erro na próxima issue não-crash.
- BUG-69 registrado no KNOWN-BUGS com evidência.

## Issue

- Fecha o defeito por trás dos vermelhos de triage citados em #342/#357 (as issues em si eram transientes de deploy, fechadas com evidência)

## Risk

- [x] low
- [ ] medium
- [ ] high

## Validation

- [x] yaml validado
- [x] Mutante mental: sem o `if`, `crash_dedupe.py < /tmp/crashes.json` falha com o MESMO erro do log
- [ ] PROVA AO VIVO: próxima issue de bot aberta → triage verde até o fim

## Bot notes

Agent: opencode