### PR TITLE
fix(bots): respeitar alcance real da faca

### DIFF
--- a/KNOWN-BUGS.md
+++ b/KNOWN-BUGS.md
@@ -1995,7 +1995,7 @@ contrário — HS1 câmera parada (teto 0,250 m / 0,250 rad / 0,5°), HS2 relóg
 Δ0,000 rad, ΔFOV 0,000°, 2,000 s de jogo em 2,000 s reais. **Mutantes:** `orbita`,
 `hitstop`, `esconde` e `sem-kill` — os quatro reprovam.
 
-### ~~BUG-143 · em rodada de faca o bot carregava a faca e jogava de fuzil~~ · CORRIGIDO LOCALMENTE 06/09/2026
+### ~~BUG-143 · em rodada de faca o bot carregava a faca e jogava de fuzil~~ · CORRIGIDO; ALCANCE REFINADO 10/09/2026
 
 **Relato do dono (06/09):** em rodadas de faca, os bots precisam respeitar o modo.
 
@@ -2015,14 +2015,21 @@ o alcance, `approach` nunca negativo) e o gate de ataque roteia para `_botMelee`
 alcance, ângulo, LOS e dano tocando `sfx.knife()`/`sfx.knifeHit()`. Fora do corpo a corpo a
 banda de fuzil não mudou.
 
+**Auditoria pós-merge (10/09):** o contato funcionava, mas `inRange` e `_botMelee` ainda
+somavam uma margem escondida de **0,60 m** ao `WEAPONS.knife.range`: 13 golpes da semente
+canônica passaram de 2,48 m e o máximo observado foi **2,98 m** para uma arma declarada com
+2,40 m. A margem foi removida nos dois gates. O mesmo cenário continua com 17 golpes/8
+abates e máximo de 2,40 m; numa matriz 8×8 de 45 s pelos 16 mapas, foram 657 golpes/301
+abates, nenhuma arma errada e nenhum golpe acima de 2,40 m.
+
 **Depois (mesma semente):** encostou a **1,24 m**, **18 golpes**, **9 abates**, **0
 traçantes e 0 fogachos**; rodada normal intacta (menor distância **23,46 m**).
 
-**Régua:** `tools/eval/botfaca-check.mjs` (`npm run eval:botfaca`) — BF1 faca na mão, BF2
-perseguição e combate, BF3 sem enfeite de arma de fogo, BF4 a rodada normal não vira corrida
-(piso de 4 m, derivado do `dist < 6 ? 'back'` da própria banda). **Mutantes:** `recuo`
-(5,40 m, zero golpes), `tracante` (18 traçantes/18 fogachos) e `corredor` (rodada normal
-colando a 2,87 m) — os três reprovam.
+**Régua:** `tools/eval/botfaca-check.mjs` (`npm run eval:botfaca`) — BF1 faca na mão e troca
+manual bloqueada, BF2 perseguição/combate, BF3 contato dentro de 2,40 m sem enfeite de arma
+de fogo, BF4 rodada normal preservada e BF5 reset de rodada/inventário/contadores. Além dos
+mutantes `recuo`, `tracante` e `corredor`, `alcance` devolve os 0,60 m e `troca` tenta equipar
+AWP no modo só faca; os cinco reprovam.
 
 ### ~~BUG-144 · o jogador não conseguia ler os próprios abates durante a partida~~ · CORRIGIDO LOCALMENTE 06/09/2026
 

