### PR TITLE
feat(frota): a camada que INTEGRA — fila por risco, ledger entre turnos e travas no PATH

### DIFF
--- a/tools/frota/GUARDRAILS.md
+++ b/tools/frota/GUARDRAILS.md
@@ -1,0 +1,76 @@
+# Travas da frota — injetadas em todo turno, sem exceção
+
+Este texto entra literalmente no prompt de cada agente da frota, antes da tarefa.
+Ele não é conselho: é o contrato do turno. Um turno que viola qualquer item abaixo
+é descartado, e o `runner.mjs` marca a lane como `VIOLACAO` no ledger.
+
+## 1 · A main é do dono
+
+A frota **prepara**, o dono **integra**. Nesta rodada o dono decidiu que nada entra
+na main sem ele.
+
+- **Nunca** `git push` para `main`, `git merge` na `main`, `gh pr merge`, `gh pr close`.
+- **Nunca** aplicar a label `safe-automerge` — ela é o botão de merge do dono, e o
+  `csbrasil-bot-automerge` mescla sozinho quando ela aparece.
+- Terminou e ficou verde? Escreva no ledger `AGUARDANDO DONO` com o número do PR.
+  Não peça, não insista, não reaplique.
+
+## 2 · Você só existe dentro da sua worktree
+
+O caminho da sua worktree está no seu briefing. Não saia dele: outra lane está
+editando o mesmo arquivo em outra worktree agora.
+
+- `cd` para fora da worktree é violação, inclusive para "só olhar".
+- Não crie, mova nem remova worktree de ninguém.
+
+## 3 · `--no-verify` é violação
+
+Os hooks (`commit-msg`, `pre-push`) cobram o trailer `Agent:`, o teto de tamanho do
+commit, co-autoria de IA e o scanner de credencial. Se um hook recusou, ele está
+certo e você está errado. Conserte a causa.
+
+- `PREPUSH=0` também é violação.
+- Commit acima de 15 arquivos ou 800 linhas exige `Commit-grande:` dizendo por quê.
+
+## 4 · Credencial nunca entra no índice
+
+Nem em fonte, doc, fixture, comentário, mensagem de commit ou ledger. Nem token de
+teste, nem URL assinada, nem id de deploy efêmero. Achou um? Tire do staging,
+registre só provedor + tipo + caminho, e **pare** — rotação é decisão do dono.
+
+## 5 · Régua antes do conserto, e a mutação que a prova
+
+Lei 1 e 3 da casa. Escreva a medição, prove que ela **reprova** o estado atual, só
+então conserte. Se você não conseguiu deixar a régua vermelha de propósito, ela não
+existe — e um turno que "consertou" sem régua vermelha antes é um turno perdido.
+
+## 6 · Quem constrói nunca dá a nota
+
+Você não aprova o próprio trabalho. Frente visual (mapa, viewmodel, personagem,
+HUD) só fica pronta com captura inspecionada e aprovação **humana** registrada.
+No fim do turno escreva o que você **viu** na figura, não o que esperava ver.
+
+## 7 · Um único agente roda browser
+
+Antes de qualquer captura headless, tome o lock:
+`node tools/frota/lock.mjs tomar browser` — se ele negar, faça outra coisa e tente
+no próximo turno. Duas capturas em paralelo derrubam o boot e produzem "countdown
+travado" que parece bug e é carga. Solte com `node tools/frota/lock.mjs soltar browser`.
+
+## 8 · `game.js` se edita por trecho
+
+Nunca reescreva o arquivo inteiro — isso apaga o trabalho de quem está na outra
+faixa, agora. Consulte `tools/eval/ARCH.md` e fique na faixa de símbolo da sua
+frente. `constructor()`, `update()` e `_dom()` são append-only.
+
+## 9 · O turno termina no ledger, sempre
+
+Mesmo turno que não conseguiu nada. O próximo agente lê o ledger e o `git status`
+para continuar — ele **não** recomeça. Escreva: o que tentou, o que mediu, o que
+ficou de pé, e qual é o próximo passo concreto.
+
+## 10 · Na dúvida, pare e registre
+
+Sem worktree? Conflito que exige decisão de produto? Régua que contradiz o
+briefing? Escreva `BLOQUEADO` no ledger com a pergunta exata para o dono e encerre
+o turno. Chutar custa mais caro que esperar.

--- a/tools/frota/GUARDRAILS.md
+++ b/tools/frota/GUARDRAILS.md
@@ -74,3 +74,28 @@ ficou de pé, e qual é o próximo passo concreto.
 Sem worktree? Conflito que exige decisão de produto? Régua que contradiz o
 briefing? Escreva `BLOQUEADO` no ledger com a pergunta exata para o dono e encerre
 o turno. Chutar custa mais caro que esperar.
+
+## 11 · Turno morto deixa mutante na árvore — limpe ANTES de acreditar num vermelho
+
+Réguas desta casa provam que mordem injetando uma mutação no arquivo e restaurando
+depois. Se o processo morre no meio — teto de turno, Ctrl+C, limite de token — a
+mutação **fica**. O turno seguinte roda o portão, vê vermelho, e vai consertar um
+defeito que não existe.
+
+Caso real, 10/09/2026: `eval:docsautoria` injeta em `docs/docs/colaborar.md` a linha
+`"linha intrusa que o gerador não escreveu"`. Um `check:deploy` interrompido deixou
+a linha lá, e `docs:check` + `eval:docsautoria` passaram a reprovar numa árvore que
+minutos antes tinha dado 35/35.
+
+**No começo de todo turno, antes de rodar régua:**
+
+```sh
+git status --short          # árvore tem que estar como o ledger diz
+git diff | grep -i intrusa  # mutante órfão de régua anterior
+```
+
+Achou modificação que você não fez e o ledger não explica? `git checkout --` nela e
+registre no ledger. Não a commite, e não trate o vermelho dela como defeito.
+
+**E nunca rode `check:deploy` com limite de tempo curto**: ele leva ~125 s, e
+matá-lo no meio é justamente o que envenena a árvore.

--- a/tools/frota/README.md
+++ b/tools/frota/README.md
@@ -1,0 +1,71 @@
+# `tools/frota/` — a frota de agentes
+
+A casa aprendeu a **produzir** mais rápido do que **integra**. No dia em que esta
+pasta nasceu: 47 PRs abertos, 13 em conflito, 21 com check vermelho, 7 verdes
+esperando decisão — contra uma main que andava sozinha. Fan-out de produção não
+resolve isso; piora, porque cada merge na main empurra os conflitantes para longe.
+
+A frota é o que integra. Ela **prepara** e o dono **integra**: nesta rodada nada
+entra na main sem ele.
+
+| arquivo | papel |
+|---|---|
+| `fila.mjs` | lê GitHub + git, classifica cada PR e ordena por **risco de apodrecer** |
+| `tarefas.mjs` | a classe do PR decide a missão — não existe registro de lanes a manter |
+| `ledger.mjs` | memória que sobrevive ao turno: o próximo agente continua, não recomeça |
+| `lock.mjs` | o recurso de um agente só (browser), com validade para não virar deadlock |
+| `shim/git`, `shim/gh` | **a trava de verdade**: recusam push na main, merge, `--no-verify`, label `safe-automerge` |
+| `GUARDRAILS.md` | o contrato injetado em todo turno, antes da tarefa |
+| `selftest.mjs` | cada trava + a mutação que a faz ficar vermelha |
+
+## A ordem da fila não é por número de PR
+
+É por risco de apodrecer, e essa é a única decisão de projeto que importa aqui:
+
+1. **CONFLITO** — a única dívida que fica **mais cara se você não fizer nada**.
+2. **VERMELHO** — bloqueia o merge, mas o custo é estável.
+3. **PRONTO** — verde, esperando o dono. Custo zero para o agente.
+4. **RASCUNHO** — só quando o de cima esvazia, senão a fila cresce pela ponta errada.
+5. **PARADO** — não despacha. Abandonar PR é decisão do dono.
+
+## Por que não existe `lanes.json`
+
+Um registro de lanes escrito à mão mente em 48 h: o PR sai do conflito, a worktree
+é podada, a main anda, e o registro continua mandando rebasear o que já foi
+rebaseado. Registro desatualizado é pior que registro nenhum, porque um agente
+confia nele. Aqui a missão é **derivada do estado real a cada turno**. O único
+estado persistido é o ledger — que é histórico, não configuração, e não apodrece.
+
+## Os dois modelos, um runner só
+
+O ZCode publica o GLM-5.3 num endpoint compatível com a API da Anthropic
+(`~/.zcode/cli/config.json` → `provider.zai.kind = "anthropic"`). O mesmo binário
+`claude` roda os dois: Opus 5 pela autenticação normal, GLM-5.3 apontando
+`ANTHROPIC_BASE_URL` para a z.ai. O modelo é um **parâmetro do turno** — não há
+segundo runner, segunda fila nem segundo ledger.
+
+Divisão de trabalho, seguindo o que a casa já tinha decidido:
+
+- **claude** — direção visual, Blender, personagem, julgar figura, revisão
+- **glm** — portão, conflito, integração determinística, áudio, código
+
+## A trava é o PATH, não o prompt
+
+Turno desassistido roda sem parar para pedir permissão. Prompt não segura isso: um
+agente que "sabe" que não deve tocar na main toca na main no turno em que a
+instrução ficar longe o suficiente no contexto. Por isso `tools/frota/shim/` entra
+**na frente** no PATH do turno, e o `git`/`gh` de lá recusam a chamada com saída 97.
+
+O `selftest.mjs` prova cada recusa e prova que ela **morde** — inclusive o caso em
+que o shim precisa DEIXAR passar (`git checkout origin/main -- <arquivo>` é
+resolução de conflito legítima, não troca de branch).
+
+## Rodando
+
+```sh
+node tools/frota/fila.mjs                   # o que precisa de trabalho, e por quê
+node tools/frota/fila.mjs --classe=CONFLITO
+node tools/frota/selftest.mjs               # travas + mutantes
+node tools/frota/ledger.mjs resumo          # em que pé está cada lane
+node tools/frota/lock.mjs ver               # quem está com o browser
+```

