### PR TITLE
feat(ci): autofix resolve conflito de arquivo gerado e para no de código

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -80,7 +80,7 @@ jobs:
         if: env.pular != '1'
         run: |
           git remote add base "https://github.com/$REPO.git" 2>/dev/null || true
-          git fetch --depth=1 base "${{ github.event.pull_request.base.ref || 'main' }}"
+          git fetch base "${{ github.event.pull_request.base.ref || 'main' }}"
           git checkout FETCH_HEAD -- tools/ scripts/ package.json
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
@@ -90,8 +90,51 @@ jobs:
         if: env.pular != '1'
         run: npm ci --ignore-scripts
 
-      - name: Conserta o mecânico
+      # RESOLVE CONFLITO DE ARQUIVO GERADO. Todo `chore(release)` na main reescreve
+      # README, STATUS, ARCH e docs/, e reabre conflito em TODO PR aberto ao mesmo
+      # tempo — medido em 21/08: o alpha.173 sozinho pôs quatro PRs em CONFLICTING, e
+      # os nove arquivos do #400 eram gerados, nenhum de código. Resolver isso à mão é
+      # trabalho de Sísifo: o release seguinte desfaz.
+      #
+      # A trava é a MESMA do resto do autofix. Sobrou UM conflito fora da lista, o bot
+      # aborta o merge e devolve para gente — conflito de código é julgamento, e
+      # julgamento não é dele.
+      - name: Traz a base e resolve conflito de arquivo gerado
         if: env.pular != '1'
+        id: merge
+        run: |
+          git config user.name  "csbrasil-bot"
+          git config user.email "csbrasil-bot@users.noreply.github.com"
+          BASE="${{ github.event.pull_request.base.ref || 'main' }}"
+          git fetch base "$BASE"
+          if git merge --no-edit FETCH_HEAD; then
+            git diff --quiet HEAD@{1} HEAD || echo "mesclou=1" >> "$GITHUB_OUTPUT"
+            echo "PR já está em cima da base (ou mesclou limpo)."
+            exit 0
+          fi
+          git diff --name-only --diff-filter=U > /tmp/conflitos.txt
+          echo "conflitos:"; cat /tmp/conflitos.txt
+          if ! python3 scripts/ci/autofix_allowlist.py --caminhos < /tmp/conflitos.txt; then
+            git merge --abort
+            echo "humano=1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Só gerado: fica o da BASE, e os geradores re-derivam logo abaixo.
+          xargs -a /tmp/conflitos.txt -r git checkout --theirs --
+          xargs -a /tmp/conflitos.txt -r git add --
+          git commit --no-edit -m "Merge da base (conflito só em arquivo gerado, resolvido pelo autofix)" \
+                     -m "Agent: csbrasil-bot (autofix)" \
+                     -m "Signed-off-by: csbrasil-bot <csbrasil-bot@users.noreply.github.com>"
+          echo "mesclou=1" >> "$GITHUB_OUTPUT"
+
+      - name: Comenta quando o conflito é de gente
+        if: env.pular != '1' && steps.merge.outputs.humano == '1'
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "🤖 **autofix**: a base andou e o conflito encostou em arquivo de código — não é meu para resolver. Os arquivos em conflito estão no log do run; rode \`git merge origin/${{ github.event.pull_request.base.ref || 'main' }}\` e decida."
+
+      - name: Conserta o mecânico
+        if: env.pular != '1' && steps.merge.outputs.humano != '1'
         run: |
           node tools/gen-docs.mjs   || echo "::warning::gen-docs falhou"
           node tools/gen-arch.mjs   || echo "::warning::gen-arch falhou"
@@ -99,11 +142,11 @@ jobs:
       # As ferramentas foram restauradas da base só para rodar; o que volta ao PR é
       # apenas o resultado delas.
       - name: Devolve as ferramentas ao estado do PR
-        if: env.pular != '1'
+        if: env.pular != '1' && steps.merge.outputs.humano != '1'
         run: git checkout HEAD -- tools/ scripts/ package.json
 
       - name: A trava — só arquivo gerado pode virar commit
-        if: env.pular != '1'
+        if: env.pular != '1' && steps.merge.outputs.humano != '1'
         id: trava
         run: |
           git status --porcelain > /tmp/mexidos.txt
@@ -126,12 +169,14 @@ jobs:
             "🤖 **autofix**: o conserto encostou em arquivo fora da lista de permissão, então **não commitei nada**. Rode \`npm run docs && node tools/gen-arch.mjs\` e confira o que mudou."
 
       - name: Empurra o conserto