--- a/docs/reports/BOTS-FACA-AUTORIDADE-R2.md
+++ b/docs/reports/BOTS-FACA-AUTORIDADE-R2.md
@@ -1,0 +1,154 @@
+# Bots em rodada de faca e autoridade de combate — R2
+
+Data: 10/09/2026  
+Worktree: `worktrees/bot-knife-round-r2`  
+Branch: `codex/bot-knife-round-r2`  
+Base cliente: `origin/main@2115d5e2c29eefb4491ae63b0f1600c200a750bb` (`v2.0.0-alpha.246`)  
+Backend auditado sem edição: `corosolto/backend origin/main@17ebd8fb28f15b34a9379f9e8210aeae4633b7b3`
+
+## Objetivo e definição de pronto
+
+Reproduzir o feedback sobre bots em rodada de faca e verificar seleção de arma, perseguição,
+distância de ataque, troca indevida, objetivos CTF, virada de rodada, reconexão e contadores.
+Pronto exige defeito causal medido, mutante que o devolva, correção mínima, ausência de
+regressão em armas normais/CTF/netcode e instrução local reproduzível. Esta lane não altera
+viewmodels, materiais, mapas, banco, deploy ou produção.
+
+## Diagnóstico
+
+A correção de 06/09 já funciona: em `praca_poderes`, seed 4242, 4×4 e 60 s, os bots fecham
+distância, usam `knife`, não geram traçante/fogacho/som de tiro e conseguem abates. A matriz
+8×8 também não encontrou bot parado em nenhum dos 16 mapas.
+
+O defeito residual estava na distância. `WEAPONS.knife.range` declara **2,40 m**, mas os dois
+gates do ataque do bot aceitavam `alcance + 0.6`. Antes da correção, a régua fortalecida ficou
+vermelha com **13 golpes fora do máximo de 2,48 m** e pico de **2,98 m**. O jogador não recebe
+essa margem em `_meleeHit`, portanto o bot tinha 25% mais alcance.
+
+A troca manual indevida já está bloqueada por `_switchWeapon` + `_pickupAllowed`; o mutante
+`troca` demonstra que BF1 detecta a regressão. BF5 agora prende também a virada: todos seguem
+com faca, `roundKills` zera, `matchKills` recebe o round uma vez, abates individuais persistem
+e nenhum rack/drop de arma aparece.
+
+## Correção
+
+`public/js/game.js` usa agora o alcance declarado sem margem tanto no gate que permite atacar
+quanto em `_botMelee`. Não mudou velocidade, pathfinding, dano, cadência, hitbox, modo normal,
+CTF ou código visual.
+
+`tools/eval/botfaca-check.mjs` passou a cobrar:
+
+- BF1: player e bots com faca, slots de arma proibida recusados;
+- BF2: perseguição, contato, golpes e abates;
+- BF3: golpe no máximo a 2,48 m (2,40 m + 8 cm de discretização), sem FX de tiro;
+- BF4: histerese de fuzil preservada no modo normal;
+- BF5: arma, inventário e contadores corretos após `_startRound`.
+
+Mutantes negativos: `recuo`, `tracante`, `corredor`, `alcance` e `troca`.
+
+## Evidência 8×8 em todos os mapas
+
+Cada cenário rodou 45 s virtuais a 60 Hz, seed 4242, qualidade baixa, 8×8, modo `knife`.
+
+| Mapa | Contato mínimo | Golpes | Abates | Golpe máximo | Arma errada |
+|---|---:|---:|---:|---:|---:|
+| amazonia | 1,22 m | 34 | 15 | 2,36 m | 0 |
+| escadao | 1,24 m | 51 | 24 | 2,37 m | 0 |
+| praca_poderes | 1,21 m | 25 | 12 | 2,37 m | 0 |
+| piscina_treta | 1,20 m | 62 | 31 | 2,40 m | 0 |
+| loja_h | 1,22 m | 28 | 12 | 2,36 m | 0 |
+| ferro_velho | 1,20 m | 68 | 32 | 2,38 m | 0 |
+| quebrada | 1,23 m | 31 | 13 | 2,36 m | 0 |
+| corrego | 1,14 m | 36 | 15 | 2,39 m | 0 |
+| lajes | 1,23 m | 28 | 12 | 2,36 m | 0 |
+| posto_treta | 1,18 m | 53 | 26 | 2,37 m | 0 |
+| upa_24h | 1,24 m | 39 | 18 | 2,38 m | 0 |
+| obras_prefeitura | 1,21 m | 50 | 23 | 2,39 m | 0 |
+| atacadao_treta | 1,22 m | 40 | 18 | 2,39 m | 0 |
+| parque_treta | 1,19 m | 42 | 19 | 2,40 m | 0 |
+| velho_oeste | 1,24 m | 34 | 15 | 2,38 m | 0 |
+| penitenciaria | 1,21 m | 36 | 16 | 2,40 m | 0 |
+
+Total: **657 golpes, 301 abates, 0 armas erradas, máximo 2,40 m**.
+
+## Objetivos CTF
+
+Uma sonda adicional rodou 8×8/90 s em modo faca. Bots chegaram aos anéis em todos os cinco
+mapas representativos e produziram progresso/capturas reais:
+
+| Mapa | Caps E/B máximos | Pontos com dono | Menor distância de ponto |
+|---|---:|---:|---:|
+| amazonia | 1/1 | 2 | 0,09 m |
+| escadao | 3/1 | 4 | 0,24 m |
+| piscina_treta | 2/2 | 3 | 0,28 m |
+| ferro_velho | 2/4 | 4 | 0,05 m |
+| penitenciaria | 1/2 | 3 | 0,25 m |
+
+## Autoridade, reconexão e contadores
+
+O multiplayer não oferece atualmente uma configuração `knife-only`: as salas autoritativas
+expõem `rounds` ou `ctf` e usam arsenal normal. Portanto não foi criada uma semântica nova de
+“rodada de faca” no servidor nesta lane.
+
+No backend atual, o contrato de arma já é autoritativo em protocolo v4. `Room.applyInput`
+aceita troca apenas dentro de `_inventory`; pickup exige rack/drop válido e distância; o
+snapshot devolve arma, slots, pente, reserva, recarga e `ackSeq`. O mutante
+`--mutante=confiar-arma` devolve a confiança no id enviado pelo cliente e é detectado.
+
+Resultados pareando backend `17ebd8f` com cliente `2115d5e2`:
+
+- `eval:authority`: 15/15; mutante de confiança detectado;
+- `eval:mp-rounds`: 10/10;
+- `eval:eventos`: 28/28;
+- `game/smoke.mjs`: 86/86, incluindo slot abandonado devolvido à IA, morte/respawn do mesmo
+  jogador, apelido preservado e snapshot ainda marcado como humano;
+- `eval:netcode`: 178/178 no cliente, incluindo kills individuais vindos do snapshot,
+  transições de round, troca de vaga e reconexão;
+- `eval:netcodecbin`: 18/18.
+
+Não houve alteração no backend.
+
+No cliente, `npm run build` terminou com `[build] Complete!`, `check:deploy` passou **39/39**,
+`eval:abateshud` e seus quatro mutantes ficaram corretos, `eval:ctfround`/`eval:ctfwin`
+passaram nos 16 mapas e `eval:botsim-golden` preservou `velho_oeste`, `upa_24h` e
+`piscina_treta`.
+
+## Como testar localmente
+
+```bash
+cd /Volumes/Zenith/Projects/game/corosolto/csbrasil/worktrees/bot-knife-round-r2
+export PATH=/opt/homebrew/bin:/Users/ruben/.bun/bin:$PATH
+npm ci
+npm run dev -- --host 127.0.0.1 --port 4407
+```
+
+Abrir `http://127.0.0.1:4407/`, escolher **Single Player**, configurar **SÓ FACA** e 8×8.
+Verificar: todos nascem com faca; 1/2 não equipa arma; bots perseguem até contato, golpeiam
+sem traçante/fogacho, continuam lutando após respawn e mantêm o comportamento após a próxima
+rodada. Repetir em **CAPTURE THE FLAG** e observar bots chegando/segurando os anéis.
+
+O servidor dessa worktree foi iniciado e a raiz respondeu HTTP 200 (84.575 bytes). Para
+encerrá-lo depois do playtest: `npx astro dev stop` dentro da worktree.
+
+Gates reproduzíveis:
+
+```bash
+npm run eval:botfaca
+for m in recuo tracante corredor alcance troca; do
+  node tools/eval/botfaca-check.mjs --mutante="$m" && exit 1 || true
+done
+npm run eval:abateshud
+npm run eval:ctfround
+npm run eval:ctfwin
+npm run eval:netcode
+npm run eval:netcodecbin
+npm run eval:botsim-golden
+npm run build
+npm run check:deploy
+```
+
+## Estado e próximo passo
+
+Correção e gates locais prontos para PR draft. A validação automatizada prova distância,
+combate, objetivos, contadores e autoridade; ainda falta o playtest humano no URL acima para
+avaliar sensação de contato/cadência. Não houve merge, deploy ou mudança em produção.