--- a/tools/frota/fila.mjs
+++ b/tools/frota/fila.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/* ============================================================================
+   fila.mjs — QUEM PRECISA DE TRABALHO AGORA, E POR QUÊ NESSA ORDEM.
+   ----------------------------------------------------------------------------
+   POR QUE EXISTE
+   A casa aprendeu a produzir mais rápido do que integra. No dia em que este
+   arquivo nasceu havia 47 PRs abertos, 11 em conflito e 22 com check vermelho,
+   contra uma main que andava sozinha. Fan-out de produção não resolve isso —
+   piora: cada merge na main empurra os conflitantes para mais longe. O gargalo
+   é integração, e integração precisa de uma FILA, não de mais braço.
+
+   A ordem não é por número de PR nem por data. É por RISCO DE APODRECER:
+
+     1. CONFLITO   — dívida que cresce sozinha. Cada commit na main aumenta o
+                     custo de resolver. É a única classe que fica mais cara se
+                     você não fizer nada, então vem primeiro, sempre.
+     2. VERMELHO   — invariante crítica reprovando. Custo estável, mas bloqueia
+                     o merge. Ordenado por quantas réguas faltam.
+     3. PRONTO     — verde, sem conflito, esperando decisão humana. Custo zero
+                     para o agente; aparece para o dono saber o que apertar.
+     4. RASCUNHO   — trabalho não terminado. Só entra quando as classes acima
+                     esvaziam, senão a fila volta a crescer pela ponta errada.
+     5. PARADO     — sem commit há PARADO_DIAS. Provável abandono; a fila marca
+                     para o dono decidir entre retomar e fechar, e nunca
+                     despacha sozinha (fechar PR é decisão do dono).
+
+   O QUE ELA NÃO FAZ
+   Não faz merge, não faz push, não fecha PR. Só lê e ordena. Quem age é o
+   `runner.mjs`, e mesmo ele para antes da main — ver `GUARDRAILS.md`.
+
+   USO
+     node tools/frota/fila.mjs              tabela para humano
+     node tools/frota/fila.mjs --json       para o runner consumir
+     node tools/frota/fila.mjs --classe=CONFLITO
+     node tools/frota/fila.mjs --limite=5
+   ========================================================================== */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+
+const PARADO_DIAS = 5;
+const CAMPOS = 'number,title,headRefName,isDraft,mergeable,updatedAt,statusCheckRollup,author';
+
+const CLASSES = ['CONFLITO', 'VERMELHO', 'PRONTO', 'RASCUNHO', 'PARADO'];
+const PESO = Object.fromEntries(CLASSES.map((c, i) => [c, i]));
+
+async function gh(args) {
+  const { stdout } = await exec('gh', args, { maxBuffer: 64 * 1024 * 1024 });
+  return stdout;
+}
+
+export async function lerPRs() {
+  const bruto = await gh(['pr', 'list', '--state', 'open', '--limit', '200', '--json', CAMPOS]);
+  return JSON.parse(bruto);
+}
+
+export async function mapaDeWorktrees() {
+  const { stdout } = await exec('git', ['worktree', 'list', '--porcelain'], { maxBuffer: 8 * 1024 * 1024 });
+  const mapa = new Map();
+  let caminho = null;
+  for (const linha of stdout.split('\n')) {
+    if (linha.startsWith('worktree ')) caminho = linha.slice(9).trim();
+    else if (linha.startsWith('branch ') && caminho) {
+      mapa.set(linha.slice(7).trim().replace(/^refs\/heads\//, ''), caminho);
+    }
+  }
+  return mapa;
+}
+
+function falhas(pr) {
+  return (pr.statusCheckRollup || [])
+    .filter((c) => c.conclusion === 'FAILURE')
+    .map((c) => c.name);
+}
+
+function diasParado(pr) {
+  return (Date.now() - new Date(pr.updatedAt).getTime()) / 86400000;
+}
+
+export function classificar(pr) {
+  const vermelhos = falhas(pr);
+  const parado = diasParado(pr);
+  if (pr.mergeable === 'CONFLICTING') return 'CONFLITO';
+  if (vermelhos.length > 0) return 'VERMELHO';
+  if (parado > PARADO_DIAS) return 'PARADO';
+  if (pr.isDraft) return 'RASCUNHO';
+  return 'PRONTO';
+}
+
+export function ordenar(itens) {
+  return [...itens].sort((a, b) => {
+    if (PESO[a.classe] !== PESO[b.classe]) return PESO[a.classe] - PESO[b.classe];
+    if (a.classe === 'VERMELHO' && a.falhas.length !== b.falhas.length) {
+      return b.falhas.length - a.falhas.length;
+    }
+    return b.dias - a.dias;
+  });
+}
+
+export async function montarFila() {
+  const [prs, worktrees] = await Promise.all([lerPRs(), mapaDeWorktrees()]);
+  const itens = prs.map((pr) => ({
+    numero: pr.number,
+    titulo: pr.title,
+    branch: pr.headRefName,
+    autor: pr.author?.login ?? '?',
+    classe: classificar(pr),
+    falhas: falhas(pr),
+    dias: Number(diasParado(pr).toFixed(1)),
+    rascunho: pr.isDraft,
+    worktree: worktrees.get(pr.headRefName) ?? null,
+  }));
+  return ordenar(itens);
+}
+
+function tabela(fila) {
+  const contagem = Object.fromEntries(CLASSES.map((c) => [c, 0]));
+  for (const i of fila) contagem[i.classe] += 1;
+
+  const linhas = [];
+  linhas.push('');
+  linhas.push('  FILA DA FROTA — ordenada por risco de apodrecer');
+  linhas.push('  ' + '-'.repeat(94));
+  linhas.push(
+    '  ' + CLASSES.map((c) => `${c} ${contagem[c]}`).join('  ·  ') + `  ·  TOTAL ${fila.length}`,
+  );
+  linhas.push('  ' + '-'.repeat(94));
+
+  let classeAtual = null;
+  for (const i of fila) {
+    if (i.classe !== classeAtual) {
+      classeAtual = i.classe;
+      linhas.push('');
+      linhas.push(`  ── ${classeAtual} ──`);
+    }
+    const wt = i.worktree ? i.worktree.split('/').slice(-1)[0] : '— sem worktree —';
+    const motivo =
+      i.classe === 'VERMELHO' ? i.falhas.join(',') : i.classe === 'PARADO' ? `${i.dias}d` : '';
+    linhas.push(
+      `  #${String(i.numero).padEnd(4)} ${i.titulo.slice(0, 46).padEnd(46)} ${String(motivo).slice(0, 20).padEnd(20)} ${wt}`,
+    );
+  }
+  linhas.push('');
+  return linhas.join('\n');
+}
+
+const ehPrincipal = process.argv[1] && import.meta.url.endsWith(process.argv[1].split('/').pop());
+
+if (ehPrincipal) {
+  const arg = (n, d) => {
+    const m = process.argv.find((a) => a.startsWith(`--${n}=`));
+    return m ? m.split('=')[1] : d;
+  };
+  let fila = await montarFila();
+  const classe = arg('classe');
+  if (classe) fila = fila.filter((i) => i.classe === classe.toUpperCase());
+  const limite = Number(arg('limite', 0));
+  if (limite > 0) fila = fila.slice(0, limite);
+
+  if (process.argv.includes('--json')) console.log(JSON.stringify(fila, null, 2));
+  else console.log(tabela(fila));
+}

--- a/tools/frota/fila.mjs
+++ b/tools/frota/fila.mjs
@@ -24,6 +24,15 @@
                      para o dono decidir entre retomar e fechar, e nunca
                      despacha sozinha (fechar PR é decisão do dono).
 
+   EMPILHAMENTO
+   Um PR pode ter como base OUTRO PR aberto, não a main — a pilha de mapas fazia
+   isso (#555 sobre #554, #560 sobre #556). Trabalhar o de cima antes do de baixo
+   é trabalho perdido: ele vai conflitar de novo quando a base mudar, e o merge
+   dele nem é possível enquanto a base não entrar. A fila marca `bloqueadoPor` e
+   empurra o dependente para depois da base DENTRO da mesma classe. Isso custou
+   uma descoberta em campo: #554 (raiz, em conflito) segurava #555, que aparecia
+   verde e convidativo na fila.
+
    O QUE ELA NÃO FAZ
    Não faz merge, não faz push, não fecha PR. Só lê e ordena. Quem age é o
    `runner.mjs`, e mesmo ele para antes da main — ver `GUARDRAILS.md`.
@@ -41,7 +50,7 @@ import { promisify } from 'node:util';
 const exec = promisify(execFile);
 
 const PARADO_DIAS = 5;
-const CAMPOS = 'number,title,headRefName,isDraft,mergeable,updatedAt,statusCheckRollup,author';
+const CAMPOS = 'number,title,headRefName,baseRefName,isDraft,mergeable,updatedAt,statusCheckRollup,author';
 
 const CLASSES = ['CONFLITO', 'VERMELHO', 'PRONTO', 'RASCUNHO', 'PARADO'];
 const PESO = Object.fromEntries(CLASSES.map((c, i) => [c, i]));
@@ -90,17 +99,33 @@ export function classificar(pr) {
 }
 
 export function ordenar(itens) {
-  return [...itens].sort((a, b) => {
+  const base = [...itens].sort((a, b) => {
     if (PESO[a.classe] !== PESO[b.classe]) return PESO[a.classe] - PESO[b.classe];
     if (a.classe === 'VERMELHO' && a.falhas.length !== b.falhas.length) {
       return b.falhas.length - a.falhas.length;
     }
     return b.dias - a.dias;
   });
+  return depoisDaBase(base);
+}
+
+/** Dependente nunca aparece antes da sua base. Estável e sem laço infinito. */
+export function depoisDaBase(itens) {
+  const restante = [...itens];
+  const saida = [];
+  const numeros = new Set(itens.map((i) => i.numero));
+  while (restante.length) {
+    const i = restante.findIndex(
+      (x) => !x.bloqueadoPor || !numeros.has(x.bloqueadoPor) || saida.some((y) => y.numero === x.bloqueadoPor),
+    );
+    saida.push(...restante.splice(i === -1 ? 0 : i, 1));
+  }
+  return saida;
 }
 
 export async function montarFila() {
   const [prs, worktrees] = await Promise.all([lerPRs(), mapaDeWorktrees()]);
+  const porBranch = new Map(prs.map((pr) => [pr.headRefName, pr.number]));
   const itens = prs.map((pr) => ({
     numero: pr.number,
     titulo: pr.title,
@@ -111,6 +136,8 @@ export async function montarFila() {
     dias: Number(diasParado(pr).toFixed(1)),
     rascunho: pr.isDraft,
     worktree: worktrees.get(pr.headRefName) ?? null,
+    base: pr.baseRefName,
+    bloqueadoPor: pr.baseRefName === 'main' ? null : (porBranch.get(pr.baseRefName) ?? null),
   }));
   return ordenar(itens);
 }
@@ -136,8 +163,13 @@ function tabela(fila) {
       linhas.push(`  ── ${classeAtual} ──`);
     }
     const wt = i.worktree ? i.worktree.split('/').slice(-1)[0] : '— sem worktree —';
-    const motivo =
-      i.classe === 'VERMELHO' ? i.falhas.join(',') : i.classe === 'PARADO' ? `${i.dias}d` : '';
+    const motivo = i.bloqueadoPor
+      ? `↑ espera #${i.bloqueadoPor}`
+      : i.classe === 'VERMELHO'
+        ? i.falhas.join(',')
+        : i.classe === 'PARADO'
+          ? `${i.dias}d`
+          : '';
     linhas.push(
       `  #${String(i.numero).padEnd(4)} ${i.titulo.slice(0, 46).padEnd(46)} ${String(motivo).slice(0, 20).padEnd(20)} ${wt}`,
     );

--- a/tools/frota/ledger.mjs
+++ b/tools/frota/ledger.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/* ============================================================================
+   ledger.mjs — A MEMÓRIA QUE SOBREVIVE AO TURNO.
+   ----------------------------------------------------------------------------
+   POR QUE EXISTE
+   Agente da frota morre no meio: estoura limite de token, a máquina reinicia, o
+   turno expira. O que não pode morrer junto é o QUE JÁ FOI FEITO. Sem isso o
+   próximo turno recomeça do zero — e recomeçar é pior que não começar, porque
+   ele desfaz o checkpoint anterior achando que está limpando sujeira.
+
+   O prompt do orquestrador da casa já dizia: "se o agente parar por limite, o
+   próximo deve ler o ledger e o `git status`, sem recomeçar". Este arquivo é o
+   ledger que aquela frase pressupunha e que nunca existiu.
+
+   FORMATO: JSONL, append-only, um arquivo por lane.
+   Append-only não é preciosismo — é o que permite dois processos escrevendo sem
+   corromper, e é o que deixa o histórico do turno auditável depois que a lane
+   mentiu sobre o que fez. Nada de reescrever linha passada.
+
+   Vive em ~/.csbrasil-frota/ledger/ e NÃO no repositório: heartbeat de agente
+   não é história do projeto, e commitar isso poluiria todo diff da frota.
+
+   USO
+     node tools/frota/ledger.mjs escrever lane-561 ANDAMENTO "rebase 3 de 7"
+     node tools/frota/ledger.mjs ler lane-561 [--n=10]
+     node tools/frota/ledger.mjs resumo
+   ========================================================================== */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const RAIZ = path.join(os.homedir(), '.csbrasil-frota', 'ledger');
+
+export const ESTADOS = [
+  'ANDAMENTO',
+  'AGUARDANDO DONO',
+  'BLOQUEADO',
+  'VIOLACAO',
+  'TURNO ABERTO',
+  'TURNO FECHADO',
+];
+
+const arquivo = (lane) => path.join(RAIZ, `${lane}.jsonl`);
+
+export function escrever(lane, estado, nota, extra = {}) {
+  fs.mkdirSync(RAIZ, { recursive: true });
+  const linha = { quando: new Date().toISOString(), lane, estado, nota, ...extra };
+  fs.appendFileSync(arquivo(lane), JSON.stringify(linha) + '\n');
+  return linha;
+}
+
+export function ler(lane, n = 20) {
+  try {
+    const linhas = fs.readFileSync(arquivo(lane), 'utf8').trim().split('\n').filter(Boolean);
+    return linhas.slice(-n).map((l) => JSON.parse(l));
+  } catch {
+    return [];
+  }
+}
+
+export function lanes() {
+  try {
+    return fs.readdirSync(RAIZ).filter((f) => f.endsWith('.jsonl')).map((f) => f.replace(/\.jsonl$/, ''));
+  } catch {
+    return [];
+  }
+}
+
+export function ultimo(lane) {
+  return ler(lane, 1)[0] ?? null;
+}
+
+/** O bloco que entra no prompt do próximo turno. Sem ele o agente recomeça. */
+export function contextoParaPrompt(lane, n = 12) {
+  const linhas = ler(lane, n);
+  if (!linhas.length) return 'LEDGER: vazio — este é o primeiro turno desta lane.';
+  return [
+    `LEDGER da ${lane} (${linhas.length} últimas entradas, mais antiga primeiro):`,
+    ...linhas.map((l) => `  [${l.quando.slice(5, 16).replace('T', ' ')}] ${l.estado}: ${l.nota}`),
+  ].join('\n');
+}
+
+const ehPrincipal = process.argv[1] && process.argv[1].endsWith('ledger.mjs');
+
+if (ehPrincipal) {
+  const [acao, lane, estado, ...resto] = process.argv.slice(2);
+
+  if (acao === 'resumo') {
+    const todas = lanes();
+    if (!todas.length) console.log('  nenhuma lane registrada ainda');
+    for (const l of todas) {
+      const u = ultimo(l);
+      console.log(`  ${l.padEnd(26)} ${String(u?.estado ?? '?').padEnd(16)} ${u?.quando?.slice(5, 16).replace('T', ' ')}  ${String(u?.nota ?? '').slice(0, 60)}`);
+    }
+    process.exit(0);
+  }
+
+  if (acao === 'ler') {
+    const n = Number(process.argv.find((a) => a.startsWith('--n='))?.split('=')[1] ?? 20);
+    for (const l of ler(lane, n)) console.log(`[${l.quando}] ${l.estado}: ${l.nota}`);
+    process.exit(0);
+  }
+
+  if (acao === 'escrever') {
+    if (!ESTADOS.includes(estado)) {
+      console.error(`estado inválido: ${estado}\nválidos: ${ESTADOS.join(' | ')}`);
+      process.exit(2);
+    }
+    const l = escrever(lane, estado, resto.join(' '));
+    console.log(`ledger ← ${l.lane} ${l.estado}`);
+    process.exit(0);
+  }
+
+  console.error('uso: ledger.mjs <escrever|ler|resumo> [lane] [estado] [nota]');
+  process.exit(2);
+}

--- a/tools/frota/lock.mjs
+++ b/tools/frota/lock.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/* ============================================================================
+   lock.mjs — O RECURSO QUE SÓ UM AGENTE PODE TER POR VEZ.
+   ----------------------------------------------------------------------------
+   POR QUE EXISTE
+   A lei da casa diz "um único agente roda browser": duas capturas headless em
+   paralelo derrubam o boot e produzem "countdown travado" que parece bug e é
+   carga. Com a frota rodando 24/7 em várias worktrees, essa lei deixa de ser
+   uma frase no AGENTS.md e precisa de um mecanismo — senão a terceira lane que
+   acorda de madrugada vai capturar por cima da segunda e reprovar as duas.
+
+   Vive fora da árvore (em ~/.csbrasil-frota/) porque o lock é da MÁQUINA, não
+   do repositório: todas as worktrees dividem a mesma GPU e o mesmo Chromium.
+
+   ROUBO DE LOCK
+   Turno morre (limite de token, máquina reinicia) segurando o lock, e aí o
+   recurso fica preso para sempre. Por isso o lock guarda PID + instante: se o
+   dono não existe mais, ou passou de VALIDADE_MIN, o próximo o toma e registra
+   o roubo. Lock sem validade é deadlock com passos extras.
+
+   USO
+     node tools/frota/lock.mjs tomar browser --dono=lane-561
+     node tools/frota/lock.mjs soltar browser --dono=lane-561
+     node tools/frota/lock.mjs ver
+   Sai com 0 se conseguiu, 1 se o recurso está com outro. O chamador decide.
+   ========================================================================== */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const RAIZ = path.join(os.homedir(), '.csbrasil-frota', 'locks');
+const VALIDADE_MIN = 25;
+
+/* O PID sozinho não serve como prova de vida aqui. Cada `lock.mjs tomar` é um
+   processo node que morre no mesmo segundo, então um lock tomado pela CLI já
+   nasceria com o dono morto e seria roubado pelo pedido seguinte — foi o que o
+   primeiro teste negativo mostrou. A morte do PID só libera depois da graça:
+   antes dela vale o relógio, que é o que cobre o turno inteiro. */
+const GRACA_MIN = 3;
+
+const arquivo = (recurso) => path.join(RAIZ, `${recurso}.json`);
+
+function vivo(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function ler(recurso) {
+  try {
+    return JSON.parse(fs.readFileSync(arquivo(recurso), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function expirado(l, agora = Date.now()) {
+  if (!l) return true;
+  const min = (agora - new Date(l.desde).getTime()) / 60000;
+  if (min > VALIDADE_MIN) return true;
+  return min > GRACA_MIN && !vivo(l.pid);
+}
+
+export function tomar(recurso, dono, pid = process.ppid) {
+  fs.mkdirSync(RAIZ, { recursive: true });
+  const atual = ler(recurso);
+  if (atual && atual.dono === dono) return { ok: true, motivo: 'ja-era-seu' };
+  if (atual && !expirado(atual)) return { ok: false, motivo: 'ocupado', por: atual.dono };
+  const roubado = atual ? atual.dono : null;
+  fs.writeFileSync(
+    arquivo(recurso),
+    JSON.stringify({ recurso, dono, pid, desde: new Date().toISOString() }, null, 2),
+  );
+  return { ok: true, motivo: roubado ? 'roubado' : 'livre', de: roubado };
+}
+
+export function soltar(recurso, dono) {
+  const atual = ler(recurso);
+  if (!atual) return { ok: true, motivo: 'ja-estava-livre' };
+  if (atual.dono !== dono && !expirado(atual)) {
+    return { ok: false, motivo: 'nao-e-seu', por: atual.dono };
+  }
+  fs.rmSync(arquivo(recurso), { force: true });
+  return { ok: true, motivo: 'solto' };
+}
+
+const ehPrincipal = process.argv[1] && process.argv[1].endsWith('lock.mjs');
+
+if (ehPrincipal) {
+  const [acao, recurso] = process.argv.slice(2);
+  const dono =
+    process.argv.find((a) => a.startsWith('--dono='))?.split('=')[1] ?? `pid-${process.pid}`;
+
+  if (acao === 'ver') {
+    fs.mkdirSync(RAIZ, { recursive: true });
+    const nomes = fs.readdirSync(RAIZ).map((f) => f.replace(/\.json$/, ''));
+    if (!nomes.length) console.log('  nenhum lock tomado');
+    for (const n of nomes) {
+      const l = ler(n);
+      console.log(`  ${n.padEnd(12)} ${l.dono.padEnd(20)} ${expirado(l) ? 'EXPIRADO' : 'ativo'}  desde ${l.desde}`);
+    }
+    process.exit(0);
+  }
+
+  if (!acao || !recurso) {
+    console.error('uso: lock.mjs <tomar|soltar|ver> <recurso> [--dono=...]');
+    process.exit(2);
+  }
+
+  const r = acao === 'tomar' ? tomar(recurso, dono) : soltar(recurso, dono);
+  console.log(`${r.ok ? 'OK' : 'NEGADO'} ${recurso} — ${r.motivo}${r.por ? ` (com ${r.por})` : ''}${r.de ? ` (de ${r.de})` : ''}`);
+  process.exit(r.ok ? 0 : 1);
+}

--- a/tools/frota/runner.mjs
+++ b/tools/frota/runner.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/* ============================================================================
+   runner.mjs — UM TURNO DE UMA LANE, E O LAÇO QUE O REPETE.
+   ----------------------------------------------------------------------------
+   POR QUE EXISTE
+   O `00-PROMPT-ORQUESTRADOR.md` descrevia a operação certa e pressupunha um
+   humano acordado colando prompt em 28 lanes. Este arquivo é o que faltava para
+   aquela descrição virar máquina: monta o prompt do turno a partir do estado
+   REAL (fila + ledger + git), roda o agente headless dentro da worktree certa, e
+   fecha o turno no ledger — dê certo ou não.
+
+   OS DOIS MODELOS, UM RUNNER SÓ
+   O ZCode publica o GLM-5.3 num endpoint compatível com a API da Anthropic
+   (`~/.zcode/cli/config.json` → provider.zai.kind = "anthropic"). Então o mesmo
+   binário `claude` roda os dois: Opus 5 pela autenticação normal, GLM-5.3
+   apontando ANTHROPIC_BASE_URL para a z.ai. O modelo é um parâmetro do turno.
+
+   SOBRE A PERMISSÃO LIBERADA
+   O turno roda com --dangerously-skip-permissions. Sem isso ele trava no
+   primeiro pedido de permissão às 3 h da manhã e a frota para calada. A escolha
+   foi do dono, e ela só é defensável porque o freio NÃO é o prompt:
+
+     · `tools/frota/shim/` entra na frente no PATH e o git/gh de lá RECUSAM push
+       na main, --force puro, --no-verify, gh pr merge/close e a label
+       safe-automerge (que é o botão de merge do bot). Saída 97.
+     · os hooks da casa continuam valendo — o shim recusa justamente quem
+       tentaria pulá-los.
+     · o turno tem teto de tempo; passou disso, morre e vira registro no ledger.
+
+   Prompt convence. Shim impede. `selftest.mjs` prova que impede.
+
+   USO
+     node tools/frota/runner.mjs --pr=561                um turno, modelo automático
+     node tools/frota/runner.mjs --pr=561 --modelo=glm
+     node tools/frota/runner.mjs --pr=561 --laco         repete até sair da fila
+     node tools/frota/runner.mjs --pr=561 --ensaio       monta o prompt e NÃO executa
+   ========================================================================== */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { montarFila } from './fila.mjs';
+import { briefing } from './tarefas.mjs';
+import { escrever, contextoParaPrompt } from './ledger.mjs';
+
+const AQUI = path.dirname(fileURLToPath(import.meta.url));
+const LOGS = path.join(os.homedir(), '.csbrasil-frota', 'logs');
+const CLAUDE_BIN = path.join(os.homedir(), '.claude', 'local', 'claude');
+
+const TETO_TURNO_MIN = 45;
+const PAUSA_ENTRE_TURNOS_S = 30;
+const TETO_TURNOS_SEGUIDOS = 12;
+
+/** Classes que a frota trabalha. PRONTO e PARADO só viram registro. */
+const TRABALHAVEIS = new Set(['CONFLITO', 'VERMELHO', 'RASCUNHO']);
+
+/* Afinidade que a casa já tinha decidido, não preferência: Claude julga figura e
+   direção visual; GLM fecha portão, conflito e integração determinística. */
+const VISUAL = /viewmodel|mapa|maps|mansao|amazonia|escadao|piscina|carandiru|personagem|miticos|visual|grafite|textura|hud/i;
+
+export function modeloPara(item) {
+  if (item.classe === 'CONFLITO') return 'glm';
+  return VISUAL.test(item.titulo) || VISUAL.test(item.branch) ? 'claude' : 'glm';
+}
+
+function envPara(modelo) {
+  const env = { ...process.env };
+  env.PATH = `${path.join(AQUI, 'shim')}:${env.PATH}`;
+  env.FROTA = '1';
+  env.AGENTE = modelo === 'glm' ? 'GLM-5.3 (frota)' : 'Claude Code (Opus 5, frota)';
+
+  if (modelo === 'glm') {
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(os.homedir(), '.zcode', 'cli', 'config.json'), 'utf8'),
+    );
+    const zai = cfg.provider.zai;
+    env.ANTHROPIC_BASE_URL = zai.options.baseURL;
+    env.ANTHROPIC_AUTH_TOKEN = zai.options.apiKey;
+    env.ANTHROPIC_MODEL = 'GLM-5.3';
+    env.ANTHROPIC_SMALL_FAST_MODEL = 'GLM-5.3';
+    env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = String(zai.models['GLM-5.3'].limit.context);
+    delete env.ANTHROPIC_API_KEY;
+  }
+  return env;
+}
+
+export function montarPrompt(item, lane, worktree) {
+  const travas = fs.readFileSync(path.join(AQUI, 'GUARDRAILS.md'), 'utf8');
+  return [
+    '===== TRAVAS DA FROTA (contrato deste turno) =====',
+    travas.trim(),
+    '',
+    '===== MEMÓRIA DOS TURNOS ANTERIORES =====',
+    contextoParaPrompt(lane),
+    '',
+    '===== SEU TURNO =====',
+    briefing(item, lane, worktree),
+  ].join('\n');
+}
+
+async function rodarTurno(item, { modelo, ensaio }) {
+  const lane = `pr-${item.numero}`;
+
+  if (!item.worktree) {
+    escrever(lane, 'BLOQUEADO', `sem worktree local — crie antes de despachar o PR #${item.numero}`);
+    return { seguir: false, motivo: 'sem-worktree' };
+  }
+  if (!TRABALHAVEIS.has(item.classe)) {
+    escrever(
+      lane,
+      item.classe === 'PRONTO' ? 'AGUARDANDO DONO' : 'BLOQUEADO',
+      `classe ${item.classe} — nada a despachar`,
+    );
+    return { seguir: false, motivo: 'nao-trabalhavel' };
+  }
+
+  const escolhido = modelo ?? modeloPara(item);
+  const prompt = montarPrompt(item, lane, item.worktree);
+
+  if (ensaio) {
+    console.log(prompt);
+    console.log(`\n----- ensaio: rodaria ${escolhido} em ${item.worktree} -----`);
+    return { seguir: false, motivo: 'ensaio' };
+  }
+
+  fs.mkdirSync(LOGS, { recursive: true });
+  const carimbo = new Date().toISOString().replace(/[:.]/g, '-');
+  const log = path.join(LOGS, `${lane}-${carimbo}-${escolhido}.log`);
+
+  escrever(lane, 'TURNO ABERTO', `${escolhido} · ${item.classe} · ${path.basename(log)}`, {
+    modelo: escolhido,
+    classe: item.classe,
+  });
+
+  const args = ['-p', prompt, '--dangerously-skip-permissions', '--add-dir', item.worktree];
+  if (escolhido === 'glm') args.push('--model', 'GLM-5.3');
+
+  const fluxo = fs.createWriteStream(log);
+  const t0 = Date.now();
+  let estourou = false;
+
+  const codigo = await new Promise((resolve) => {
+    const p = spawn(CLAUDE_BIN, args, { cwd: item.worktree, env: envPara(escolhido) });
+    const teto = setTimeout(() => {
+      estourou = true;
+      p.kill('SIGTERM');
+    }, TETO_TURNO_MIN * 60000);
+    p.stdout.pipe(fluxo, { end: false });
+    p.stderr.pipe(fluxo, { end: false });
+    p.stdout.on('data', (d) => process.stdout.write(d));
+    p.on('error', (e) => {
+      fluxo.write(`\nfrota: falhou ao lançar o agente — ${e.message}\n`);
+      resolve(-1);
+    });
+    p.on('close', (c) => {
+      clearTimeout(teto);
+      fluxo.end();
+      resolve(c);
+    });
+  });
+
+  const min = ((Date.now() - t0) / 60000).toFixed(1);
+  escrever(
+    lane,
+    'TURNO FECHADO',
+    `${estourou ? `ESTOUROU o teto de ${TETO_TURNO_MIN} min` : `saída ${codigo}`} em ${min} min · ${path.basename(log)}`,
+    { codigo, minutos: Number(min), estourou },
+  );
+  return { seguir: true, codigo, log };
+}
+
+const arg = (n, d) => process.argv.find((a) => a.startsWith(`--${n}=`))?.split('=')[1] ?? d;
+const numero = Number(arg('pr', 0));
+
+if (!numero) {
+  console.error('uso: runner.mjs --pr=<numero> [--modelo=claude|glm] [--laco] [--ensaio]');
+  process.exit(2);
+}
+
+const opcoes = { modelo: arg('modelo'), ensaio: process.argv.includes('--ensaio') };
+const laco = process.argv.includes('--laco');
+let voltas = 0;
+
+while (true) {
+  const item = (await montarFila()).find((i) => i.numero === numero);
+  if (!item) {
+    console.log(`frota: PR #${numero} saiu da fila (mesclado ou fechado). Encerrando.`);
+    escrever(`pr-${numero}`, 'TURNO FECHADO', 'saiu da fila — mesclado ou fechado');
+    break;
+  }
+
+  console.log(`\nfrota: #${item.numero} · ${item.classe} · ${item.titulo.slice(0, 58)}`);
+  const r = await rodarTurno(item, opcoes);
+
+  if (!laco || !r.seguir) break;
+  if (++voltas >= TETO_TURNOS_SEGUIDOS) {
+    escrever(`pr-${numero}`, 'BLOQUEADO', `${voltas} turnos seguidos sem sair da classe ${item.classe} — parando para o dono olhar`);
+    console.log(`frota: ${voltas} turnos sem progresso de classe. Parando.`);
+    break;
+  }
+  await new Promise((s) => setTimeout(s, PAUSA_ENTRE_TURNOS_S * 1000));
+}

--- a/tools/frota/selftest.mjs
+++ b/tools/frota/selftest.mjs
@@ -24,7 +24,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { classificar, ordenar } from './fila.mjs';
+import { classificar, ordenar, depoisDaBase } from './fila.mjs';
 import { tomar, soltar, expirado } from './lock.mjs';
 
 const AQUI = path.dirname(fileURLToPath(import.meta.url));
@@ -111,6 +111,31 @@ caso('fila: rascunho vermelho conta como VERMELHO, não como RASCUNHO', () => {
     updatedAt: new Date().toISOString(),
   };
   igual(classificar(pr), 'VERMELHO', 'o vermelho é o que bloqueia, não o rascunho');
+});
+
+caso('fila: dependente nunca vem antes da base (a pilha de mapas)', () => {
+  const ordem = depoisDaBase([
+    { numero: 556, classe: 'PRONTO', bloqueadoPor: 555 },
+    { numero: 555, classe: 'PRONTO', bloqueadoPor: 554 },
+    { numero: 554, classe: 'CONFLITO', bloqueadoPor: null },
+  ]).map((i) => i.numero);
+  igual(ordem, [554, 555, 556], 'trabalhar o de cima antes da raiz é trabalho perdido');
+});
+
+caso('fila: base já fechada não segura ninguém', () => {
+  const ordem = depoisDaBase([
+    { numero: 700, classe: 'PRONTO', bloqueadoPor: 999 },
+    { numero: 701, classe: 'PRONTO', bloqueadoPor: null },
+  ]).map((i) => i.numero);
+  igual(ordem, [700, 701], 'base que não está mais aberta não é bloqueio');
+});
+
+caso('fila: ciclo de dependência não trava a fila', () => {
+  const ordem = depoisDaBase([
+    { numero: 1, classe: 'PRONTO', bloqueadoPor: 2 },
+    { numero: 2, classe: 'PRONTO', bloqueadoPor: 1 },
+  ]).map((i) => i.numero);
+  igual(ordem.length, 2, 'ciclo tem que sair com os dois, não em laço infinito');
 });
 
 const shim = (bin, args) => {
@@ -246,6 +271,20 @@ mutante(
       { classe: 'CONFLITO', falhas: [], dias: 1 },
     ]).map((i) => i.classe);
     return ordem[0] !== 'CONFLITO';
+  },
+);
+
+mutante(
+  'M5 · fila deixa de olhar a base e o dependente sobe na frente',
+  'fila.mjs',
+  [['  return depoisDaBase(base);', '  return base;']],
+  async (temp) => {
+    const m = await import(`file://${temp}`);
+    const ordem = m.ordenar([
+      { numero: 556, classe: 'PRONTO', falhas: [], dias: 3, bloqueadoPor: 555 },
+      { numero: 555, classe: 'PRONTO', falhas: [], dias: 1, bloqueadoPor: 554 },
+    ]).map((i) => i.numero);
+    return ordem[0] === 556;
   },
 );
 

--- a/tools/frota/selftest.mjs
+++ b/tools/frota/selftest.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/* ============================================================================
+   selftest.mjs — CADA TRAVA DA FROTA COM A MUTAÇÃO QUE A FAZ FICAR VERMELHA.
+   ----------------------------------------------------------------------------
+   POR QUE EXISTE
+   Lei 3 da casa: "toda invariante vem com a mutação que a faz ficar vermelha".
+   Um teste que passa tanto no código certo quanto no código quebrado não testa
+   nada. Este arquivo roda cada trava duas vezes: uma no código real (tem que
+   passar) e uma num MUTANTE que desfaz exatamente a trava (tem que reprovar).
+
+   O primeiro caso aqui não é hipotético. Na primeira execução do lock, o pedido
+   de `lane-B` foi CONCEDIDO em vez de negado: `tomar()` guardava `process.pid`,
+   que na CLI é um node que morre no mesmo segundo, então o lock nascia com o
+   dono morto e era roubado pelo pedido seguinte. A trava existia e não mordia.
+   O mutante M1 é essa versão, congelada, para que ela não volte.
+
+   USO
+     node tools/frota/selftest.mjs
+   Sai 0 se todas as travas passam no real E reprovam no mutante.
+   ========================================================================== */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { classificar, ordenar } from './fila.mjs';
+import { tomar, soltar, expirado } from './lock.mjs';
+
+const AQUI = path.dirname(fileURLToPath(import.meta.url));
+const SHIM = path.join(AQUI, 'shim');
+
+let passou = 0;
+let falhou = 0;
+
+function caso(nome, fn) {
+  try {
+    fn();
+    console.log(`  ok    ${nome}`);
+    passou += 1;
+  } catch (e) {
+    console.log(`  FALHA ${nome}\n        ${e.message}`);
+    falhou += 1;
+  }
+}
+
+const igual = (a, b, m) => {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(`${m}\n        esperado ${JSON.stringify(b)}, veio ${JSON.stringify(a)}`);
+  }
+};
+
+console.log('\n  TRAVAS NO CÓDIGO REAL');
+
+caso('lock: segundo dono é NEGADO enquanto o primeiro está vivo', () => {
+  const r = `t-${Date.now()}`;
+  igual(tomar(r, 'lane-A').ok, true, 'A devia pegar');
+  igual(tomar(r, 'lane-B').ok, false, 'B NÃO devia pegar — foi o defeito real do primeiro teste');
+  soltar(r, 'lane-A');
+});
+
+caso('lock: dono do lock consegue retomar o próprio lock', () => {
+  const r = `t-${Date.now()}-b`;
+  tomar(r, 'lane-A');
+  igual(tomar(r, 'lane-A').motivo, 'ja-era-seu', 'retomar o próprio devia ser idempotente');
+  soltar(r, 'lane-A');
+});
+
+caso('lock: pela CLI, em dois processos curtos, o segundo é NEGADO', () => {
+  const rec = `cli-${Date.now()}`;
+  const chama = (dono) => {
+    try {
+      execFileSync(process.execPath, [path.join(AQUI, 'lock.mjs'), 'tomar', rec, `--dono=${dono}`], { stdio: 'pipe' });
+      return 0;
+    } catch (e) {
+      return e.status;
+    }
+  };
+  igual(chama('lane-A'), 0, 'A devia pegar pela CLI');
+  igual(chama('lane-B'), 1, 'B devia ser NEGADO pela CLI — este é o caso que o agente realmente usa');
+  execFileSync(process.execPath, [path.join(AQUI, 'lock.mjs'), 'soltar', rec, '--dono=lane-A'], { stdio: 'pipe' });
+});
+
+caso('lock: expira pelo relógio, senão vira deadlock', () => {
+  const velho = { pid: process.pid, desde: new Date(Date.now() - 60 * 60000).toISOString() };
+  igual(expirado(velho), true, 'lock de 1 h atrás tinha que estar expirado');
+  const novo = { pid: process.pid, desde: new Date().toISOString() };
+  igual(expirado(novo), false, 'lock recém-tomado não pode estar expirado');
+});
+
+caso('fila: CONFLITO ganha de VERMELHO — é a dívida que cresce sozinha', () => {
+  const ordem = ordenar([
+    { classe: 'PRONTO', falhas: [], dias: 1 },
+    { classe: 'VERMELHO', falhas: ['build'], dias: 1 },
+    { classe: 'CONFLITO', falhas: [], dias: 1 },
+    { classe: 'RASCUNHO', falhas: [], dias: 1 },
+  ]).map((i) => i.classe);
+  igual(ordem, ['CONFLITO', 'VERMELHO', 'PRONTO', 'RASCUNHO'], 'ordem de risco errada');
+});
+
+caso('fila: conflito é CONFLITO mesmo com check verde', () => {
+  const pr = { mergeable: 'CONFLICTING', isDraft: false, statusCheckRollup: [], updatedAt: new Date().toISOString() };
+  igual(classificar(pr), 'CONFLITO', 'verde não apaga conflito');
+});
+
+caso('fila: rascunho vermelho conta como VERMELHO, não como RASCUNHO', () => {
+  const pr = {
+    mergeable: 'MERGEABLE',
+    isDraft: true,
+    statusCheckRollup: [{ conclusion: 'FAILURE', name: 'build' }],
+    updatedAt: new Date().toISOString(),
+  };
+  igual(classificar(pr), 'VERMELHO', 'o vermelho é o que bloqueia, não o rascunho');
+});
+
+const shim = (bin, args) => {
+  try {
+    execFileSync(path.join(SHIM, bin), args, { stdio: 'pipe', env: { ...process.env, PATH: process.env.PATH } });
+    return 0;
+  } catch (e) {
+    return e.status;
+  }
+};
+
+caso('shim git: push na main é recusado com 97', () => {
+  igual(shim('git', ['push', 'origin', 'main']), 97, 'push na main tinha que ser recusado');
+});
+
+caso('shim git: --no-verify é recusado', () => {
+  igual(shim('git', ['commit', '--no-verify', '-m', 'x']), 97, '--no-verify tinha que ser recusado');
+});
+
+caso('shim git: checkout de ARQUIVO da main passa (não é troca de branch)', () => {
+  const r = shim('git', ['checkout', 'origin/main', '--', 'AGENTS.md']);
+  if (r === 97) throw new Error('recusou checkout de arquivo, que é resolução de conflito legítima');
+});
+
+caso('shim gh: pr merge é recusado', () => {
+  igual(shim('gh', ['pr', 'merge', '555']), 97, 'merge tinha que ser recusado');
+});
+
+caso('shim gh: label safe-automerge é recusada (ela É o botão de merge)', () => {
+  igual(shim('gh', ['pr', 'edit', '555', '--add-label', 'safe-automerge']), 97, 'label tinha que ser recusada');
+});
+
+console.log('\n  MUTANTES — cada um tem de REPROVAR');
+
+/* `trocas` é uma lista porque um conserto pode ter DUAS pontas que se cobrem: o
+   mutante fiel desfaz as duas. Foi o que M1 mostrou — desfazer só o `ppid`
+   deixava a graça segurando a trava, e o mutante passava em verde fingindo que
+   o `ppid` carregava peso sozinho. */
+function mutante(nome, arquivo, trocas, prova) {
+  const p = path.join(AQUI, arquivo);
+  const original = fs.readFileSync(p, 'utf8');
+  let mutado = original;
+  for (const [de, para] of trocas) {
+    if (!mutado.includes(de)) {
+      console.log(`  FALHA ${nome}\n        alvo da mutação sumiu do arquivo: ${de.slice(0, 60)}`);
+      falhou += 1;
+      return;
+    }
+    mutado = mutado.replace(de, para);
+  }
+  const temp = path.join(os.tmpdir(), `mut-${Date.now()}-${path.basename(arquivo)}`);
+  fs.writeFileSync(temp, mutado);
+  try {
+    const morreu = prova(temp);
+    if (morreu) {
+      console.log(`  ok    ${nome} (mutante reprovou, como devia)`);
+      passou += 1;
+    } else {
+      console.log(`  FALHA ${nome}\n        o mutante PASSOU — a trava não morde`);
+      falhou += 1;
+    }
+  } finally {
+    fs.rmSync(temp, { force: true });
+  }
+}
+
+/* M1 só se manifesta ATRAVÉS DA CLI: dentro deste processo o `process.pid` do
+   mutante está vivo e a trava aguenta. O defeito real precisava de dois
+   processos curtos, que é como o agente da frota chama o lock. Provar em
+   processo seria provar outra coisa — e passaria em verde no código quebrado. */
+mutante(
+  'M1 · o código ORIGINAL inteiro: PID da CLI + sem graça (o defeito da 1ª execução)',
+  'lock.mjs',
+  [
+    ['export function tomar(recurso, dono, pid = process.ppid) {',
+     'export function tomar(recurso, dono, pid = process.pid) {'],
+    ['  if (min > VALIDADE_MIN) return true;\n  return min > GRACA_MIN && !vivo(l.pid);',
+     '  return min > VALIDADE_MIN || !vivo(l.pid);'],
+  ],
+  (temp) => {
+    const rec = `m1-${Date.now()}`;
+    const chama = (dono) => {
+      try {
+        execFileSync(process.execPath, [temp, 'tomar', rec, `--dono=${dono}`], { stdio: 'pipe' });
+        return 0;
+      } catch (e) {
+        return e.status;
+      }
+    };
+    chama('lane-A');
+    const segundo = chama('lane-B');
+    try {
+      execFileSync(process.execPath, [temp, 'soltar', rec, '--dono=lane-B'], { stdio: 'pipe' });
+    } catch {}
+    return segundo === 0;
+  },
+);
+
+mutante(
+  'M2 · lock sem graça: PID morto expira na hora',
+  'lock.mjs',
+  [['return min > GRACA_MIN && !vivo(l.pid);', 'return !vivo(l.pid);']],
+  () => {
+    const l = { pid: 999999, desde: new Date().toISOString() };
+    return expirado(l) === false;
+  },
+);
+
+mutante(
+  'M3 · shim git deixa de olhar o alvo do push',
+  'shim/git',
+  [['main|master|*:main|*:master|refs/heads/main|refs/heads/master)', '__nunca_casa__)']],
+  (temp) => {
+    fs.chmodSync(temp, 0o755);
+    try {
+      execFileSync(temp, ['push', 'origin', 'main'], { stdio: 'pipe' });
+      return true;
+    } catch (e) {
+      return e.status !== 97;
+    }
+  },
+);
+
+mutante(
+  'M4 · fila deixa de priorizar CONFLITO',
+  'fila.mjs',
+  [["const CLASSES = ['CONFLITO', 'VERMELHO', 'PRONTO', 'RASCUNHO', 'PARADO'];",
+    "const CLASSES = ['VERMELHO', 'CONFLITO', 'PRONTO', 'RASCUNHO', 'PARADO'];"]],
+  async (temp) => {
+    const m = await import(`file://${temp}`);
+    const ordem = m.ordenar([
+      { classe: 'VERMELHO', falhas: ['build'], dias: 1 },
+      { classe: 'CONFLITO', falhas: [], dias: 1 },
+    ]).map((i) => i.classe);
+    return ordem[0] !== 'CONFLITO';
+  },
+);
+
+console.log(`\n  ${passou} passaram · ${falhou} falharam\n`);
+process.exit(falhou ? 1 : 0);

--- a/tools/frota/shim/gh
+++ b/tools/frota/shim/gh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Shim de `gh` para a frota. Mesma razão do shim de `git`: prompt não é trava.
+#
+# O QUE ELE RECUSA
+#   gh pr merge          · integrar é do dono
+#   gh pr close          · fechar PR alheio é decisão do dono
+#   gh label ... safe-automerge / gh pr edit --add-label safe-automerge
+#                        · essa label É o botão de merge: o csbrasil-bot-automerge
+#                          mescla sozinho quando ela aparece. Aplicá-la é mesclar.
+#   gh api ... -X DELETE · nada da frota apaga recurso no GitHub
+#   gh repo delete / gh api .../branches/main/protection -X PUT|DELETE
+#
+# Tudo o mais passa: view, list, checks, run view, pr ready, pr comment, api GET.
+
+set -uo pipefail
+
+REAL=""
+for c in /opt/homebrew/bin/gh /usr/bin/gh /usr/local/bin/gh; do
+  [ -x "$c" ] && REAL="$c" && break
+done
+[ -z "$REAL" ] && { echo "frota: gh real não encontrado" >&2; exit 98; }
+
+recusa() {
+  echo "frota: RECUSADO — $1" >&2
+  echo "frota: veja tools/frota/GUARDRAILS.md. Escreva AGUARDANDO DONO no ledger." >&2
+  exit 97
+}
+
+todos="$*"
+
+case "$todos" in
+  *safe-automerge*)
+    recusa "a label safe-automerge é o botão de merge do dono — aplicá-la mescla o PR" ;;
+esac
+
+if [ "${1:-}" = "pr" ]; then
+  case "${2:-}" in
+    merge) recusa "gh pr merge. A frota prepara; quem integra é o dono." ;;
+    close) recusa "gh pr close. Fechar PR é decisão do dono." ;;
+  esac
+fi
+
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "delete" ]; then
+  recusa "gh repo delete"
+fi
+
+if [ "${1:-}" = "api" ]; then
+  case "$todos" in
+    *"-X DELETE"*|*"--method DELETE"*|*"-X PUT"*|*"--method PUT"*|*"-X PATCH"*|*"--method PATCH"*)
+      recusa "gh api com método de escrita. A frota lê o GitHub, não o reconfigura." ;;
+  esac
+fi
+
+exec "$REAL" "$@"