-        if: env.pular != '1' && steps.trava.outputs.commitar == '1' && env.PODE_EDITAR == 'true'
+        if: env.pular != '1' && (steps.trava.outputs.commitar == '1' || steps.merge.outputs.mesclou == '1') && env.PODE_EDITAR == 'true'
         run: |
           git config user.name  "csbrasil-bot"
           git config user.email "csbrasil-bot@users.noreply.github.com"
-          xargs -a /tmp/permitidos.txt -r git add --
-          git commit -m "chore(docs): regenera bloco derivado (autofix)" \
+          if [ -s /tmp/permitidos.txt ]; then
+            xargs -a /tmp/permitidos.txt -r git add --
+          fi
+          git diff --cached --quiet || git commit -m "chore(docs): regenera bloco derivado (autofix)" \
                      -m "Rodado pelo autofix: só arquivo gerado, conferido pela lista de permissão." \
                      -m "Signed-off-by: csbrasil-bot <csbrasil-bot@users.noreply.github.com>"
           git push origin "HEAD:$HEAD_REF"
@@ -141,7 +186,7 @@ jobs:
       # Fork com "allow edits by maintainers" desligado: o bot não tem como empurrar.
       # Comentar o comando é melhor que um vermelho que o autor não entende.
       - name: Sem permissão de push — comenta o comando
-        if: env.pular != '1' && steps.trava.outputs.commitar == '1' && env.PODE_EDITAR != 'true'
+        if: env.pular != '1' && (steps.trava.outputs.commitar == '1' || steps.merge.outputs.mesclou == '1') && env.PODE_EDITAR != 'true'
         run: |
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
             "🤖 **autofix**: dá para consertar sozinho, mas este PR está com *allow edits by maintainers* desligado. Rode \`npm run docs && node tools/gen-arch.mjs\` e commite — ou ligue a opção e eu faço."

--- a/scripts/ci/autofix_allowlist.py
+++ b/scripts/ci/autofix_allowlist.py
@@ -78,6 +78,8 @@ def selftest() -> int:
         ("package.json NÃO passa", ["package.json"], False),
         ("uma proibida contamina o lote", ["STATUS.md", "public/js/game.js"], False),
         ("nada mexido é lote vazio", [], True),
+        ("CHANGELOG não é gerado por ferramenta nossa", ["CHANGELOG.md"], False),
+        ("lote típico de release só toca gerado", ["README.md", "STATUS.md", "docs/docs/comecando.md"], True),
     ]
     erros = 0
     for nome, caminhos, esperado in casos:
@@ -100,7 +102,12 @@ def selftest() -> int:
 def main() -> int:
     if "--selftest" in sys.argv:
         return selftest()
-    caminhos = caminhos_do_porcelain(sys.stdin.read())
+    # `--caminhos`: a entrada já é uma lista crua (o `git diff --name-only` do merge),
+    # e não o porcelain. É o modo que o resolvedor de conflito usa.
+    if "--caminhos" in sys.argv:
+        caminhos = [l.strip() for l in sys.stdin.read().splitlines() if l.strip()]
+    else:
+        caminhos = caminhos_do_porcelain(sys.stdin.read())
     ok, fora = separa(caminhos)
     if fora:
         print("BLOQUEADO: o conserto encostou em arquivo que o bot não pode reescrever:")

--- a/tools/eval/autofix-check.mjs
+++ b/tools/eval/autofix-check.mjs
@@ -17,6 +17,11 @@
          workflow pode chamar `gh pr merge`. O `csbrasil-bot-automerge` chamava, e
          era a única coisa que um bot daqui fazia sozinho — justamente a que não
          devia. Ele agora aplica `pronto-pra-merge` e o botão continua humano.
+   AF5 · o resolvedor de conflito passa pela MESMA trava e ABORTA quando sobra
+         conflito fora dela. Resolver conflito de arquivo gerado é mecânico (todo
+         `chore(release)` reabre um em cada PR aberto); resolver conflito de código
+         é julgamento. Sem o `git merge --abort` no caminho de exceção, o bot
+         resolveria código escolhendo um lado no escuro.
 
    Uso: node tools/eval/autofix-check.mjs [--mutante=<nome>]
    ============================================================================ */
@@ -29,6 +34,7 @@ const MUTANTES = {
   'lista-abre-workflow': 'AF2',
   'autofix-mergeia': 'AF3',
   'automerge-volta': 'AF4',
+  'resolve-conflito-de-codigo': 'AF5',
 };
 if (MUT && !MUTANTES[MUT]) { console.error(`mutante desconhecido: ${MUT}`); process.exit(2); }
 
