### PR TITLE
feat(audio): roteiro e gerador de vozes do time Mítico

### DIFF
--- a/ARCH.generated.md
+++ b/ARCH.generated.md
@@ -10,7 +10,7 @@ Números atuais das zonas, do quality gate e do `package.json`:
 |---|---|---|---|
 | `public/` | o **jogo** | 52 arquivos `.js`, 35.214 linhas · Three.js `r160` vendorizado | ES modules servidos crus, **zero build**, sem dependência de runtime |
 | `src/` | o **site** | 19 páginas `.astro`, 4 rotas `/api` · Astro `^7.1.1` | framework é bem-vindo; `service_role` só no servidor |
-| `tools/` | o **arnês** | 210 scripts em `tools/eval/`, 57 em `tools/` | node puro: sobe o jogo real sem browser |
+| `tools/` | o **arnês** | 210 scripts em `tools/eval/`, 58 em `tools/` | node puro: sobe o jogo real sem browser |
 
 **Não existe `public/index.html`.** O HTML do jogo é `src/pages/index.astro`, servido na rota `/`. Servir `public/` estaticamente entrega os arnêses visuais, **não o jogo** — é a pegadinha que custa a primeira hora de todo mundo.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ contra bots, direto na aba. Sem download, sem instalação, sem cadastro.
 | Mapas no registro | 13 | objeto `MAPS` de `maps.js` |
 | Arnêses visuais em HTML | 15 | `git ls-files 'public/*.html' \| wc -l` |
 | Scripts do arnês | 210 | `git ls-files 'tools/eval/*.mjs' 'tools/eval/*.py' \| wc -l` |
-| Scripts de pipeline | 57 | `git ls-files 'tools/*.mjs' \| wc -l` |
+| Scripts de pipeline | 58 | `git ls-files 'tools/*.mjs' \| wc -l` |
 | Tarefas de entrada escritas | 26 | `git ls-files 'docs/issues/[0-9]*.md' \| wc -l` |
 | Versão | `2.0.0-alpha.203` | `public/js/version.js` e `package.json` (batem) |
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@
 - **Versão:** `2.0.0-alpha.203`
 - **Conteúdo jogável:** 5 facções, 44 personagens, 13 mapas e 26 armas com GLB
 - **Código do jogo:** 35.214 linhas em 52 módulos JavaScript
-- **Automação:** 127 comandos npm, 210 scripts de avaliação e 57 scripts de pipeline
+- **Automação:** 127 comandos npm, 210 scripts de avaliação e 58 scripts de pipeline
 
 > Bloco gerado por `node tools/gen-docs.mjs`. Fonte: `package.json · CHARACTERS · MAPS · public/models/weapons · public/js · tools/`
 