--- a/tools/frota/shim/git
+++ b/tools/frota/shim/git
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Shim de `git` para a frota. Entra ANTES do git real no PATH do turno.
+#
+# POR QUE EXISTE
+# Prompt não é trava. Um agente com --dangerously-skip-permissions que "sabe" que
+# não deve tocar na main vai tocar na main no turno em que a instrução ficar longe
+# o suficiente no contexto. A única trava que vale é a que recusa a chamada.
+#
+# O QUE ELE RECUSA
+#   push para main/master        · a main é do dono, a frota só prepara
+#   push --force (sem lease)     · outra lane pode ter empurrado agora
+#   --no-verify                  · pula commit-msg/pre-push, que cobram Agent:,
+#                                  co-autoria de IA e o scanner de credencial
+#   trocar a worktree para a main · cada lane fica na sua branch
+#
+# O QUE ELE DEIXA PASSAR, DE PROPÓSITO
+#   `git checkout main -- <arquivo>` e `git checkout origin/main -- <arquivo>`:
+#   trazer UM arquivo da main é resolução de conflito legítima e acontece o tempo
+#   todo. Só a troca de branch é recusada.
+
+set -uo pipefail
+
+REAL=""
+for c in /opt/homebrew/bin/git /usr/bin/git /usr/local/bin/git; do
+  [ -x "$c" ] && REAL="$c" && break
+done
+[ -z "$REAL" ] && { echo "frota: git real não encontrado" >&2; exit 98; }
+
+recusa() {
+  echo "frota: RECUSADO — $1" >&2
+  echo "frota: veja tools/frota/GUARDRAILS.md. Registre no ledger e siga em frente." >&2
+  exit 97
+}
+
+for a in "$@"; do
+  [ "$a" = "--no-verify" ] && recusa "--no-verify pula os hooks que cobram Agent:, co-autoria de IA e credencial"
+done
+
+case "${1:-}" in
+  push)
+    for a in "$@"; do
+      case "$a" in
+        main|master|*:main|*:master|refs/heads/main|refs/heads/master)
+          recusa "push para a main. A frota prepara; quem integra é o dono." ;;
+        --force|-f)
+          recusa "--force puro apaga o push de outra lane. Use --force-with-lease." ;;
+      esac
+    done
+    ;;
+  checkout|switch)
+    # Só recusa TROCA DE BRANCH: se houver `--`, é checkout de arquivo e passa.
+    tem_sep=0
+    for a in "$@"; do [ "$a" = "--" ] && tem_sep=1; done
+    if [ "$tem_sep" = "0" ] && [ "$#" -le 3 ]; then
+      for a in "$@"; do
+        case "$a" in
+          main|master) recusa "trocar esta worktree para a main. Cada lane fica na sua branch." ;;
+        esac
+      done
+    fi
+    ;;
+esac
+
+exec "$REAL" "$@"

