### PR TITLE
fix(site): /discord levava para um convite que não é mais o nosso

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![three.js](https://img.shields.io/badge/jogo-three.js%20r160-000000?logo=three.js)](https://threejs.org)
 [![supabase](https://img.shields.io/badge/ranking-supabase-3fcf8e?logo=supabase&logoColor=white)](https://supabase.com)
 [![vercel](https://img.shields.io/badge/deploy-vercel-000000?logo=vercel)](https://vercel.com)
-[![Discord](https://img.shields.io/badge/Discord-entrar-5865F2?logo=discord&logoColor=white)](https://discord.gg/MJq7Csam)
+[![Discord](https://img.shields.io/badge/Discord-entrar-5865F2?logo=discord&logoColor=white)](https://discord.gg/fmunXnaj)
 [![Telegram](https://img.shields.io/badge/Telegram-entrar-26A5E4?logo=telegram&logoColor=white)](https://t.me/corosolto)
 
 **AI generated & AI friendly** — construído em par com agentes de IA, e cada

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "redirects": [
     {
       "source": "/discord",
-      "destination": "https://discord.gg/MJq7Csam",
+      "destination": "https://discord.gg/fmunXnaj",
       "permanent": false
     },
     {


### PR DESCRIPTION
## O que estava errado

O redirect `/discord` na `vercel.json` e o badge do `README.md` apontavam para `discord.gg/MJq7Csam`. O convite certo do servidor é `discord.gg/fmunXnaj`.

Como o rodapé (`Layout.astro:602`) e o index (`index.astro:693`) usam `DISCORD_URL = '/discord'` (`src/lib/site.ts:48`), todo mundo que clicava no botão do Discord no site caía no convite errado.

## O que mudou

- `vercel.json:7` — destino do redirect `/discord`
- `README.md:10` — link do badge

Duas linhas, nada mais. As menções ao convite velho em `CHANGELOG.md` e `docs/reports/` ficaram como estão: são registro histórico, não link vivo.

## Por que o redirect continua 302

`"permanent": false`. Se fosse 301, quem já tivesse aberto `/discord` uma vez continuaria indo para o convite velho mesmo depois do deploy — o navegador teria cacheado o destino. Com 302 o deploy resolve para todo mundo na hora.

## Fora de escopo, mas fica o registro

O comentário em `src/lib/site.ts:46-47` diz "URL externa, não o atalho `/discord`: o atalho só resolve na Vercel, e o rodapé também é servido no dev, no itch.io e na CrazyGames" — mas o valor logo abaixo é justamente `'/discord'`. Ou seja, no itch.io e na CrazyGames o botão do Discord resolve contra o domínio do host, não contra o convite. Mesma coisa com `/telegram`. É anterior a esta mudança e não tem régua cobrindo; não mexi aqui para o PR continuar sendo só a troca do convite.