### PR TITLE
fix(portão): autoria não vota em clone raso - Vercel e produção vermelhas desde o #398

### DIFF
--- a/tools/eval/docs-autoria-check.mjs
+++ b/tools/eval/docs-autoria-check.mjs
@@ -15,7 +15,8 @@
    A REGRA QUE ESTA RÉGUA GUARDA
    (a) num PR (`--check`), o bloco de autoria NÃO derruba o portão;
    (b) na main (`--check --autoria`), ele derruba — lá é derivável e consertável;
-   (c) qualquer OUTRO bloco gerado continua derrubando os dois — a tolerância é só da autoria.
+   (c) qualquer OUTRO bloco gerado continua derrubando os dois — a tolerância é só da autoria;
+   (d) em clone RASO não há o que medir, e portão sem medida não vota (ver o guard lá embaixo).
 
    Mede executando o gerador de verdade sobre uma mutação real no arquivo, e devolve o
    arquivo ao estado original no fim (recusa rodar se ele já estiver sujo).
@@ -28,6 +29,16 @@ import { readFileSync, writeFileSync } from 'node:fs';
 const MUT = (process.argv.find((a) => a.startsWith('--mutante=')) || '').split('=')[1] || '';
 const ALVO = 'docs/docs/colaborar.md';
 const GERADOR = 'tools/gen-docs.mjs';
+
+/* Clone RASO (Vercel, CI com fetch-depth:1) não tem histórico, e o gen-docs - por decisão
+   já registrada nele - NÃO regenera o bloco `pessoas` ali: número que não existe no
+   ambiente não derruba portão. Sem regeneração, a mutação de autoria não tem como acender
+   nada, e a DOCSAUT2 acusa cegueira onde na verdade falta medida. Foi o que derrubou o
+   deploy da Vercel (e a produção) desde o #398. Onde há histórico, a régua segue mordendo. */
+if (execFileSync('git', ['rev-parse', '--is-shallow-repository']).toString().trim() === 'true') {
+  console.log('  \x1b[33m⚠\x1b[0m DOCSAUT não medido: clone raso não tem o histórico de onde sai a autoria');
+  process.exit(0);
+}
 
 const sujo = execFileSync('git', ['status', '--porcelain', '--', ALVO, GERADOR]).toString().trim();
 if (sujo) {


### PR DESCRIPTION
## Summary

- `docs-autoria-check.mjs` sai com "não medido" quando o repositório é um **clone raso**, antes de qualquer medição;
- onde há histórico (máquina, CI com clone cheio), as três cláusulas continuam valendo e os dois mutantes continuam mordendo.

## Evidência

O `gen-docs.mjs` já decide - e documenta desde o #91 - que em clone raso o bloco `pessoas` **não é regenerado**: o número sai do `git shortlog` e, sem histórico, ele não existe no ambiente. A DOCSAUT2 não herdou essa decisão: ela torce a contagem de autoria e exige que o `--autoria` reprove. Em clone raso nada é regenerado, a mutação não acende nada, e a régua acusa "portão cego" onde na verdade **falta medida**.

O preço foi o deploy. A Vercel roda `check:deploy` num clone raso, e desde que o #398 pôs a DOCSAUT no portão **todo build falha** - main e PRs:

```
eval:docsautoria … FALHOU 2.0s
✗ DOCSAUT2 autoria torta PASSOU com --autoria — o portão da main está cego [...]
28/29 passaram
Error: Command "[...] && npm run check:deploy && npm run build" exited with 1
```

Status do Vercel nos commits da main: `d5797b23` verde → **`4eaae793` (#398) vermelho** → `654b90d1` vermelho. Produção parou aí. E o vermelho reaparece em PR que não tem nada com isso - a **culpa errada** que esta mesma régua nasceu para evitar (#392 → #395).

Medido nos dois sentidos, no MESMO clone raso (`git clone --depth 1`, `is-shallow-repository=true`):

| árvore | veredito |
|---|---|
| com o guard | `⚠ DOCSAUT não medido: clone raso não tem o histórico de onde sai a autoria` · exit 0 |
| guard removido | `✗ DOCSAUT2 autoria torta PASSOU com --autoria` · exit 1 |

E no clone cheio os mutantes seguem mordendo: `sem-tolerancia` acende a DOCSAUT1, `tolerancia-demais` acende a DOCSAUT2. `check:fast` 56/56.

## Issue

Regressão do #398. Não muda o gerador nem o conteúdo de doc nenhum - só quem pode votar.

## Risk

- [x] low - docs/tooling/text only
- [ ] medium - UI/site/runtime path touched
- [ ] high - gameplay/render/backend/anti-cheat touched

Uma cláusula de guarda num script de `tools/eval/`. Nenhum arquivo do jogo ou do site.

## Validation

- [x] `npm run check:fast` - 56/56
- [x] `eval:docsautoria` + os mutantes `sem-tolerancia` e `tolerancia-demais`
- [x] clone raso real, com e sem o guard (tabela acima)

## Limite declarado

Não faz a Vercel clonar fundo, e não passa a conferir autoria lá - continua sendo a main, com `--autoria` e histórico, o único lugar onde esse número é derivável.

## Bot notes

- [x] ok to label `safe-automerge`
- [ ] needs `needs-staging`
- [ ] needs `needs-human-gameplay`
- [ ] needs `needs-human-backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
