### PR TITLE
fix(ci): bot marca `pronto-pra-merge` em vez de mergear sozinho

### DIFF
--- a/.github/workflows/csbrasil-bot-automerge.yml
+++ b/.github/workflows/csbrasil-bot-automerge.yml
@@ -45,6 +45,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.13'
+      - name: Garante a etiqueta de pronto
+        run: python3 scripts/ci/ensure_labels.py pronto-pra-merge
       - name: Fetch PR status
         run: gh pr view "$PR_NUMBER" --json isDraft,labels,reviewDecision,mergeStateStatus,statusCheckRollup,files > /tmp/automerge.json
       - name: Check eligibility
@@ -53,13 +55,24 @@ jobs:
         run: |
           python3 scripts/ci/check_automerge.py --selftest
           python3 scripts/ci/check_automerge.py < /tmp/automerge.json > /tmp/automerge-result.json
-      - name: Merge when eligible
+      # DEIXAR PRONTO NÃO É MERGEAR (decisão do dono, 21/08). Este passo chamava
+      # `gh pr merge --squash --auto` e fechava o PR sozinho. A intenção declarada dos
+      # bots é outra: autocorreção e autorrevisão para deixar o PR PRONTO, com o botão
+      # de merge continuando humano. O que era merge vira etiqueta e um comentário que
+      # diz por que o PR está pronto.
+      - name: Marca como pronto quando elegível
         run: |
           python3 - <<'PY'
           import json, os, subprocess, sys
           data = json.load(open('/tmp/automerge-result.json'))
+          pr = os.environ['PR_NUMBER']
           if not data.get('eligible'):
-              print('automerge: not eligible')
+              print('pronto-pra-merge: not eligible')
+              subprocess.run(['gh', 'pr', 'edit', pr, '--remove-label', 'pronto-pra-merge'], check=False)
               sys.exit(0)
-          subprocess.run(['gh', 'pr', 'merge', os.environ['PR_NUMBER'], '--squash', '--delete-branch', '--auto'], check=True)
+          subprocess.run(['gh', 'pr', 'edit', pr, '--add-label', 'pronto-pra-merge'], check=True)
+          subprocess.run(['gh', 'pr', 'comment', pr, '--body',
+                          '🤖 **csbrasil-bot**: portões verdes e diff dentro do que o '
+                          '`check_automerge` aceita — marquei como `pronto-pra-merge`. '
+                          'O merge continua sendo seu.'], check=True)
           PY

--- a/scripts/ci/ensure_labels.py
+++ b/scripts/ci/ensure_labels.py
@@ -18,6 +18,7 @@ LABELS = {
     "stale-backlog": ("c2e0c6", "Issue antiga ou desalinhada com o checkout atual; precisa revalidação"),
     "needs-repro": ("f9d0c4", "Issue precisa passos de reprodução mais concretos"),
     "preview-autorizado": ("0e8a16", "Mantenedor revisou o SHA atual e liberou preview do fork na Vercel"),
+    "pronto-pra-merge": ("0e8a16", "Portões verdes e diff dentro do aceito: falta só o merge, que é humano"),
 }
 
 

--- a/tools/eval/autofix-check.mjs
+++ b/tools/eval/autofix-check.mjs
@@ -13,10 +13,14 @@
          bot que edita o workflow que o governa amplia a própria permissão.
    AF3 · o bot não mergeia. Deixar o PR pronto e fechá-lo são coisas diferentes, e
          a segunda é humana (decisão do dono, 21/08).
