### PR TITLE
fix(discord): convite do rodapé estava expirado e a porta da comunidade fechada

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![three.js](https://img.shields.io/badge/jogo-three.js%20r160-000000?logo=three.js)](https://threejs.org)
 [![supabase](https://img.shields.io/badge/ranking-supabase-3fcf8e?logo=supabase&logoColor=white)](https://supabase.com)
 [![vercel](https://img.shields.io/badge/deploy-vercel-000000?logo=vercel)](https://vercel.com)
-[![Discord](https://img.shields.io/badge/Discord-entrar-5865F2?logo=discord&logoColor=white)](https://discord.gg/fmunXnaj)
+[![Discord](https://img.shields.io/badge/Discord-entrar-5865F2?logo=discord&logoColor=white)](https://discord.gg/XQHAFBcrhv)
 [![Telegram](https://img.shields.io/badge/Telegram-entrar-26A5E4?logo=telegram&logoColor=white)](https://t.me/corosolto)
 
 **AI generated & AI friendly** — construído em par com agentes de IA, e cada

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "redirects": [
     {
       "source": "/discord",
-      "destination": "https://discord.gg/fmunXnaj",
+      "destination": "https://discord.gg/XQHAFBcrhv",
       "permanent": false
     },
     {


### PR DESCRIPTION
## O que estava quebrado

Os dois convites de Discord que existiam na base respondem **`code 50270 — Invite is expired`** na API:

| código | onde | estado |
|---|---|---|
| `fmunXnaj` | `vercel.json:7` e `README.md:10` | **expirado** |
| `MJq7Csam` | worktrees antigas | **expirado** |

O atalho `/discord` redirecionava `307` normalmente, então nada falhava e nada avisou: o jogador clicava no rodapé, chegava numa página de convite inválido e voltava. Falha silenciosa.

## Por que importa agora

`VISION.md` (branch `september-10-reset` do repo ROADMAP) lista **"Discord como praça (redirects já no ar)"** como um dos três pilares de retenção de setembro. E a retenção medida hoje no Supabase é:

- **D7 = 0,0% em toda coorte desde 20/08**
- D1 ~3%; dos 4.710 jogadores únicos, só 448 (9,5%) voltaram algum dia

O pilar existia como decisão e não existia como porta.

## O conserto

Troca para `XQHAFBcrhv`, **conferido na API do Discord antes de entrar**:

```
guild       : 1537491530225418302  (Coro Solto — bate com DISCORD_GUILD_ID do discord-bot)
expires_at  : null                 <- não expira
canal       : 💬-geral
membros     : 18 (4 online)
```

O primeiro convite oferecido nesta rodada expirava em 7 dias (19/09, no meio da campanha) e foi recusado por ser exatamente o modo como o atual venceu. Este é permanente.

## Portões

`check:deploy` (39 passos) verde no pre-push, 52 s. `vercel.json` revalidado como JSON. Nenhum resquício de `fmunXnaj`/`MJq7Csam` nos dois arquivos.

## O que este PR NÃO fecha

Não há régua que detecte convite expirado — foi assim que este passou despercebido. O `prod-watch.yml` já bate em produção a cada 15 min e seria o lugar natural para uma cláusula que consulta `discord.com/api/v10/invites/<code>` e reprova em `50270`. Fica registrado, fora deste PR para mantê-lo pequeno.

https://claude.ai/code/session_0147SA4jeYTGZEaBKuDG7Yr6