### PR TITLE
fix(ci): extrai a trava do autofix antes do FETCH_HEAD ser sobrescrito

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -121,6 +121,12 @@ jobs:
           git remote add base "https://github.com/$REPO.git" 2>/dev/null || true
           BASE="${{ github.event.pull_request.base.ref || 'main' }}"
           git fetch base "$BASE"
+          # A trava é extraída AQUI, logo depois do fetch: mais adiante o `FETCH_HEAD` já
+          # pode ter sido sobrescrito, e o `git show` falhava com "exists on disk, but not
+          # in FETCH_HEAD" (medido no #397). Vem da BASE porque um PR que reescrevesse o
+          # allowlist liberaria a si mesmo.
+          git show "base/$BASE:scripts/ci/autofix_allowlist.py" > /tmp/allowlist-base.py \
+            || git show FETCH_HEAD:scripts/ci/autofix_allowlist.py > /tmp/allowlist-base.py
           # A mensagem vai EXPLÍCITA mesmo quando o merge não conflita: `--no-edit` usa a
           # mensagem automática do git, que não leva `Agent:` nem `Signed-off-by` — e aí o
           # bot conserta o PR e o dco reprova o commit que ele mesmo fez (medido no #406).
@@ -133,9 +139,6 @@ jobs:
           fi
           git diff --name-only --diff-filter=U > /tmp/conflitos.txt
           echo "conflitos:"; cat /tmp/conflitos.txt
-          # A trava é lida da BASE, não do PR: um PR que reescrevesse o allowlist
-          # liberaria a si mesmo. Extrair para /tmp mantém a árvore limpa para o merge.
-          git show FETCH_HEAD:scripts/ci/autofix_allowlist.py > /tmp/allowlist-base.py
           if ! python3 /tmp/allowlist-base.py --caminhos < /tmp/conflitos.txt; then
             git merge --abort
             echo "humano=1" >> "$GITHUB_OUTPUT"

--- a/tools/eval/autofix-check.mjs
+++ b/tools/eval/autofix-check.mjs
@@ -47,6 +47,7 @@ const MUTANTES = {
   'sem-varredura-pos-release': 'AF6',
   'commit-sem-trailer': 'AF7',
   'merge-sem-trailer': 'AF7',
+  'trava-do-pr': 'AF5',
 };
 if (MUT && !MUTANTES[MUT]) { console.error(`mutante desconhecido: ${MUT}`); process.exit(2); }
 
@@ -103,7 +104,8 @@ if (MUT === 'resolve-conflito-de-codigo') {
   wf = wf.replace(/\s*git merge --abort\n/, '\n');
 }
 const resolveConflito = /--caminhos/.test(wf) && /git checkout --theirs/.test(wf);
-if (resolveConflito && !/git show FETCH_HEAD:scripts\/ci\/autofix_allowlist\.py/.test(wf)) {
+if (MUT === 'trava-do-pr') wf = wf.replace(/git show "base\/\$BASE:scripts\/ci\/autofix_allowlist\.py"[\s\S]*?allowlist-base\.py\n/, '');
+if (resolveConflito && !/git show ["']?base\/\$BASE:scripts\/ci\/autofix_allowlist\.py/.test(wf)) {
   falhas.push('AF5 a trava consultada no merge não vem da BASE — um PR que reescrevesse o allowlist liberaria a si mesmo');
 }
 if (resolveConflito) {


### PR DESCRIPTION
Um dos doze runs do disparo geral morreu com:

```
fatal: path 'scripts/ci/autofix_allowlist.py' exists on disk, but not in 'FETCH_HEAD'
```

O `git show FETCH_HEAD:...` rodava **depois** do `git merge`, e a essa altura o `FETCH_HEAD` já não era mais o que o `git fetch base` tinha deixado. A extração passa a acontecer logo após o fetch, por `base/$BASE` com `FETCH_HEAD` como reserva.

A trava continua vindo da **base** — um PR que reescrevesse o allowlist liberaria a si mesmo. Mutante `trava-do-pr` acende a AF5.

**Onze dos doze runs passaram**; este era o décimo segundo.

## Risk
- [x] low - docs/tooling/text only

## Validation
- [x] `eval:autofix` verde + o mutante novo
- [x] YAML valida

🤖 Generated with [Claude Code](https://claude.com/claude-code)