--- a/tools/frota/tarefas.mjs
+++ b/tools/frota/tarefas.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/* ============================================================================
+   tarefas.mjs — A CLASSE DO PR DECIDE A MISSÃO. NÃO EXISTE REGISTRO A MANTER.
+   ----------------------------------------------------------------------------
+   POR QUE EXISTE (e por que não é um lanes.json escrito à mão)
+   A tentação óbvia é um registro de lanes com worktree, dono, tarefa e estado,
+   mantido à mão. Esse registro mente em 48 h: o PR sai do conflito, a worktree
+   é podada, a main anda, e o registro continua mandando o agente rebasear o que
+   já foi rebaseado. Registro desatualizado é pior que registro nenhum, porque
+   um agente confia nele.
+
+   Aqui a missão é DERIVADA do estado real a cada turno: a `fila.mjs` lê o
+   GitHub e o git, classifica, e a classe escolhe o texto da missão. O único
+   estado persistido é o ledger — que é histórico, não configuração, e por isso
+   não apodrece.
+
+   AS MISSÕES
+     CONFLITO   rebase sobre a main e devolver verde. Primeiro sempre, porque é
+                a única dívida que fica mais cara enquanto você não mexe nela.
+     VERMELHO   a régua vermelha vira verde SEM afrouxar teto. Afrouxar teto é
+                a fraude clássica desta base — a rodada que foi de 16/21 para
+                19/21 e foi reprovada.
+     RASCUNHO   terminar o que falta e tirar do rascunho.
+     PRONTO     nada a fazer: registrar AGUARDANDO DONO e encerrar.
+     PARADO     não despacha. Só o dono decide entre retomar e fechar.
+   ========================================================================== */
+
+const COMUM = `
+ANTES DE QUALQUER COISA
+1. Leia \`AGENTS.md\` inteiro. As leis da casa não são estilo — cada uma custou dias.
+2. Rode \`git status\` e \`git log --oneline -5\`. O ledger acima diz o que já foi
+   feito; o git diz o que está de pé AGORA. Onde os dois discordarem, o git ganha.
+3. NÃO recomece o que o ledger diz que já foi feito. Continue de onde parou.
+
+COMO TERMINAR O TURNO (obrigatório, mesmo se não conseguiu nada)
+  node tools/frota/ledger.mjs escrever <LANE> <ESTADO> "<o que tentou · o que mediu · o que ficou de pé · próximo passo>"
+Estados: ANDAMENTO | AGUARDANDO DONO | BLOQUEADO | TURNO FECHADO
+`;
+
+const MISSOES = {
+  CONFLITO: (i) => `
+MISSÃO: tirar o PR #${i.numero} do conflito e devolvê-lo verde.
+
+O conflito com a main cresce sozinho — cada merge na main te empurra para longe.
+Por isso esta classe vem antes de todas as outras.
+
+PASSOS
+1. \`git fetch origin main\` e \`git rebase origin/main\` (ou merge, se o histórico
+   desta branch já foi publicado e rebase reescreveria commit de outro agente —
+   nesse caso merge e diga no ledger por quê).
+2. Em CADA conflito, resolva pela INTENÇÃO das duas pontas, não pegando um lado
+   inteiro. Se o conflito for em arquivo GERADO (bloco entre BEGIN:GERADO), não
+   resolva à mão: regenere com o script que o gera (\`npm run arch\`, \`npm run docs\`).
+3. Se o conflito exigir decisão de produto — duas autorias visuais disputando o
+   mesmo mapa, dois tetos diferentes para a mesma régua — PARE. Escreva BLOQUEADO
+   no ledger com a pergunta exata. Não escolha por conta própria.
+4. Depois de resolver: \`npm run check:deploy\`. Verde antes de push.
+5. \`git push --force-with-lease\` (nunca \`--force\` puro: outra lane pode ter
+   empurrado enquanto você resolvia).
+
+PRONTO É: \`gh pr view ${i.numero} --json mergeable\` responder MERGEABLE e os checks
+voltarem verdes. Aí escreva AGUARDANDO DONO no ledger. NÃO mescle, NÃO aplique
+label \`safe-automerge\`.`,
+
+  VERMELHO: (i) => `
+MISSÃO: fazer a régua vermelha do PR #${i.numero} ficar verde — sem afrouxar teto.
+
+CHECKS VERMELHOS: ${i.falhas.join(', ')}
+
+O check \`build\` desta casa é o portão de invariantes. Ele não falha por infra:
+falha porque uma régua crítica está reprovando de verdade. Descubra QUAL:
+  gh run view --log-failed --job <id do job>   (pegue o id em \`gh pr checks ${i.numero}\`)
+e procure a linha "CRÍTICAS: N/56 passam ← XXX VERMELHAS".
+
+PASSOS
+1. Identifique a sigla da régua vermelha (ex.: MAP2B, VM14) e leia o que ela mede
+   em \`tools/eval/\`. Entenda o que ela cobra ANTES de mexer em qualquer código.
+2. Reproduza local: \`npm run check:deploy\` (ou a régua isolada). Você tem que ver
+   o vermelho na sua máquina. Vermelho que só existe no CI é outro bug.
+3. Conserte a CAUSA. Proibido: subir o teto, mover a régua para KNOWN-RED.json,
+   pular o caso. Uma rodada desta base foi de 16/21 para 19/21 sem afrouxar teto
+   nenhum e AINDA ASSIM foi reprovada, por destruir em silêncio uma decisão
+   estética que nenhuma régua codificava. Afrouxar teto é pior que isso.
+4. Se a régua estiver ERRADA (mede o que não devia), isso é um achado — escreva
+   BLOQUEADO no ledger com a evidência. Não a conserte no mesmo PR.
+5. Se a mudança é visível, gere a figura e OLHE. Descreva no ledger o que você
+   VIU, não o que esperava ver. Precisa de browser? Tome o lock antes (trava 7).
+
+PRONTO É: os checks vermelhos verdes, sem teto afrouxado e sem sigla nova em
+KNOWN-RED.json. Então AGUARDANDO DONO.`,
+
+  RASCUNHO: (i) => `
+MISSÃO: terminar o PR #${i.numero} e tirá-lo de rascunho.
+
+Ele está verde e sem conflito — está em rascunho porque falta trabalho, não
+porque falta conserto. Descubra o que falta:
+1. \`gh pr view ${i.numero}\` — o corpo do PR costuma listar o que ficou pendente.
+2. Procure na branch por TODO, FIXME, "falta", "pendente", "handoff".
+3. Se o PR é de frente visual, o que falta quase sempre é a EVIDÊNCIA: captura
+   inspecionada. Gere, olhe, descreva o que viu, anexe no PR.
+
+PRONTO É: o que o corpo do PR prometeu, entregue e medido. Aí
+\`gh pr ready ${i.numero}\` e AGUARDANDO DONO. NÃO mescle.`,
+
+  PRONTO: (i) => `
+MISSÃO: nenhuma. O PR #${i.numero} está verde, sem conflito e fora de rascunho.
+
+Ele espera decisão do dono, e nesta rodada o dono decidiu que nada entra na main
+sem ele. Escreva no ledger AGUARDANDO DONO com o número do PR e encerre o turno.
+Não mescle, não aplique label, não reabra a discussão.`,
+
+  PARADO: (i) => `
+MISSÃO: nenhuma — só relatório. O PR #${i.numero} está há ${i.dias} dias sem commit.
+
+Abandono é decisão do dono, não sua. Escreva no ledger BLOQUEADO com uma linha
+dizendo o que o PR entrega e se o trabalho dele já foi feito por outro PR
+(procure por título parecido em \`gh pr list\`). Encerre o turno.`,
+};
+
+export function briefing(item, lane, worktree) {
+  const missao = MISSOES[item.classe];
+  if (!missao) throw new Error(`classe sem missão: ${item.classe}`);
+  return [
+    `LANE: ${lane}`,
+    `WORKTREE: ${worktree}`,
+    `PR: #${item.numero} — ${item.titulo}`,
+    `BRANCH: ${item.branch}`,
+    `CLASSE: ${item.classe}`,
+    '',
+    missao(item).trim(),
+    '',
+    COMUM.trim().replaceAll('<LANE>', lane),
+  ].join('\n');
+}
+
+export { MISSOES };