--- a/docs/audio/ROTEIRO-VOZES-MITICOS.md
+++ b/docs/audio/ROTEIRO-VOZES-MITICOS.md
@@ -1,0 +1,147 @@
+# ROTEIRO — Vozes do Time Mítico (IA/TTS)
+
+Falas de INGAME (provocação, grito de guerra, bordão) para os 9 personagens do
+Time Mítico (folclore + história BR). Tom satírico do jogo, PT-BR, PEGI12,
+falas curtas (≤ 4 s faladas).
+
+Regras da casa:
+- A instrução de VOZ descreve **arquétipo** (sotaque, energia, idade) — NUNCA
+  imita pessoa real, nem viva nem morta.
+- Nenhuma gravação comercial; tudo TTS via OpenRouter.
+- Zumbi dos Palmares é herói histórico real: tratamento digno, falas de
+  coragem e liberdade, **sem** caricatura étnica e sem sotaque forçado.
+- Bandeirante é o "vilão que o time tolera" (blurb oficial): a sátira mira a
+  arrogância dele, não glorifica a figura histórica.
+
+Gerador: `tools/gerar-vozes-miticos.mjs` (embute esta tabela). 2 tomadas por
+fala, vozes-base distintas → `public/audio/ia/miticos/<id>/<slug>-tN-<voz>.mp3`
+(public/audio é gitignorado; só script e roteiro entram no git).
+
+---
+
+## Lampião (`lampiao`)
+> Blurb: "Cangaço no gatilho. Quanto mais segura o tiro, mais dano faz — Virgem Maria!"
+
+**Direção de voz:** homem adulto, sotaque nordestino do sertão, voz seca e
+rouca de chefe de bando, autoridade teatral de cordel, meio cantado.
+
+| slug | fala |
+|---|---|
+| virgem-maria | "Virgem Maria! Aqui quem manda é o cangaço!" |
+| sertao | "No sertão, quem atira primeiro é quem conta a história." |
+| aceiro | "Avisa o teu bando: hoje tem fogo no aceiro!" |
+| chapeu | "Meu chapéu tem mais estrela que o teu time inteiro." |
+| arreda | "Arreda, moço! O cangaço passou aqui." |
+
+## Maria Bonita (`mariabonita`)
+> Blurb: "Cangaceira de precisão. Parou, mirou, acertou — a rainha do primeiro tiro."
+
+**Direção de voz:** mulher adulta, sotaque nordestino, calma e afiada, sorriso
+no canto da voz, confiança de quem nunca precisa do segundo tiro.
+
+| slug | fala |
+|---|---|
+| assina | "Parou, mirou, acertou. Assina embaixo: Maria." |
+| moda | "No cangaço, a moda sou eu — e a mira também." |
+| um-tiro | "Um tiro só, meu bem. Mais que isso é desperdício." |
+| costume | "Bonita é o nome. Certeira é o costume." |
+| avisar | "Atiro duas vezes: uma pra acertar, outra pra avisar." |
+
+## Saci-Pererê (`saci`)
+> Blurb: "Moleque de uma perna só. Redemoinho de fumaça e some — o gorro vermelho é hitbox."
+
+**Direção de voz:** moleque travesso, agudo, rápido, risadinha no fim, energia
+de pião de redemoinho.
+
+| slug | fala |
+|---|---|
+| redemoinho | "Cadê tua munição? Pergunta pro redemoinho!" |
+| uma-perna | "Uma perna só e ainda corro mais que tu!" |
+| atras | "Pega o gorro se puder... psiu — tô aqui atrás!" |
+| sumiu | "Virou o vento, virei eu — sumiu!" |
+| cadarco | "Teu cadarço desamarrou. Mentira! ... Ou será?" |
+
+## Curupira (`curupira`)
+> Blurb: "Menino de cabelo de fogo, pés virados. As pegadas apontam pro lado errado."
+
+**Direção de voz:** menino selvagem da mata, provocador, cadência meio cantada
+de quem brinca de esconde-esconde, assobio implícito.
+
+| slug | fala |
+|---|---|
+| pe-virado | "Pé virado, rastro errado — vem me achar!" |
+| pegada | "Seguindo minha pegada? Então tu já tá voltando pra casa." |
+| mata | "Quem mexe com a mata... se perde nela." |
+| cabelo-fogo | "Meu cabelo é fogo. Meu rastro é mentira." |
+| assobio | "Assobiei três vezes. Pronto: tu tá perdido." |
+
+## Cuca (`cuca`)
+> Blurb: "A bruxa de Lobato. Lança poção de lentidão e visão embaralhada — 'dorme com o medo'."
+
+**Direção de voz:** bruxa velha, voz rachada e arrastada, ameaça de canção de
+ninar, terror-comédia teatral, ritmo lento que acelera no bote.
+
+| slug | fala |
+|---|---|
+| dorme-nenem | "Dorme, neném... que a Cuca já chegou." |
+| cem-anos | "Eu não durmo há cem anos. Tu vai dormir agorinha." |
+| pocao | "Nana, nenê... a poção já tá no teu ar." |
+| feitico | "Bruxa aqui não faz feitiço de brincadeira, não." |
+| caverna | "Na minha caverna sempre cabe mais um." |
+
+## Boto Cor de Rosa (`boto`)
+> Blurb: "Golfinho rosa do Amazonas. Sai da cobertura, encanta a mira inimiga e responde de Deagle."
+
+**Direção de voz:** galã metido, voz aveludada e sedutora de festa ribeirinha,
+charme escorrendo, convencido até o osso.
+
+| slug | fala |
+|---|---|
+| chapeu | "Bonito é o chapéu. Melhor não perguntar o que tem embaixo." |
+| encantar | "Saí do rio só pra te encantar, meu bem." |
+| madrugada | "Dança comigo até de madrugada... depois eu volto pro fundo." |
+| rosa | "Rosa é a cor de quem nunca erra o alvo." |
+| charme | "O charme é meu, a mira era tua. Era." |
+
+## Lobisomem (`lobisomem`)
+> Blurb: "Sétimo filho, maldição da encruzilhada. O lobo preto acorda forte, dentuço e sem coleira."
+
+**Direção de voz:** homem adulto, voz grave e gutural com rosnado no fundo,
+lenta e pesada, prazer de caçador.
+
+| slug | fala |
+|---|---|
+| setimo | "Sétimo filho... primeira mordida." |
+| lua-cheia | "Lua cheia, arena cheia. Melhor pra caçar." |
+| coleira | "A coleira? Arrebentou faz tempo." |
+| cheiro | "Sente esse cheiro? É medo. E é teu." |
+| encruzilhada | "Na encruzilhada eu virei bicho. Tu vai virar placar." |
+
+## Bandeirante (`bandeirante`)
+> Blurb: "Caçador de pegadas. Vê onde o inimigo pisou — o vilão que o time tolera."
+
+**Direção de voz:** homem maduro, voz de cascalho, arrogância seca de velho
+explorador, deadpan — a sátira é a prepotência dele.
+
+| slug | fala |
+|---|---|
+| pegada | "Toda pegada conta uma história. A tua termina aqui." |
+| trilha | "Eu abro a trilha. Tu vira marco no caminho." |
+| mapa | "Mapa? Eu sou o mapa." |
+| vilao | "Vilão do time? Pode ser. Mas ninguém rastreia melhor." |
+| sinal | "Pisou no mato, deixou sinal. Já tô chegando." |
+
+## Zumbi dos Palmares (`zumbi`)
+> Blurb: "Capitão quilombola. O grito de Palmares ecoa e acelera a recarga dos aliados."
+
+**Direção de voz:** líder digno, voz grave, quente e ressonante, calma de
+comando, heroica — **sem caricatura, sem sotaque forçado**. Falas de coragem
+e liberdade.
+
+| slug | fala |
+|---|---|
+| palmares | "Palmares vive em cada passo meu." |
+| liberdade | "Liberdade não se pede. Se toma." |
+| juntos | "Comigo, ninguém luta sozinho." |
+| avanca | "O grito da serra ecoa: avança!" |
+| quilombo | "Cai a muralha. Não cai o quilombo." |