+   AF4 · e isso vale para o repositório INTEIRO, não só para o autofix: nenhum
+         workflow pode chamar `gh pr merge`. O `csbrasil-bot-automerge` chamava, e
+         era a única coisa que um bot daqui fazia sozinho — justamente a que não
+         devia. Ele agora aplica `pronto-pra-merge` e o botão continua humano.
 
    Uso: node tools/eval/autofix-check.mjs [--mutante=<nome>]
    ============================================================================ */
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 
 const MUT = (process.argv.find((a) => a.startsWith('--mutante=')) || '').split('=')[1] || '';
 const MUTANTES = {
@@ -24,6 +28,7 @@ const MUTANTES = {
   'lista-abre-codigo': 'AF2',
   'lista-abre-workflow': 'AF2',
   'autofix-mergeia': 'AF3',
+  'automerge-volta': 'AF4',
 };
 if (MUT && !MUTANTES[MUT]) { console.error(`mutante desconhecido: ${MUT}`); process.exit(2); }
 
@@ -73,6 +78,20 @@ else {
 /* ---- AF3: o bot não mergeia ---- */
 if (/gh pr merge/.test(wf)) {
   falhas.push('AF3 autofix.yml mergeia PR — o autofix deixa pronto, quem fecha é gente');
+}
+
+/* ---- AF4: e nenhum outro workflow mergeia tampouco ---- */
+const WORKFLOWS = readdirSync('.github/workflows').filter((f) => /\.ya?ml$/.test(f));
+for (const nome of WORKFLOWS) {
+  let texto = ler(`.github/workflows/${nome}`);
+  if (MUT === 'automerge-volta' && nome === 'csbrasil-bot-automerge.yml') {
+    texto += "\n          subprocess.run(['gh', 'pr', 'merge', pr, '--squash', '--auto'])\n";
+  }
+  /* Só a CHAMADA conta: o comentário que explica por que ela saiu tem de poder citá-la. */
+  const linhas = texto.split('\n').filter((l) => !/^\s*#/.test(l));
+  if (linhas.some((l) => /gh['"]?,\s*['"]pr['"],\s*['"]merge['"]|gh pr merge/.test(l))) {
+    falhas.push(`AF4 ${nome} mergeia PR sozinho — deixar pronto e fechar são coisas diferentes`);
+  }
 }
 
 for (const f of falhas) console.log(`  \x1b[31m✗\x1b[0m ${f}`);


### PR DESCRIPTION
> **Empilhado sobre o #411** (fase 3) → #409 (fase 2) → #408 (fase 1). Última das quatro.

## Summary

- o passo que chamava `gh pr merge --squash --auto` passa a aplicar a etiqueta **`pronto-pra-merge`** e comentar por que o PR está pronto;
- a etiqueta **sai** quando o PR deixa de ser elegível, para não virar carimbo velho;
- régua **AF4**: nenhum workflow do repositório pode chamar `gh pr merge`.

## Evidência

A intenção declarada dos bots é autocorreção e autorrevisão para deixar o PR **pronto** — não fechar o assunto. Mas o `csbrasil-bot-automerge` fazia exatamente isto:

```python
subprocess.run(['gh', 'pr', 'merge', os.environ['PR_NUMBER'],
                '--squash', '--delete-branch', '--auto'], check=True)
```

E era a **única** coisa que um bot deste repositório fazia sozinho — nos 29 PRs auditados nenhum bot jamais commitou um conserto. A capacidade que faltava não existia; a que sobrava era a de fechar o assunto sem ninguém olhar.

A AF4 ignora linha de comentário de propósito, para que o comentário que explica por que a chamada saiu possa citá-la. O mutante `automerge-volta` recoloca a chamada e reprova.

## Fora do alcance deste repositório

O **Esbirro** repetiu o mesmo alerta de `bundle-em-dia` a cada 30 minutos por **17 horas** na issue #393 sem nunca agir — a versão citada mudou de `alpha.163` para `alpha.172` no meio, ou seja, o incidente mudou e o alerta não. Ele vive em `game3/bots/vigia-prod/plantao.mjs`, outro repositório. Dar ação a ele (disparar o purge de edge que o `prod-watch` já sabe fazer, em vez de comentar de novo) é trabalho de lá.

## Risk

- [x] low - docs/tooling/text only
- [ ] medium - UI/site/runtime path touched
- [ ] high - gameplay/render/backend/anti-cheat touched

Tira uma capacidade do bot, não adiciona. Nenhum arquivo do jogo.

## Validation

- [x] `npm run check:fast` - 60/60
- [x] `eval:autofix` com AF4 + o mutante `automerge-volta`
- [x] `ensure_labels.py --selftest` com a etiqueta nova
- [x] YAML valida

## Limite declarado

Não mexe no `check_automerge.py` — o critério de elegibilidade continua o mesmo; só o que se faz com a resposta mudou.

## Bot notes

- [x] ok to label `safe-automerge`
- [ ] needs `needs-staging`
- [ ] needs `needs-human-gameplay`
- [ ] needs `needs-human-backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