### PR DESCRIPTION
A casa produz mais rápido do que integra. Ao abrir isto: **47 PRs abertos, 13 em conflito, 21 vermelhos**, contra uma main que anda sozinha. Mais braço em paralelo piora — cada merge na main empurra os conflitantes para longe. Faltava a camada que integra, e o `00-PROMPT-ORQUESTRADOR.md` já a descrevia pressupondo um humano acordado colando prompt em 28 lanes.

## O achado que reordena a prioridade da casa

A fila reportava **7 PRs prontos**. Só **3** estavam. Os mapas formam duas correntes empilhadas — `#540→#541→…→#551` e `#554→#555→…→#565` — e os PRs de cima têm como base outro PR aberto, não a main: não podem entrar enquanto a raiz não entrar.

**As duas raízes estão em CONFLITO e seguram 16 dos 47 PRs: #554 destrava 9, #540 destrava 7.** É o trabalho de maior alavanca do repositório, e a fila anterior o escondia atrás de uma fileira de verdes convidativos que não podiam ser mesclados.

## O que entra

| arquivo | papel |
|---|---|
| `fila.mjs` | classifica e ordena por **risco de apodrecer**; CONFLITO primeiro porque é a única dívida que fica mais cara enquanto ninguém mexe nela |
| `tarefas.mjs` | a classe do PR decide a missão — sem `lanes.json`, que mentiria em 48 h |
| `ledger.mjs` | memória entre turnos: o próximo agente **continua**, não recomeça |
| `lock.mjs` | "um único agente roda browser" vira mecanismo, com validade para não virar deadlock |
| `shim/git`, `shim/gh` | **a trava de verdade** |
| `runner.mjs` | monta o prompt do estado real, roda o agente na worktree, fecha o ledger |
| `selftest.mjs` | cada trava + a mutação que a faz ficar vermelha |

