### PR TITLE
fix: keep prod watch green during legitimate player idle

### DIFF
--- a/.github/workflows/prod-watch.yml
+++ b/.github/workflows/prod-watch.yml
@@ -69,7 +69,11 @@ jobs:
           const response = await fetch('https://www.csbrasil.online/api/health');
           const body = await response.json().catch(() => ({}));
           console.log(JSON.stringify(body));
-          if (!response.ok || body.database !== true || body.telemetrySchema !== true || body.fresh !== true) {
+          // perf/match/city dependem de gente jogando e podem ficar ociosos legitimamente.
+          // operationalFresh cobre o heartbeat de máquina (multiplayer, a cada 5 min).
+          // O fresh geral continua no log para diagnóstico, mas não cria incidente sem tráfego.
+          if (body.fresh !== true) console.warn('pipelines humanos sem atividade recente:', body.stale ?? []);
+          if (!response.ok || body.database !== true || body.telemetrySchema !== true || body.operationalFresh !== true) {
             process.exit(1);
           }
           NODE


### PR DESCRIPTION
## Resumo
- mantém a visibilidade dos pipelines humanos sem tratá-los como indisponibilidade
- usa o novo campo operacional da API como gate do monitor contínuo
- preserva falha fechada para banco, schema e telemetria multiplayer

## Validação
- npm run check:deploy — 36/36
- eval:wfsecret e eval:deploygate verdes
- API de produção: operationalFresh=true, operationalStale=[]

Backend correspondente: corosolto/backend#9