### PR TITLE
feat(audio): pack v8 — vozes do time Mítico e upgrade dos funkeiros

### DIFF
--- a/scripts/build-audio-pack.mjs
+++ b/scripts/build-audio-pack.mjs
@@ -42,7 +42,12 @@ const hashNome = (rel) => {
   return novo;
 };
 const reescreve = (o) => {
-  if (Array.isArray(o)) return o.map((v) => (typeof v === 'string' && v.startsWith('audio/') ? hashNome(v) : v));
+  // String em QUALQUER posição (array OU valor de objeto). Antes só o caso de array
+  // era coberto: `characterVoice.<id>` é string solta e passava reto sem hashear nem
+  // copiar — o manifest do zip apontava pra um caminho que não estava no zip. Foi a
+  // classe do arquivo faltando do v7; o probe refs×zip do v8 pegou de novo (30/08).
+  if (typeof o === 'string') return o.startsWith('audio/') ? hashNome(o) : o;
+  if (Array.isArray(o)) return o.map(reescreve);
   if (o && typeof o === 'object') { const r = {}; for (const [k, v] of Object.entries(o)) r[k] = reescreve(v); return r; }
   return o;
 };

--- a/scripts/fetch-audio.sh
+++ b/scripts/fetch-audio.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$0")/.."
 # Pacote completo — vozes/rounds/SFX/menu/ingame — com nomes hasheados
 # (decisão do dono: nenhum título legível em URL/zip). Fecha o BUG-19
 # (produção servia o pack de julho e todo som novo dava 404).
-URL="${AUDIO_PACK_URL:-https://github.com/corosolto/client/releases/download/audio-pack-v7/audio-pack.zip}"
+URL="${AUDIO_PACK_URL:-https://github.com/corosolto/client/releases/download/audio-pack-v8/audio-pack.zip}"
 DEST="public/audio"
 
 if [ -f "$DEST/manifest.json" ]; then

--- a/tools/eval/character-select-voice-check.mjs
+++ b/tools/eval/character-select-voice-check.mjs
@@ -41,8 +41,8 @@ expect(!/characterSelectVoice/.test(selectBody),
   'VOICE3 selectChar fala durante a montagem automática da tela');
 expect(!/row\?\.click\(\)/.test(main),
   'VOICE4 a query string simula clique humano e dispara fala');
-expect(/releases\/download\/audio-pack-v7\/audio-pack\.zip/.test(fetchAudio),
-  'VOICE12 o build não baixa o pacote com a voz corrigida do Faria Limer (e o menu Suno do v7)');
+expect(/releases\/download\/audio-pack-v8\/audio-pack\.zip/.test(fetchAudio),
+  'VOICE12 o build não baixa o pacote com as vozes do time Mítico e o upgrade dos funkeiros (v8; inclui o Faria Limer corrigido e o menu Suno do v7)');
 
 globalThis.location ||= { search: '' };
 const { Sfx } = await import('../../public/js/audio.js');


### PR DESCRIPTION
Publica o **release audio-pack-v8** e aponta o build pra ele.

## O que tem no v8 (= v7 intacto + adições)
- **Pool `voice.M`: 56** — kill-shouts dos 8 falantes do Time Mítico (Lampião e Maria Bonita no Fish Audio; Saci/Curupira/Cuca/Boto/Bandeirante/Zumbi no ElevenLabs) + 8 sons de lobo do Lobisomem (Sound Effects; ele não fala).
- **`characterVoice`: 18** (era 6) — falas de SELEÇÃO dos 8 míticos (lobisomem não tem, por design) + funkraiz (substituída, decisão do dono)/trapfunk/oakley/mandrake/pagodeiro.
- **Pool F: 45→69** (upgrade aditivo dos funkeiros — nada removido; o v7 listava 1 ref duplicada, que agora entra 1×) e **pool U: 11→15** (kills do Pagodeiro, time dele).
- menuMusic 26 e soundtrack 30 intactos.

## Mudanças de código
- `scripts/fetch-audio.sh`: v7→v8.
- `tools/eval/character-select-voice-check.mjs`: VOICE12 repinada no v8.
- **fix `scripts/build-audio-pack.mjs`**: `reescreve()` só hasheava string dentro de array — `characterVoice.<id>` (string em valor de objeto) passava sem copiar e o manifest do zip apontava pra fora do zip (a classe do arquivo faltando do v7). O probe refs×zip pegou 18 faltando; após o fix, **0 faltando**.

## Validação
- Auditoria do zip: 416 refs × namelist → **0 faltando**; m01..m26 presentes.
- Fetch em dir limpo com `AUDIO_PACK_URL` do v8: menuMusic 26, voice.M 56, voice.F 69, characterVoice 18, 0 refs sem arquivo no disco.

## ⚠ Dependência do #481
A main ainda **não tem `FACTIONS['M']`** no jogo: o pool `M` do manifest é chave extra ignorada (inofensiva). **As vozes do Time Mítico só passam a tocar quando o #481 (merge/399) mergear.** As characterVoice novas dos míticos também só são usadas quando os personagens M entrarem no roster.

Roteiros/geradores das vozes: PR #486. Proveniência (modelos e ids por personagem): local, `~/Music/PROVENANCE-v8.md` — sem áudio no git.

https://claude.ai/code/session_01UkPGcWL7D4vXYZMbnZJV9c