## A trava é o PATH, não o prompt

Turno desassistido não para para pedir permissão, e prompt não segura isso. `tools/frota/shim/` entra **na frente** no PATH do turno; o `git`/`gh` de lá recusam com saída 97 exatamente o que o dono tirou da mesa: push na main, `--force` puro, `--no-verify`, `gh pr merge/close` e a label `safe-automerge` — que **é** o botão de merge, porque o `csbrasil-bot-automerge` mescla sozinho quando ela aparece.

Deixam passar de propósito `git checkout origin/main -- <arquivo>`: trazer um arquivo da main é resolução de conflito legítima, e há caso no selftest cobrando isso.

## O lock nasceu sem morder

Guardava `process.pid`, que na CLI morre no mesmo segundo — o lock nascia com o dono morto e o pedido seguinte o roubava em vez de ser negado. O **teste negativo** pegou. M1 congela o código original **inteiro**: desfazer só uma ponta deixava a outra segurando a trava, e o mutante passava em verde fingindo que a primeira carregava peso sozinha.

## Réguas

`node tools/frota/selftest.mjs` — **20 passaram, 0 falharam**; 5 mutantes reprovaram como deviam.
`npm run check:deploy` — verde (pre-push, 23 s).

## Dois achados operacionais de brinde

1. **`node_modules` inconsistente entre worktrees** — várias têm zero pacotes, inclusive o checkout principal. Sem `sharp` e `@gltf-transform/core`, 5 réguas do `check:deploy` reprovam por ambiente e parecem defeito de código. Toda worktree da frota precisa de `npm ci` antes de virar lane.
2. **O `pre-push` reporta o portão errado.** Ele extrai a falha com `grep -m1 -E '✗|FALHA|error'`, e `eval:error-console` casa com `error` — então ele acusou um teste que passou. Não corrigido aqui para não misturar frentes.

## Fora de escopo, de propósito

Nada entra na main sem o dono: a frota **prepara**, ele **integra**. Nenhum merge, nenhuma label aplicada.

https://claude.ai/code/session_01CKo8ixRptzgH3LeGhT6XN9