### PR TITLE
fix(release): perdedor da corrida não toca na release — edit apagava o crédito dos colaboradores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,14 @@ jobs:
           # Idempotente: o release.yml do push na main e este job do push da
           # TAG criam a mesma release numa corrida de segundos — o perdedor
           # levava 422 "tag_name already exists" e pintava o run de vermelho
-          # (alpha.154, 18/08). Release que já existe só recebe as notas.
+          # (alpha.154, 18/08). Release que já existe NÃO SE TOCA: o `edit`
+          # com --notes do CHANGELOG APAGAVA a seção "What's Changed" com os
+          # colaboradores que o vencedor gerou (alpha.156-.158, 19/08).
           TAG="${{ github.ref_name }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "release $TAG já existe — atualizando notas"
-            gh release edit "$TAG" "${EXTRA[@]}" --title "CSBR $TAG" || true
-          else
-            gh release create "$TAG" --generate-notes "${EXTRA[@]}" --title "CSBR $TAG"
+            echo "release $TAG já existe (vencedor da corrida) — nada a fazer"
+            exit 0
           fi
+          gh release create "$TAG" --generate-notes "${EXTRA[@]}" --title "CSBR $TAG"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,11 +140,11 @@ jobs:
           # antigo (`git log --oneline`) apagou esse crédito no alpha.47 (BUG-40).
           # Idempotente: este job e o "release" do ci.yml (disparo de tag)
           # correm pela mesma release — quem chega segundo levava 422
-          # "tag_name already exists" (alpha.154, 18/08). Já existindo, só
-          # atualiza notas e título.
+          # "tag_name already exists" (alpha.154, 18/08). Existindo, NÃO TOCA:
+          # `edit` com --notes do CHANGELOG apagava o "What's Changed" dos
+          # colaboradores gerado pelo vencedor (alpha.156-.158, 19/08).
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "release $TAG já existe — atualizando notas"
-            gh release edit "$TAG" "${EXTRA[@]}" --title "CSBR $TAG" || true
-          else
-            gh release create "$TAG" --generate-notes "${EXTRA[@]}" --title "CSBR $TAG"
+            echo "release $TAG já existe (vencedor da corrida) — nada a fazer"
+            exit 0
           fi
+          gh release create "$TAG" --generate-notes "${EXTRA[@]}" --title "CSBR $TAG"


### PR DESCRIPTION
## Summary

- O ramo idempotente do #355 fazia `gh release edit --notes` (trecho do CHANGELOG) quando a release já existia — **apagando a seção "What's Changed" (by @autor in PR)** que o vencedor da corrida tag×main tinha gerado.
- Vítimas: v2.0.0-alpha.156/157/158 saíram sem crédito de colaborador. **Retro-corrigidas hoje** via `generate-notes` + PATCH (14 releases no total; outras 62 sem PR na faixa — pushes diretos, nada a creditar).
- Agora: release existe = vencedor já fez tudo certo → perdedor `exit 0` sem tocar (último passo do job nos dois workflows).

## Issue

- Nenhuma (diagnóstico ao vivo; releases retro-corrigidas na mão)

## Risk

- [x] low — só o caminho de release duplicada muda; criação única idêntica
- [ ] medium
- [ ] high

## Validation

- [x] yaml validado; `exit 0` confirmado como último passo do job nos dois
- [x] Prova retroativa: .156 hoje lista @rubenmarcus (#351-#354) — https://github.com/corosolto/client/releases/tag/v2.0.0-alpha.156
- [ ] PROVA VIVA: próximo release natural conserva o crédito

## Bot notes

Agent: opencode