--- a/docs/docs/comecando.md
+++ b/docs/docs/comecando.md
@@ -50,7 +50,7 @@ esta página envelhecia no primeiro commit — ver
 | Mapas no registro | 13 | objeto `MAPS` de `maps.js` |
 | Arnêses visuais em HTML | 15 | `git ls-files 'public/*.html' \| wc -l` |
 | Scripts do arnês | 210 | `git ls-files 'tools/eval/*.mjs' 'tools/eval/*.py' \| wc -l` |
-| Scripts de pipeline | 57 | `git ls-files 'tools/*.mjs' \| wc -l` |
+| Scripts de pipeline | 58 | `git ls-files 'tools/*.mjs' \| wc -l` |
 | Tarefas de entrada escritas | 26 | `git ls-files 'docs/issues/[0-9]*.md' \| wc -l` |
 | Versão | `2.0.0-alpha.203` | `public/js/version.js` e `package.json` (batem) |
 

--- a/docs/docs/quality-gates.md
+++ b/docs/docs/quality-gates.md
@@ -15,7 +15,7 @@ PR (`.github/workflows/ci.yml`).
 {/* BEGIN:GERADO:invariantes — não edite à mão, rode `npm run docs` */}
 
 - `tools/eval/invariants.mjs`: **2.285 linhas**, **65 identificadores de invariante declarados** (`put()`), dos quais **28** têm caminho de `skip()` declarado.
-- O arnês inteiro são **210 scripts** em `tools/eval/` (`.mjs` + `.py`), mais **57 scripts** de pipeline em `tools/`.
+- O arnês inteiro são **210 scripts** em `tools/eval/` (`.mjs` + `.py`), mais **58 scripts** de pipeline em `tools/`.
 - Quantas invariantes rodam como **críticas** numa execução **não é derivável do fonte**: depende de qual insumo existe na máquina (o JSON do auditor de viewmodel, um GLB, uma pasta de anims). Esse número só sai rodando o quality gate — e o lugar dele é o cabeçalho do `KNOWN-BUGS.md`, atualizado com saída real.
 
 Reproduza:

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/comecando.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/comecando.md
@@ -52,7 +52,7 @@ this page was aging at the very first commit — see
 | Maps in the registry | 13 | `MAPS` object in `maps.js` |
 | Visual harnesses in HTML | 15 | `git ls-files 'public/*.html' \| wc -l` |
 | Harness scripts | 210 | `git ls-files 'tools/eval/*.mjs' 'tools/eval/*.py' \| wc -l` |