--- a/docs/reports/BOTS-FACA-AUTORIDADE-R2.md
+++ b/docs/reports/BOTS-FACA-AUTORIDADE-R2.md
@@ -6,6 +6,9 @@ Branch: `codex/bot-knife-round-r2`
 Base cliente: `origin/main@2115d5e2c29eefb4491ae63b0f1600c200a750bb` (`v2.0.0-alpha.246`)  
 Backend auditado sem edição: `corosolto/backend origin/main@17ebd8fb28f15b34a9379f9e8210aeae4633b7b3`
 
+Draft PR: [corosolto/client#580](https://github.com/corosolto/client/pull/580)  
+Checkpoint funcional: `478626b12`
+
 ## Objetivo e definição de pronto
 
 Reproduzir o feedback sobre bots em rodada de faca e verificar seleção de arma, perseguição,
@@ -149,6 +152,6 @@ npm run check:deploy
 
 ## Estado e próximo passo
 
-Correção e gates locais prontos para PR draft. A validação automatizada prova distância,
+Correção e gates locais publicados no draft PR #580. A validação automatizada prova distância,
 combate, objetivos, contadores e autoridade; ainda falta o playtest humano no URL acima para
 avaliar sensação de contato/cadência. Não houve merge, deploy ou mudança em produção.

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -3152,7 +3152,7 @@ export class Game {
     const to = alvo.clone().sub(from);
     const d = to.length();
     const dir = to.clone().normalize();
-    if (d > alcance + 0.6) return;
+    if (d > alcance) return;
     if (dir.dot(new THREE.Vector3(Math.sin(b.yaw), 0, Math.cos(b.yaw))) < 0.5) return;
     if (!this._losClear(from, alvo)) return;
     const mul = e.isPlayer ? (BOT_FAIR ? this._botDmgPlayer : BOT_DMG_PLAYER) : 1;
@@ -6370,7 +6370,7 @@ export class Game {
       }
       // FACA (w.range): bot de faca disparava hitscan a 40m como se fosse rifle — agora só
       // "ataca" no alcance real da arma; longe disso ele avança (o approach acima já faz isso).
-      const inRange = alcanceArma > 0 ? dist <= alcanceArma + 0.6 : true;
+      const inRange = alcanceArma > 0 ? dist <= alcanceArma : true;
       // fire (bloqueado enquanto o alvo está stale/sem LOS — ver aquisição: sem wallhack)
       // TURNO DE DUELO: contra o JOGADOR só atira quem tem o token (ver _duelToken). Fora do
       // turno o bot continua manobrando/avançando — ele não congela, só não soma fogo.

--- a/tools/eval/botfaca-check.mjs
+++ b/tools/eval/botfaca-check.mjs
@@ -20,24 +20,30 @@
          Faca não tem cano nem projétil — o traçante é a arma de fogo aparecendo.
 
    O QUE ESTA RÉGUA MEDE (Game de verdade, sem navegador, semente fixa)
-   BF1 em modo faca TODO bot nasce com 'knife' (a garantia que já existia, presa aqui
-       pra ninguém consertar (a)/(b) e quebrar isto de lado).
+   BF1 em modo faca TODO combatente nasce com 'knife', e trocar para uma arma de fogo
+       pelos slots 1/2 é recusado. A seleção do modo não pode ser só cosmética.
    BF2 PERSEGUIÇÃO: em 60 s de partida os bots encostam — a menor distância bot->alvo
        cai dentro do alcance da faca — e o combate ACONTECE (há abates).
-   BF3 SEM ARMA DE FOGO: durante os golpes de faca não sai traçante nem fogacho, e o
-       som é o da faca.
+   BF3 CONTATO REAL: o golpe respeita os 2,4 m declarados por WEAPONS.knife.range (com
+       só 8 cm de tolerância para o passo discreto da simulação), sem a margem escondida
+       de 0,6 m que dava ao bot 25% mais alcance que o jogador. Durante o golpe não sai
+       traçante nem fogacho, e o som é o da faca.
    BF4 o modo 'all' (rodada normal) NÃO muda: os bots continuam abrindo distância (piso de
        4 m, derivado do 'back' abaixo de 6 m da própria banda de fuzil). É a cláusula que
        impede "consertar" a faca transformando todo bot num corredor.
+   BF5 a virada de rodada preserva arma e placar individual, transfere os abates do time
+       uma vez para o acumulado e não deixa rack/drop de arma furar o modo.
 
    Mutantes:
      recuo    — devolve a banda de recuo de fuzil pro bot de faca (defeito (a))
      tracante — devolve traçante/fogacho no golpe de faca (defeito (b))
      corredor — tira a banda de distância de TODO bot, inclusive de fuzil (prova BF4)
+     alcance  — devolve os 0,6 m extras ao golpe do bot (prova BF3)
+     troca    — deixa o jogador equipar arma de fogo no modo só faca (prova BF1)
    Uso: node tools/eval/botfaca-check.mjs [--mutante=<nome>]
    ============================================================================ */
 const MUT = (process.argv.find((a) => a.startsWith('--mutante=')) || '').split('=')[1] || '';
-const MUTANTES = ['recuo', 'tracante', 'corredor'];
+const MUTANTES = ['recuo', 'tracante', 'corredor', 'alcance', 'troca'];
 if (MUT && !MUTANTES.includes(MUT)) { console.error(`mutante desconhecido: ${MUT}`); process.exit(2); }
 
 const h = await import('./harness.mjs');
@@ -68,6 +74,20 @@ function jogo(wpnMode, seed) {
 
 /* Os mutantes voltam o defeito por cima do jogo já construído — comportamento, não texto. */
 function planta(g) {
+  if (MUT === 'troca') {
+    const orig = g._switchWeapon.bind(g);
+    g._switchWeapon = (wid, ...args) => {
+      const mode = g.settings.wpnMode;
+      g.settings.wpnMode = 'all';
+      const out = orig(wid, ...args);
+      g.settings.wpnMode = mode;
+      return out;
+    };
+  }
+  if (MUT === 'alcance') {
+    const orig = g._meleeRange.bind(g);
+    g._meleeRange = (wid) => orig(wid) + (wid === 'knife' ? 0.6 : 0);
+  }
   /* Os dois mexem na POSIÇÃO depois do quadro, não em `b._range`: a banda é recalculada no
      topo de todo `_updateBot`, então escrever nela por fora não muda deslocamento nenhum — o
      mutante passaria verde sem reproduzir defeito algum. */
@@ -130,6 +150,12 @@ const mk = instrumenta(gk);
 
 const semFaca = gk.bots.filter((b) => b.weapon !== 'knife');
 if (semFaca.length) falhas.push(`BF1 ${semFaca.length}/${gk.bots.length} bots nasceram com arma de fogo em rodada de faca (${[...new Set(semFaca.map((b) => b.weapon))].join(', ')})`);
+if (gk.player.weapon !== 'knife') falhas.push(`BF1 jogador nasceu com ${gk.player.weapon}, não com faca`);
+gk._switchWeapon('awp');
+if (gk.player.weapon !== 'knife') falhas.push(`BF1 slot de arma furou o modo só faca: jogador equipou ${gk.player.weapon}`);
+/* O mutante deixa a arma proibida ativa; restaura o cenário para BF2/BF3 medirem a IA,
+   e não a consequência secundária de um player armado no meio da rodada. */
+if (gk.player.weapon !== 'knife') gk._switchWeapon('knife');
 
 roda(gk, mk, 60);
 
@@ -141,14 +167,35 @@ if (!mk.golpes.length)
 if (!abates)
   falhas.push('BF2 zero abates em 60 s de rodada de faca — a rodada não acontece');
 
-const longe = mk.golpes.filter((x) => x.d > ALCANCE + 1.0);
-if (longe.length) falhas.push(`BF3 ${longe.length} golpes de faca fora do alcance (até ${num(Math.max(...longe.map((x) => x.d)))} m) — ainda é hitscan de arma de fogo`);
+/* Um quadro a 60 Hz desloca o bot em ~5 cm; 8 cm absorvem essa discretização sem
+   transformar tolerância técnica em alcance de gameplay. Medido antes do conserto:
+   2,99 m para uma arma declarada com 2,40 m. */
+const MARGEM_PASSO = 0.08;
+const longe = mk.golpes.filter((x) => x.d > ALCANCE + MARGEM_PASSO);
+if (longe.length) falhas.push(`BF3 ${longe.length} golpes de faca fora do alcance declarado (até ${num(Math.max(...longe.map((x) => x.d)))} m, máximo ${num(ALCANCE + MARGEM_PASSO)} m)`);
 if (mk.tracers) falhas.push(`BF3 ${mk.tracers} traçantes numa rodada de faca — faca não tem projétil`);
 if (mk.flashes) falhas.push(`BF3 ${mk.flashes} fogachos de cano numa rodada de faca — faca não tem cano`);
 const tiros = mk.sons.filter((s) => s.startsWith('shotWeapon'));
 if (tiros.length) falhas.push(`BF3 ${tiros.length} chamadas de som de TIRO numa rodada de faca (${[...new Set(tiros)].join(', ')}) — o golpe deve tocar knife/knifeHit`);
 if (mk.golpes.length && !mk.sons.some((s) => s === 'knife' || s === 'knifeHit'))
   falhas.push('BF3 houve golpe de faca e nenhum som de faca — o ataque saiu mudo');
+
+/* ---------------- BF5: continuidade entre rodadas ---------------- */
+const roundAntes = { ...gk.roundKills };
+const matchAntes = { ...gk.matchKills };
+const individuais = gk.combatants.map((c) => c.kills);
+gk._startRound();
+const armadosDepois = gk.bots.filter((b) => b.weapon !== 'knife');
+if (gk.player.weapon !== 'knife' || armadosDepois.length)
+  falhas.push(`BF5 rodada nova furou o modo faca (player=${gk.player.weapon}, bots armados=${armadosDepois.length})`);
+if (gk.roundKills.E !== 0 || gk.roundKills.B !== 0)
+  falhas.push(`BF5 placar da rodada não zerou (${gk.roundKills.E}×${gk.roundKills.B})`);
+if (gk.matchKills.E !== matchAntes.E + roundAntes.E || gk.matchKills.B !== matchAntes.B + roundAntes.B)
+  falhas.push('BF5 abates do round não foram transferidos exatamente uma vez para matchKills');
+if (gk.combatants.some((c, i) => c.kills !== individuais[i]))
+  falhas.push('BF5 a virada zerou/alterou o contador individual de abates');
+if ((gk.world.pickups?.length || 0) || gk.drops.length)
+  falhas.push(`BF5 modo faca deixou armas coletáveis após reset (mapa=${gk.world.pickups?.length || 0}, drops=${gk.drops.length})`);
 
 /* ---------------- BF4: a rodada normal não vira corrida ---------------- */
 const ga = planta(jogo('all', 4242));


### PR DESCRIPTION
O modo só faca já fazia os bots perseguirem e atacarem, mas o alcance efetivo aceitava `range + 0,6 m`: na semente canônica, 13 golpes passaram do limite e chegaram a 2,98 m para uma arma declarada com 2,40 m. Este PR remove a margem nos dois gates do ataque e fortalece a régua BF1–BF5 para seleção, troca proibida, contato real, FX, modo normal, virada de rodada e contadores.

A matriz 8x8/45 s nos 16 mapas produziu 657 golpes e 301 abates, com 0 armas erradas e nenhum golpe acima de 2,40 m. CTF foi exercitado em Amazônia, Escadão, Piscina, Ferro Velho e Penitenciária; bots chegaram aos pontos e capturaram em todos.

Validação:
- `npm run eval:botfaca` + mutantes `recuo`, `tracante`, `corredor`, `alcance`, `troca`
- `npm run eval:abateshud` + 4 mutantes
- `npm run eval:ctfround`, `npm run eval:ctfwin`
- `npm run eval:netcode` (178/178), `npm run eval:netcodecbin` (18/18)
- `npm run eval:botsim-golden`
- `npm run build`
- `npm run check:deploy` (39/39)

O backend atual foi auditado sem alteração: autoridade de inventário 15/15, mutante de confiança detectado, rounds 10/10, eventos 28/28 e smoke 86/86. Multiplayer hoje não expõe um modo `knife-only`; este PR corrige o modo single-player existente.

Teste humano local: `http://127.0.0.1:4407/` (servidor da worktree já responde 200). Escolher Single Player → SÓ FACA → 8x8, conferir slots 1/2 bloqueados e combate após respawn/virada; repetir em CTF.

Relatório completo: `docs/reports/BOTS-FACA-AUTORIDADE-R2.md`.
