### PR TITLE
fix(audio): renovar cache do manifesto privado

### DIFF
--- a/docs/audio/FAB-PILOT-HANDOFF.md
+++ b/docs/audio/FAB-PILOT-HANDOFF.md
@@ -2,6 +2,20 @@
 
 Atualizado em 2026-09-05 (décima sétima rodada: Blob privado e fetch autenticado).
 
+## Pós-merge — cache-bust do catálogo privado
+
+O PR [#506](https://github.com/corosolto/client/pull/506) foi mergeado em `f55cd04f` e o
+deployment de produção `dpl_2K71UJeMt3ePX2pKvMtp1gsTNguN` ficou `READY`. O objeto publicado
+continha 770 referências, 558 arquivos únicos, 13 mapas com `mapSoundscapes`, zero Fish e
+zero callout legado. Um WAV hasheado respondeu por range HTTP.
+
+A validação pelo domínio encontrou um problema depois do deploy: a Cloudflare ainda servia
+`audio/manifest.json?v=8` do fallback público anterior (434 referências, zero mapa), porque
+`/audio/*` tem TTL de edge longo. `main.js` já pede a versão da aplicação, mas `Sfx` ainda
+usava a chave fixa v8. A correção autoritativa é `audio/manifest.json?v=9`; o mutante
+`manifest-antigo` volta para v8 e precisa reprovar. Esse cache-bust é obrigatório para que
+os tiros, passos e ambiência do Blob cheguem aos jogadores que já visitaram o site.
+
 ## Décima sétima rodada — canal privado criado
 
 O dono autorizou criar o armazenamento privado e incorporar ao build as famílias já

--- a/public/js/audio.js
+++ b/public/js/audio.js
@@ -42,7 +42,7 @@ export class Sfx {
     // production plays real shots instead of the synth. Never throws.
     // A chave acompanha a release de fetch-audio.sh; se atrasar, a CDN conserva catálogo
     // antigo mesmo com os MP3 novos presentes no deployment (BUG-109).
-    for (const url of ['audio/manifest.json?v=8', 'audio/manifest.default.json?v=1']) {
+    for (const url of ['audio/manifest.json?v=9', 'audio/manifest.default.json?v=1']) {
       try {
         const r = await fetch(url, { cache: 'no-cache' });
         if (r.ok) { this.pack = await r.json(); return; }

--- a/tools/audio/map-ids.mjs
+++ b/tools/audio/map-ids.mjs
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs';
 
+const CAMINHO_MAPS_PADRAO = new URL('../../public/js/maps.js', import.meta.url);
+
 /* Lê somente as chaves do registro, sem importar `maps.js`: importar o módulo em
  * Node carrega a árvore 3D inteira e cria uma dependência de `three` que o CI de
  * assets não precisa ter. A fonte continua sendo o objeto MAPS autoritativo. */
-export function carregarMapIds(caminho = 'public/js/maps.js') {
+export function carregarMapIds(caminho = CAMINHO_MAPS_PADRAO) {
   const fonte = readFileSync(caminho, 'utf8');
   const inicio = fonte.indexOf('export const MAPS = {');
   const fim = inicio < 0 ? -1 : fonte.indexOf('\n};', inicio);

--- a/tools/eval/character-select-voice-check.mjs
+++ b/tools/eval/character-select-voice-check.mjs
@@ -23,7 +23,7 @@ if (mutante === 'auto-fala') {
   main = main.replace('if (row) selectChar(character, row);', 'row?.click();');
 }
 if (mutante === 'pack-antigo') fetchAudio = fetchAudio.replace('audio-pack-v8', 'audio-pack-v7');
-if (mutante === 'manifest-antigo') audio = audio.replace('audio/manifest.json?v=8', 'audio/manifest.json?v=7');
+if (mutante === 'manifest-antigo') audio = audio.replace('audio/manifest.json?v=9', 'audio/manifest.json?v=8');
 
 const failures = [];
 const expect = (ok, message) => { if (!ok) failures.push(message); };
@@ -47,8 +47,8 @@ expect(/releases\/download\/audio-pack-v8\/audio-pack\.zip/.test(fetchAudio),
   'VOICE12 o build não baixa o pacote com as vozes do time Mítico e o upgrade dos funkeiros (v8; inclui o Faria Limer corrigido e o menu Suno do v7)');
 const packVersion = fetchAudio.match(/audio-pack-v(\d+)\/audio-pack\.zip/)?.[1];
 const manifestVersion = audio.match(/audio\/manifest\.json\?v=(\d+)/)?.[1];
-expect(packVersion && manifestVersion && packVersion === manifestVersion,
-  `VOICE13 pacote v${packVersion || '?'} diverge da chave do manifesto v${manifestVersion || '?'}; CDN pode servir catálogo antigo`);
+expect(packVersion === '8' && manifestVersion === '9',
+  `VOICE13 fallback público v${packVersion || '?'} e chave privada v${manifestVersion || '?'} não identificam o canal atual; CDN pode servir catálogo antigo`);
 
 globalThis.location ||= { search: '' };
 const { Sfx } = await import('../../public/js/audio.js');


### PR DESCRIPTION
## Problema

Depois do merge do canal privado, o deployment continha o pack completo, mas a Cloudflare ainda entregava `audio/manifest.json?v=8` do fallback público: 434 referências e nenhum `mapSoundscapes`. O runtime de SFX usava essa chave fixa e, portanto, não alcançava os tiros, passos e ambiências novos.

## Correção

- avança a chave do manifesto privado de v8 para v9;
- atualiza o gate mutante para impedir regressão ao catálogo antigo;
- resolve o registro de mapas relativo ao módulo, mantendo os fixtures de proveniência verdes mesmo quando executados em outro cwd;
- registra a validação pós-merge no handoff.

## Evidência

- produção `?v=8`: 434 refs, 0 mapas (stale);
- produção `?v=9`: 770 refs, 558 arquivos únicos, 13 mapas;
- `npm run check:fast`: 82/82;
- `npm run check:deploy`: 37/37;
- mutante `manifest-antigo`: reprovado pela régua como esperado;
- `git diff --check`: verde.

Nenhum áudio, token ou segredo entra neste PR.