-| Pipeline scripts | 57 | `git ls-files 'tools/*.mjs' \| wc -l` |
+| Pipeline scripts | 58 | `git ls-files 'tools/*.mjs' \| wc -l` |
 | Written entry tasks | 26 | `git ls-files 'docs/issues/[0-9]*.md' \| wc -l` |
 | Version | `2.0.0-alpha.203` | `public/js/version.js` and `package.json` (match) |
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/quality-gates.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/quality-gates.md
@@ -18,7 +18,7 @@ PR (`.github/workflows/ci.yml`).
 {/* BEGIN:GERADO:invariantes — não edite à mão, rode `npm run docs` */}
 
 - `tools/eval/invariants.mjs`: **2,285 lines**, **65 declared invariant identifiers**, with **28** declared `skip()` paths.
-- The harness contains **210 scripts** in `tools/eval/`, plus **57 pipeline scripts** in `tools/`.
+- The harness contains **210 scripts** in `tools/eval/`, plus **58 pipeline scripts** in `tools/`.
 - The number of critical checks in one run depends on the inputs present on that machine; dated results belong in `KNOWN-BUGS.md`.
 
 ```bash

--- a/tools/gerar-vozes-miticos.mjs
+++ b/tools/gerar-vozes-miticos.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// Vozes TTS do Time Mítico via OpenRouter.
+// 2 tomadas por fala (vozes-base distintas) em public/audio/ia/miticos/<id>/
+// para o dono escolher no ouvido. public/audio é gitignorado — mp3 não entra no git.
+//
+// Uso:
+//   OPENROUTER_API_KEY=... node tools/gerar-vozes-miticos.mjs        # gera tudo
+//   node tools/gerar-vozes-miticos.mjs --dry                          # só lista
+//   node tools/gerar-vozes-miticos.mjs --so=saci,cuca                 # filtra personagens
+//   node tools/gerar-vozes-miticos.mjs --faltantes                    # só o que não existe em disco
+//
+// CAMINHO REAL (medido em 29/08): o endpoint /api/v1/audio/speech do OpenRouter
+// recusa os ids de TTS dedicado ("Model ... does not exist"). O que funciona é
+// /api/v1/chat/completions com modalities audio + stream:true, modelo
+// openai/gpt-audio-mini — e stream só aceita format pcm16, então o ffmpeg
+// converte pra mp3 local. Como é um chat-model, o framing do system prompt é
+// "TTS engine, leia VERBATIM" (sem isso ele moraliza a fala em vez de falar);
+// o transcript devolvido é conferido contra a linha e diverge ⇒ erro + re-tentativa.
+//
+// A instrução descreve ARQUÉTIPO (sotaque/energia/idade) — NUNCA imita pessoa
+// real. PT-BR, PEGI12. Roteiro versionado: docs/audio/ROTEIRO-VOZES-MITICOS.md.
+
+import { mkdir, writeFile, access, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const OUT = 'public/audio/ia/miticos';
+const MODEL = 'openai/gpt-audio-mini';
+
+// Cada personagem: instrução de voz (inglês, arquétipo) + 2 vozes-base + falas.
+const MITICOS = [
+  {
+    id: 'lampiao',
+    vozes: ['onyx', 'ash'],
+    instr: 'adult male, dry raspy northeastern Brazilian sertão accent, commanding cangaço bandit-chief energy, theatrical cordel-singer cadence, playful cartoon menace',
+    falas: [
+      ['virgem-maria', 'Virgem Maria! Aqui quem manda é o cangaço!'],
+      ['sertao', 'No sertão, quem atira primeiro é quem conta a história.'],
+      ['aceiro', 'Avisa o teu bando: hoje tem fogo no aceiro!'],
+      ['chapeu', 'Meu chapéu tem mais estrela que o teu time inteiro.'],
+      ['arreda', 'Arreda, moço! O cangaço passou aqui.'],
+    ],
+  },
+  {
+    id: 'mariabonita',
+    vozes: ['coral', 'shimmer'],
+    instr: 'adult female, northeastern Brazilian accent, calm and razor-sharp, a smile at the edge of the voice, cool confidence of a sharpshooter who never needs a second shot',
+    falas: [
+      ['assina', 'Parou, mirou, acertou. Assina embaixo: Maria.'],
+      ['moda', 'No cangaço, a moda sou eu — e a mira também.'],
+      ['um-tiro', 'Um tiro só, meu bem. Mais que isso é desperdício.'],
+      ['costume', 'Bonita é o nome. Certeira é o costume.'],
+      ['avisar', 'Atiro duas vezes: uma pra acertar, outra pra avisar.'],
+    ],
+  },
+  {
+    id: 'saci',
+    vozes: ['echo', 'verse'],
+    instr: 'mischievous young boy trickster, high-pitched and fast, giggly whirlwind energy, teasing hide-and-seek tone, a hint of laughter at the end of lines',
+    falas: [
+      ['redemoinho', 'Cadê tua munição? Pergunta pro redemoinho!'],
+      ['uma-perna', 'Uma perna só e ainda corro mais que tu!'],
+      ['atras', 'Pega o gorro se puder... psiu — tô aqui atrás!'],
+      ['sumiu', 'Virou o vento, virei eu — sumiu!'],
+      ['cadarco', 'Teu cadarço desamarrou. Mentira! ... Ou será?'],
+    ],
+  },
+  {
+    id: 'curupira',
+    vozes: ['fable', 'echo'],
+    instr: 'wild forest-guardian boy, taunting sing-song cadence like a hide-and-seek game, feral playful energy, slightly eerie confidence of someone who owns the woods',
+    falas: [
+      ['pe-virado', 'Pé virado, rastro errado — vem me achar!'],
+      ['pegada', 'Seguindo minha pegada? Então tu já tá voltando pra casa.'],
+      ['mata', 'Quem mexe com a mata... se perde nela.'],
+      ['cabelo-fogo', 'Meu cabelo é fogo. Meu rastro é mentira.'],
+      ['assobio', 'Assobiei três vezes. Pronto: tu tá perdido.'],
+    ],
+  },
+  {
+    id: 'cuca',
+    vozes: ['sage', 'ballad'],
+    instr: 'ancient cartoon witch, cracked slow drawling voice, menacing lullaby cadence that speeds up on the pounce, theatrical horror-comedy, croaky and gleeful',
+    falas: [
+      ['dorme-nenem', 'Dorme, neném... que a Cuca já chegou.'],
+      ['cem-anos', 'Eu não durmo há cem anos. Tu vai dormir agorinha.'],
+      ['pocao', 'Nana, nenê... a poção já tá no teu ar.'],
+      ['feitico', 'Bruxa aqui não faz feitiço de brincadeira, não.'],
+      ['caverna', 'Na minha caverna sempre cabe mais um.'],
+    ],
+  },
+  {
+    id: 'boto',
+    vozes: ['ash', 'verse'],
+    instr: 'adult male heartthrob, velvety seductive voice of an Amazonian river-party charmer, smooth and self-satisfied, dripping charm, light northern Brazilian accent',
+    falas: [
+      ['chapeu', 'Bonito é o chapéu. Melhor não perguntar o que tem embaixo.'],
+      ['encantar', 'Saí do rio só pra te encantar, meu bem.'],
+      ['madrugada', 'Dança comigo até de madrugada... depois eu volto pro fundo.'],
+      ['rosa', 'Rosa é a cor de quem nunca erra o alvo.'],
+      ['charme', 'O charme é meu, a mira era tua. Era.'],
+    ],
+  },
+  {
+    id: 'lobisomem',
+    vozes: ['onyx', 'ash'],
+    instr: 'adult male, deep guttural voice with a growl underneath, slow and heavy, predatory relish kept playful cartoon-monster style',
+    falas: [
+      ['setimo', 'Sétimo filho... primeira mordida.'],
+      ['lua-cheia', 'Lua cheia, arena cheia. Melhor pra caçar.'],
+      ['coleira', 'A coleira? Arrebentou faz tempo.'],
+      ['cheiro', 'Sente esse cheiro? É medo. E é teu.'],
+      ['encruzilhada', 'Na encruzilhada eu virei bicho. Tu vai virar placar.'],
+    ],
+  },
+  {
+    id: 'bandeirante',
+    vozes: ['onyx', 'echo'],
+    instr: 'mature male, gravelly voice, dry arrogant deadpan of an old expedition tracker, self-important and unhurried — the satire targets his own smugness',
+    falas: [
+      ['pegada', 'Toda pegada conta uma história. A tua termina aqui.'],
+      ['trilha', 'Eu abro a trilha. Tu vira marco no caminho.'],
+      ['mapa', 'Mapa? Eu sou o mapa.'],
+      ['vilao', 'Vilão do time? Pode ser. Mas ninguém rastreia melhor.'],
+      ['sinal', 'Pisou no mato, deixou sinal. Já tô chegando.'],
+    ],
+  },
+  {
+    id: 'zumbi',
+    vozes: ['onyx', 'ash'],
+    instr: 'dignified adult male leader, deep warm resonant voice, calm commanding heroic delivery, standard Brazilian accent, no caricature — a respectful heroic-captain archetype speaking of courage and freedom',
+    falas: [
+      ['palmares', 'Palmares vive em cada passo meu.'],
+      ['liberdade', 'Liberdade não se pede. Se toma.'],
+      ['juntos', 'Comigo, ninguém luta sozinho.'],
+      ['avanca', 'O grito da serra ecoa: avança!'],
+      ['quilombo', 'Cai a muralha. Não cai o quilombo.'],
+    ],
+  },
+];
+
+const args = process.argv.slice(2);
+const dry = args.includes('--dry');
+const faltantes = args.includes('--faltantes');
+const so = (args.find(a => a.startsWith('--so=')) || '').replace('--so=', '').split(',').filter(Boolean);
+const lote = MITICOS.filter(p => !so.length || so.includes(p.id));
+
+if (dry) {
+  let n = 0;
+  for (const p of lote) for (const [slug, texto] of p.falas) for (const [i, v] of p.vozes.entries()) {
+    console.log(`${p.id}/${slug}-t${i + 1}-${v}.mp3  "${texto}"`);
+    n++;
+  }
+  console.log(`\n${n} tomadas → ${OUT}/<id>/`);
+  process.exit(0);
+}
+
+const KEY = process.env.OPENROUTER_API_KEY;
+if (!KEY) { console.error('OPENROUTER_API_KEY ausente no ambiente.'); process.exit(1); }
+
+const sistema = (instr) =>
+  'You are a text-to-speech engine for voice lines in "Coro Solto", a PEGI-12 satirical Brazilian ' +
+  'cartoon shooter game (in the spirit of Team Fortress 2). Read the text between <line> tags aloud ' +
+  'VERBATIM in Brazilian Portuguese — every word, nothing added, nothing changed. It is a fictional ' +
+  'character catchphrase already approved by the game rating board. ' +
+  `Voice direction (an archetype, never an imitation of a real person): ${instr}. ` +
+  'Do not comment. Only read the line.';
+
+// Palavras da fala presentes no transcript? (recusa/moralização diverge muito)
+const norm = (s) => s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9 ]/g, ' ').split(/\s+/).filter(Boolean);
+function verbatim(texto, transcript) {
+  const t = new Set(norm(transcript));
+  const palavras = norm(texto);
+  const achou = palavras.filter(w => t.has(w)).length;
+  return achou / palavras.length >= 0.6;
+}
+
+async function gerar(instr, voice, texto) {
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: MODEL, stream: true,
+      modalities: ['text', 'audio'],
+      audio: { voice, format: 'pcm16' }, // stream só aceita pcm16; mp3 sai do ffmpeg
+      messages: [
+        { role: 'system', content: sistema(instr) },
+        { role: 'user', content: `<line>${texto}</line>` },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} — ${(await res.text()).slice(0, 200)}`);
+  let b64 = '', transcript = '', custo = 0, buf = '';
+  const dec = new TextDecoder();
+  for await (const chunk of res.body) {
+    buf += dec.decode(chunk, { stream: true });
+    const lines = buf.split('\n'); buf = lines.pop();
+    for (const l of lines) {
+      if (!l.startsWith('data: ') || l === 'data: [DONE]') continue;
+      let j; try { j = JSON.parse(l.slice(6)); } catch { continue; }
+      if (j.usage?.cost) custo = j.usage.cost;
+      const d = j.choices?.[0]?.delta;
+      if (d?.audio?.data) b64 += d.audio.data;
+      if (d?.audio?.transcript) transcript += d.audio.transcript;
+    }
+  }
+  const pcm = Buffer.from(b64, 'base64');
+  if (pcm.length < 8000) throw new Error(`áudio vazio (${pcm.length} B) — transcript: "${transcript.slice(0, 120)}"`);
+  if (!verbatim(texto, transcript)) throw new Error(`não-verbatim — transcript: "${transcript.slice(0, 120)}"`);
+  return { pcm, custo };
+}
+
+function pcmParaMp3(pcm, destino) {
+  return new Promise((resolve, reject) => {
+    const ff = spawn('ffmpeg', ['-y', '-loglevel', 'error', '-f', 's16le', '-ar', '24000', '-ac', '1', '-i', '-', '-b:a', '96k', destino]);
+    let err = '';
+    ff.stderr.on('data', d => { err += d; });
+    ff.on('close', c => c === 0 ? resolve() : reject(new Error(`ffmpeg saiu ${c}: ${err.slice(0, 150)}`)));
+    ff.stdin.end(pcm);
+  });
+}
+
+let ok = 0, erro = 0, pulado = 0, custoTotal = 0;
+const falhas = [];
+for (const p of lote) {
+  const dir = join(OUT, p.id);
+  await mkdir(dir, { recursive: true });
+  for (const [slug, texto] of p.falas) {
+    for (const [i, voice] of p.vozes.entries()) {
+      const nome = `${slug}-t${i + 1}-${voice}.mp3`;
+      const destino = join(dir, nome);
+      if (faltantes && await access(destino).then(() => true, () => false)) { pulado++; continue; }
+      let feito = false, err = null;
+      for (let tentativa = 1; tentativa <= 2 && !feito; tentativa++) {
+        try {
+          const { pcm, custo } = await gerar(p.instr, voice, texto);
+          await pcmParaMp3(pcm, destino);
+          custoTotal += custo;
+          feito = true;
+        } catch (e) {
+          err = e;
+          await unlink(destino).catch(() => {});
+          if (tentativa === 1) await new Promise(r => setTimeout(r, 2000));
+        }
+      }
+      if (!feito) {
+        erro++;
+        falhas.push(`${p.id}/${nome}`);
+        console.error(`✗ ${p.id}/${nome}: ${err.message}`);
+        continue;
+      }
+      ok++;
+      console.log(`✓ ${p.id}/${nome}`);
+    }
+  }
+}
+console.log(`\n${ok} geradas, ${erro} erros${pulado ? `, ${pulado} puladas` : ''} → ${OUT}/`);
+console.log(`Custo reportado pela API: US$ ${custoTotal.toFixed(4)}`);
+if (falhas.length) console.log(`Falhas (re-rode com --faltantes): ${falhas.join(', ')}`);
+process.exit(erro ? 1 : 0);