@@ -78,6 +84,24 @@ else {
 /* ---- AF3: o bot não mergeia ---- */
 if (/gh pr merge/.test(wf)) {
   falhas.push('AF3 autofix.yml mergeia PR — o autofix deixa pronto, quem fecha é gente');
+}
+
+/* ---- AF5: o resolvedor de conflito aborta quando o conflito é de gente ---- */
+if (MUT === 'resolve-conflito-de-codigo') {
+  wf = wf.replace(/\s*git merge --abort\n/, '\n');
+}
+const resolveConflito = /--caminhos/.test(wf) && /git checkout --theirs/.test(wf);
+if (resolveConflito) {
+  const trecho = wf.slice(wf.indexOf('diff-filter=U'), wf.indexOf('git checkout --theirs'));
+  if (!/autofix_allowlist\.py --caminhos/.test(trecho)) {
+    falhas.push('AF5 o resolvedor escolhe lado do conflito sem consultar a lista de permissão');
+  }
+  if (!/git merge --abort/.test(trecho)) {
+    falhas.push('AF5 o resolvedor não aborta o merge quando sobra conflito fora da lista — passaria a decidir código no escuro');
+  }
+  if (!/--caminhos/.test(ler('scripts/ci/autofix_allowlist.py'))) {
+    falhas.push('AF5 autofix_allowlist.py não entende `--caminhos`, que é como o resolvedor o consulta');
+  }
 }
 
 /* ---- AF4: e nenhum outro workflow mergeia tampouco ---- */


### PR DESCRIPTION
> **Fase 5**, empilhada sobre o #412 → #411 → #409 → #408.

## Summary

- o autofix passa a **trazer a base** antes de consertar;
- conflitou só em arquivo gerado → resolve pela base e re-deriva; sobrou **um** fora da lista → `git merge --abort` e comenta;
- régua **AF5** guarda o caminho de exceção.

## Evidência — medida ao vivo, hoje

Enquanto eu resolvia conflito à mão em quatro PRs, o `chore(release): v2.0.0-alpha.173` entrou na main e **reabriu os quatro de uma vez**. Os nove arquivos em conflito do #400 depois disso:

```
ARCH.generated.md
README.md
STATUS.md
docs/docs/arquitetura.md
docs/docs/comecando.md
docs/docs/quality-gates.md
docs/i18n/en/.../arquitetura.md
docs/i18n/en/.../comecando.md
docs/i18n/en/.../quality-gates.md
```

**Todos gerados. Nenhum de código.** Todo `chore(release)` reescreve esses arquivos, então resolver isso à mão é trabalho de Sísifo — o release seguinte desfaz.

A conta dos quatro PRs que resolvi à mão hoje: **53 arquivos em conflito, 45 gerados e 8 de código**. É exatamente essa fatia de 85% que o bot passa a cobrir.

## O que ele NÃO faz

Sobra para gente a fatia que exige decisão, e ela é real. No #372 a numeração colidiu — o PR usa `BUG-68` para a rampa sem textura e a main já usa `BUG-68` para o classify repetido. Preservei os dois lados e **não renumerei**: renumerar bug alheio muda referência em régua e commit. É esse tipo de coisa que o `git merge --abort` protege.

A AF5 é o que garante isso: sem o abort no caminho de exceção, o bot resolveria código escolhendo um lado no escuro. O mutante `resolve-conflito-de-codigo` remove o abort e reprova.

## Risk

- [ ] low - docs/tooling/text only
- [x] medium - UI/site/runtime path touched
- [ ] high - gameplay/render/backend/anti-cheat touched

Amplia o que o bot escreve — mas dentro da mesma lista de permissão da fase 3, que continua excluindo `public/`, `src/`, `scripts/`, `.github/` e os manifestos.

## Validation

- [x] `npm run check:fast` - 60/60
- [x] `eval:autofix` com AF5 + os seis mutantes
- [x] `autofix_allowlist.py --selftest` - 12 casos, inclui o lote típico de release
- [x] `--caminhos` exercitado nos dois sentidos (só gerado → 0; com código → 1)

## Limite declarado

Não resolve conflito de código, de `package.json` nem de `CHANGELOG.md` — os três estão fora da lista de propósito.

## Bot notes

- [ ] ok to label `safe-automerge`
- [x] needs `needs-staging`
- [ ] needs `needs-human-gameplay`
- [ ] needs `needs-human-backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