### PR DESCRIPTION
45 falas de ingame para os 9 personagens do Time Mítico (Lampião, Maria Bonita, Saci-Pererê, Curupira, Cuca, Boto Cor de Rosa, Lobisomem, Bandeirante, Zumbi dos Palmares), com direção de voz por arquétipo — nunca imitação de pessoa real — e gerador TTS via OpenRouter.

- `docs/audio/ROTEIRO-VOZES-MITICOS.md`: roteiro versionado (personagem → falas → direção de voz). Zumbi dos Palmares tratado com dignidade: falas de coragem/liberdade, sem caricatura.
- `tools/gerar-vozes-miticos.mjs`: 2 tomadas por fala com vozes-base distintas → `public/audio/ia/miticos/<id>/` (gitignorado; mp3 não entra no git).

Caminho técnico (medido): o endpoint `/api/v1/audio/speech` do OpenRouter não expõe os modelos de TTS dedicado; o gerador usa `/api/v1/chat/completions` com `modalities: audio` + `stream: true` (modelo `openai/gpt-audio-mini`), recebe pcm16 e converte pra mp3 via ffmpeg. Framing verbatim no system prompt + verificação do transcript devolvido (sem isso o chat-model moraliza a fala) e re-tentativa por item.

https://claude.ai/code/session_01UkPGcWL7D4vXYZMbnZJV9c